### PR TITLE
ci: add commit and branch conventions

### DIFF
--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   commit-check:
@@ -23,4 +22,4 @@ jobs:
           author-name: false
           author-email: false
           job-summary: true
-          pr-comments: ${{ github.event_name == 'pull_request' }}
+          pr-comments: false

--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -1,0 +1,26 @@
+name: Commit Check
+
+on:
+  push:
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  commit-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: commit-check/commit-check-action@v2
+        with:
+          message: true
+          branch: true
+          author-name: false
+          author-email: false
+          job-summary: true
+          pr-comments: ${{ github.event_name == 'pull_request' }}

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+# Validate commit message follows Conventional Commits
+# https://www.conventionalcommits.org/en/v1.0.0/
+#
+# Format: <type>(<scope>): <description>
+# Types: feat, fix, docs, style, refactor, perf, test, chore, ci, build, revert
+
+commit_msg=$(cat "$1")
+
+# Allow merge commits
+if echo "$commit_msg" | grep -qE "^Merge "; then
+  exit 0
+fi
+
+# Allow revert commits
+if echo "$commit_msg" | grep -qE "^Revert "; then
+  exit 0
+fi
+
+# Allow fixup commits
+if echo "$commit_msg" | grep -qE "^fixup! "; then
+  exit 0
+fi
+
+# Validate conventional commit format
+if ! echo "$commit_msg" | grep -qE "^(feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert)(\(.+\))?(!)?: .{1,}$"; then
+  echo ""
+  echo "❌ Invalid commit message format."
+  echo ""
+  echo "Expected: <type>(<scope>): <description>"
+  echo ""
+  echo "Types: feat, fix, docs, style, refactor, perf, test, chore, ci, build, revert"
+  echo ""
+  echo "Examples:"
+  echo "  feat(auth): add JWT refresh token support"
+  echo "  fix: handle null response in user endpoint"
+  echo "  docs: update API reference"
+  echo "  feat!: remove deprecated v1 endpoints"
+  echo ""
+  echo "See: https://www.conventionalcommits.org/en/v1.0.0/"
+  echo ""
+  exit 1
+fi
+
+# Check subject line length (max 80 chars)
+subject=$(echo "$commit_msg" | head -1)
+if [ ${#subject} -gt 80 ]; then
+  echo ""
+  echo "❌ Commit subject too long (${#subject} chars, max 80)."
+  echo ""
+  exit 1
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,3 @@
+#!/bin/sh
+
 pnpm lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# Validate branch name follows Conventional Branch
+# https://conventional-branch.github.io/
+#
+# Format: <type>/<description>
+# Types: feature, feat, bugfix, fix, hotfix, release, chore
+
+branch=$(git branch --show-current)
+
+# Allow main/master/develop
+if echo "$branch" | grep -qE "^(main|master|develop)$"; then
+  exit 0
+fi
+
+# Validate conventional branch format
+if ! echo "$branch" | grep -qE "^(feature|feat|bugfix|fix|hotfix|release|chore)/[a-z0-9][a-z0-9.\-]*[a-z0-9]$"; then
+  echo ""
+  echo "❌ Invalid branch name: $branch"
+  echo ""
+  echo "Expected: <type>/<description>"
+  echo ""
+  echo "Types: feature, feat, bugfix, fix, hotfix, release, chore"
+  echo ""
+  echo "Examples:"
+  echo "  feat/add-login-page"
+  echo "  fix/header-bug"
+  echo "  hotfix/security-patch"
+  echo "  release/v1.2.0"
+  echo "  chore/update-dependencies"
+  echo ""
+  echo "Rules:"
+  echo "  - Lowercase alphanumerics, hyphens, and dots only"
+  echo "  - No consecutive hyphens or dots"
+  echo "  - No leading/trailing hyphens or dots in description"
+  echo ""
+  echo "See: https://conventional-branch.github.io/"
+  echo ""
+  exit 1
+fi

--- a/commit-check.toml
+++ b/commit-check.toml
@@ -1,0 +1,21 @@
+[commit]
+conventional_commits = true
+subject_capitalized = false
+subject_imperative = true
+subject_max_length = 80
+subject_min_length = 5
+allow_commit_types = ["feat", "fix", "docs", "style", "refactor", "perf", "test", "chore", "ci", "build", "revert"]
+allow_merge_commits = true
+allow_revert_commits = true
+allow_empty_commits = false
+allow_fixup_commits = true
+allow_wip_commits = false
+require_body = false
+require_signed_off_by = false
+ignore_authors = ["dependabot[bot]", "copilot[bot]", "pre-commit-ci[bot]", "github-actions[bot]"]
+
+[branch]
+conventional_branch = true
+allow_branch_types = ["feature", "bugfix", "hotfix", "release", "chore", "feat", "fix"]
+require_rebase_target = "origin/main"
+ignore_authors = ["dependabot[bot]", "copilot[bot]", "pre-commit-ci[bot]", "github-actions[bot]"]


### PR DESCRIPTION
## Summary
- add commit-check GitHub Actions workflow
- add commit-check.toml for commit and branch validation
- add Husky hooks for commit message and branch naming enforcement
- disable commit-check PR comments and remove extra workflow permission

## Testing
- local Husky commit-msg hook rejects invalid commit messages
- local Husky commit-msg hook accepts valid conventional commits
- local Husky pre-push hook allows the default branch
- remote Commit Check GitHub Action passed on push and pull request