### PR TITLE
feat: shadcn registry + sitemap/robots

### DIFF
--- a/REGISTRY_PLAN.md
+++ b/REGISTRY_PLAN.md
@@ -1,0 +1,420 @@
+# shieldcn Registry Plan
+
+## Goal
+
+Build a **small shadcn-compatible registry surface** that drives discovery and traffic from the shadcn ecosystem **without changing shieldcn's core positioning**.
+
+shieldcn remains:
+
+- a **Markdown / README badge service first**
+- a **drop-in SVG badge service**
+- a **shields.io alternative with shadcn/ui visual quality**
+
+The registry is a **distribution channel**, not the product identity.
+
+---
+
+## Product Positioning
+
+### Public positioning
+
+> shieldcn is a Markdown badge service with the visual quality of shadcn/ui.
+
+### Internal strategy
+
+> shieldcn also ships a shadcn-compatible registry to capture search traffic,
+> registry installs, and component discovery intent.
+
+### Important constraint
+
+Do **not** reposition the homepage or top-level messaging around "being a registry."
+
+The registry should be presented as:
+
+- an integration layer
+- a React/shadcn convenience layer
+- an installable helper surface for shieldcn badges
+
+---
+
+## v1 Scope
+
+Ship **3 components** only.
+
+This should be intentionally small and high-signal.
+
+### 1. `readme-badge`
+
+**Purpose:** the main registry entrypoint.
+
+This is the clearest bridge from shadcn traffic to shieldcn usage.
+
+It should:
+
+- render a shieldcn badge URL
+- be tiny and dependency-light
+- support simple props like:
+  - `src`
+  - `alt`
+  - `href?`
+  - `className?`
+  - `imgClassName?`
+
+Example:
+
+```tsx
+<ReadmeBadge
+  src="https://shieldcn.dev/npm/react.svg?variant=branded"
+  alt="React npm version"
+/>
+```
+
+### 2. `readme-badge-row`
+
+**Purpose:** polished grouping for multiple badges.
+
+This should:
+
+- lay out multiple badges cleanly
+- wrap nicely
+- feel like a reusable shadcn-style primitive
+- work well in docs pages, landing pages, and app settings pages
+
+Example:
+
+```tsx
+<ReadmeBadgeRow>
+  <ReadmeBadge src="https://shieldcn.dev/npm/react.svg" alt="npm" />
+  <ReadmeBadge src="https://shieldcn.dev/github/vercel/next.js/stars.svg" alt="stars" />
+</ReadmeBadgeRow>
+```
+
+### 3. `badge-preview`
+
+**Purpose:** visual badge demo component for docs and app UIs.
+
+This should be adapted from the current shieldcn preview component, but simplified for registry use.
+
+It should:
+
+- render a live badge preview
+- optionally show example code below it
+- fit docs and demos
+- stay dependency-light
+
+---
+
+## What Not to Ship in v1
+
+Do **not** ship these as registry items yet:
+
+- badge builder
+- badge modal
+- badge marquee
+- showcase internals
+- sidebar docs internals
+- token pool UI
+- auth flows
+- homepage sections
+- provider-specific giant preset packs
+
+The registry should not feel like a dump of site internals.
+
+---
+
+## Naming and Registry Alias
+
+Use:
+
+```json
+{
+  "registries": {
+    "@shieldcn": "https://shieldcn.dev/r/{name}.json"
+  }
+}
+```
+
+Install commands should look like:
+
+```bash
+pnpm dlx shadcn@latest add @shieldcn/readme-badge
+pnpm dlx shadcn@latest add @shieldcn/readme-badge-row
+pnpm dlx shadcn@latest add @shieldcn/badge-preview
+```
+
+This is important for brand consistency and memorability.
+
+---
+
+## Styling Rules
+
+Registry components must feel consistent with the shieldcn site and current design system.
+
+### Typography
+
+Use the current site typography conventions:
+
+- **headings:** Sora
+- **body/UI:** Geist
+- **mono/code:** Fira Code
+
+Registry-installed components should rely on the consumer project's existing typography tokens where possible.
+
+### Component style expectations
+
+Registry components should:
+
+- feel shadcn-native
+- use rounded corners consistent with current shieldcn UI
+- avoid hardcoded visual gimmicks
+- use subtle borders and muted surfaces
+- favor clean spacing and simple composition
+- avoid over-styled marketing chrome
+
+### Color and theming
+
+Components should:
+
+- support dark and light mode naturally
+- use semantic tokens when possible
+- avoid assuming a specific background
+- not require shieldcn site CSS to look correct
+
+### Installability standard
+
+Each registry item should:
+
+- minimize dependencies
+- avoid requiring unrelated site-only utilities
+- avoid dragging in large internal systems
+- be installable in isolation
+
+---
+
+## Documentation Strategy
+
+Create a new docs section for registry content.
+
+The docs should visually and structurally align with the shadcn registry documentation style, while staying specific to shieldcn.
+
+Use this MDX frontmatter and intro style as the reference pattern:
+
+```mdx
+---
+title: Introduction
+description: Run your own code registry.
+---
+
+You can use the `shadcn` CLI to run your own code registry. Running your own registry allows you to distribute your custom components, hooks, pages, config, rules and other files to any project.
+
+<Callout>
+  **Note:** The registry works with any project type and any framework, and is
+  not limited to React.
+</Callout>
+```
+
+Reference:
+
+- https://ui.shadcn.com/docs/registry
+
+### Important adaptation for shieldcn
+
+Do **not** copy the shadcn docs verbatim.
+
+Instead, adapt the structure and tone to shieldcn's use case:
+
+- install shieldcn helpers via the shadcn registry
+- use them to render or preview shieldcn badges
+- link back to the hosted badge service
+
+### Recommended docs pages
+
+#### `/docs/registry`
+
+Landing page for registry docs.
+
+Should explain:
+
+- what the registry is
+- why shieldcn ships registry items
+- how it complements the hosted badge service
+- which components are available
+
+#### `/docs/registry/getting-started`
+
+Should cover:
+
+- adding the `@shieldcn` registry alias
+- installing the first component
+- using `readme-badge`
+
+#### `/docs/registry/components`
+
+Should list and demo the v1 items:
+
+- `readme-badge`
+- `readme-badge-row`
+- `badge-preview`
+
+#### `/docs/registry/examples`
+
+Should show:
+
+- hero-style badge rows
+- README-style examples
+- docs-style preview blocks
+
+---
+
+## Docs UI Pattern
+
+When building the docs landing page, use a structure inspired by the shadcn registry docs page.
+
+Example content structure to adapt:
+
+```mdx
+---
+title: Introduction
+description: Run your own code registry.
+---
+
+You can use the `shadcn` CLI to run your own code registry. Running your own registry allows you to distribute your custom components, hooks, pages, config, rules and other files to any project.
+
+<Callout>
+  **Note:** The registry works with any project type and any framework, and is
+  not limited to React.
+</Callout>
+
+<figure className="flex flex-col gap-4">
+  <Image
+    src="/images/registry-light.png"
+    width="1432"
+    height="960"
+    alt="Registry"
+    className="mt-6 w-full overflow-hidden rounded-lg border dark:hidden"
+  />
+  <Image
+    src="/images/registry-dark.png"
+    width="1432"
+    height="960"
+    alt="Registry"
+    className="mt-6 hidden w-full overflow-hidden rounded-lg border shadow-sm dark:block"
+  />
+  <figcaption className="text-center text-sm text-gray-500">
+    A distribution system for code
+  </figcaption>
+</figure>
+```
+
+### For shieldcn, swap the messaging to:
+
+- install React helpers for shieldcn badges
+- use the hosted badge service in apps/docs/components
+- keep the examples badge-focused
+
+### Suggested CTA cards
+
+Use linked cards similar to the shadcn docs style, but for these routes:
+
+- `/docs/registry/getting-started`
+- `/docs/registry/components`
+- `/docs/registry/examples`
+- `/docs/registry/schema`
+
+---
+
+## Technical Architecture
+
+### Routes
+
+Create a registry route:
+
+- `app/r/[name]/route.ts`
+
+Optional later:
+
+- `app/r/index/route.ts`
+- namespace support
+
+### Source layout
+
+Suggested structure:
+
+```txt
+registry/
+  readme-badge.tsx
+  readme-badge-row.tsx
+  badge-preview.tsx
+
+lib/registry/
+  items.ts
+  types.ts
+  build-item.ts
+```
+
+### Responsibility split
+
+#### `registry/`
+
+Contains installable source files/templates.
+
+#### `lib/registry/items.ts`
+
+Defines the item registry map and metadata.
+
+#### `lib/registry/build-item.ts`
+
+Builds the registry JSON payload returned by `/r/{name}.json`.
+
+---
+
+## v1 Delivery Order
+
+### Step 1
+
+Build registry infrastructure:
+
+- registry route
+- item type definitions
+- one sample item response
+
+### Step 2
+
+Ship `readme-badge`
+
+This is the first and most important installable component.
+
+### Step 3
+
+Ship `readme-badge-row`
+
+### Step 4
+
+Ship `badge-preview`
+
+### Step 5
+
+Add docs pages and sidebar navigation
+
+---
+
+## Success Criteria
+
+v1 is successful if:
+
+- users can install `@shieldcn/readme-badge`
+- users can install `@shieldcn/readme-badge-row`
+- users can install `@shieldcn/badge-preview`
+- registry docs are clear and polished
+- registry content drives traffic without confusing shieldcn's core identity
+
+---
+
+## Final Principle
+
+The registry should make people discover shieldcn.
+
+It should **not** make people wonder whether shieldcn is a registry product or a badge service.
+
+shieldcn remains the badge service.
+The registry is the growth layer.

--- a/app/r/[name]/route.ts
+++ b/app/r/[name]/route.ts
@@ -1,0 +1,52 @@
+/**
+ * shieldcn
+ * app/r/[name]/route.ts
+ *
+ * Dynamic registry route. Serves registry items at /r/{name}.json.
+ * Tracks downloads via OpenPanel.
+ */
+
+import { type NextRequest, NextResponse } from "next/server"
+import { notFound } from "next/navigation"
+import { getAllItemNames, buildRegistryItemResponse } from "@/lib/registry"
+import { trackEvent } from "@/lib/openpanel"
+
+interface RouteParams {
+  params: Promise<{ name: string }>
+}
+
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  const { name } = await params
+
+  if (!name.endsWith(".json")) {
+    return NextResponse.json(
+      { error: "Registry items must end with .json" },
+      { status: 400 }
+    )
+  }
+
+  const itemName = name.replace(".json", "")
+
+  void trackEvent({
+    name: "registry_download",
+    data: { component: itemName },
+  })
+
+  try {
+    const item = buildRegistryItemResponse(itemName)
+
+    if (!item) {
+      notFound()
+    }
+
+    return NextResponse.json(item)
+  } catch (error) {
+    console.error(`Failed to serve registry item: ${itemName}`, error)
+    notFound()
+  }
+}
+
+export async function generateStaticParams() {
+  const names = getAllItemNames()
+  return names.map((name) => ({ name: `${name}.json` }))
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next"
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/", "/dev/"],
+      },
+    ],
+    sitemap: "https://shieldcn.dev/sitemap.xml",
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,48 @@
+import type { MetadataRoute } from "next"
+import { readdirSync, statSync } from "node:fs"
+import { join } from "node:path"
+
+const BASE_URL = "https://shieldcn.dev"
+
+function collectDocSlugs(dir: string, prefix = ""): string[] {
+  const slugs: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    const stat = statSync(full)
+    if (stat.isDirectory()) {
+      slugs.push(...collectDocSlugs(full, `${prefix}${entry}/`))
+    } else if (entry.endsWith(".mdx")) {
+      const name = entry.replace(/\.mdx$/, "")
+      if (name === "index") {
+        slugs.push(prefix.replace(/\/$/, ""))
+      } else {
+        slugs.push(`${prefix}${name}`)
+      }
+    }
+  }
+  return slugs
+}
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date()
+
+  // Static pages
+  const staticPages: MetadataRoute.Sitemap = [
+    { url: BASE_URL, lastModified: now, changeFrequency: "weekly", priority: 1 },
+    { url: `${BASE_URL}/showcase`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
+    { url: `${BASE_URL}/gallery`, lastModified: now, changeFrequency: "weekly", priority: 0.8 },
+    { url: `${BASE_URL}/sponsor`, lastModified: now, changeFrequency: "monthly", priority: 0.5 },
+    { url: `${BASE_URL}/token-pool`, lastModified: now, changeFrequency: "monthly", priority: 0.4 },
+  ]
+
+  // Docs pages — auto-discovered from content/docs
+  const docSlugs = collectDocSlugs(join(process.cwd(), "content/docs"))
+  const docPages: MetadataRoute.Sitemap = docSlugs.map((slug) => ({
+    url: `${BASE_URL}/docs${slug ? `/${slug}` : ""}`,
+    lastModified: now,
+    changeFrequency: "weekly" as const,
+    priority: slug === "" ? 0.9 : 0.7,
+  }))
+
+  return [...staticPages, ...docPages]
+}

--- a/components/install-block.tsx
+++ b/components/install-block.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+/**
+ * shieldcn
+ * InstallBlock
+ *
+ * Registry install command block with package manager tabs.
+ */
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+interface InstallBlockProps {
+  /** Registry item name (e.g. "readme-badge"). */
+  name: string
+  className?: string
+}
+
+const managers = [
+  { id: "pnpm", label: "pnpm", cmd: (n: string) => `pnpm dlx shadcn@latest add @shieldcn/${n}` },
+  { id: "npx", label: "npx", cmd: (n: string) => `npx shadcn@latest add @shieldcn/${n}` },
+  { id: "yarn", label: "yarn", cmd: (n: string) => `npx shadcn@latest add @shieldcn/${n}` },
+  { id: "bun", label: "bun", cmd: (n: string) => `bunx --bun shadcn@latest add @shieldcn/${n}` },
+] as const
+
+export function InstallBlock({ name, className }: InstallBlockProps) {
+  const [active, setActive] = React.useState<string>("pnpm")
+  const [copied, setCopied] = React.useState(false)
+
+  const command = managers.find((m) => m.id === active)?.cmd(name) ?? ""
+
+  const handleCopy = React.useCallback(() => {
+    navigator.clipboard.writeText(command)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }, [command])
+
+  return (
+    <div
+      className={cn(
+        "not-prose overflow-hidden rounded-lg border border-border/60 shadow-xs",
+        className
+      )}
+    >
+      <div className="flex items-center border-b border-border/40 bg-muted/40">
+        {managers.map((m) => (
+          <button
+            key={m.id}
+            type="button"
+            onClick={() => setActive(m.id)}
+            className={cn(
+              "px-3 py-2 text-xs font-medium transition-colors",
+              active === m.id
+                ? "border-b-2 border-primary text-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            {m.label}
+          </button>
+        ))}
+        <div className="ml-auto pr-2">
+          <button
+            type="button"
+            onClick={handleCopy}
+            className={cn(
+              "rounded-md px-2 py-1 text-[10px] font-medium transition-colors",
+              copied
+                ? "text-primary"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            {copied ? "Copied" : "Copy"}
+          </button>
+        </div>
+      </div>
+      <div className="bg-muted/20 px-4 py-3">
+        <code className="font-mono text-sm text-foreground">{command}</code>
+      </div>
+    </div>
+  )
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -78,6 +78,15 @@ const docsNav: NavGroup[] = [
       { title: "Styles", href: "/docs/customization/styles" },
     ],
   },
+  {
+    title: "Registry",
+    items: [
+      { title: "Overview", href: "/docs/registry" },
+      { title: "ReadmeBadge", href: "/docs/registry/readme-badge" },
+      { title: "ReadmeBadgeRow", href: "/docs/registry/readme-badge-row" },
+      { title: "BadgePreview", href: "/docs/registry/badge-preview" },
+    ],
+  },
 ]
 
 export { docsNav }

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -7,6 +7,8 @@
     "...badges",
     "---Customization---",
     "...customization",
+    "---Registry---",
+    "...registry",
     "---Reference---",
     "api-reference"
   ]

--- a/content/docs/registry/badge-preview.mdx
+++ b/content/docs/registry/badge-preview.mdx
@@ -1,0 +1,116 @@
+---
+title: BadgePreview
+description: Visual badge preview with live rendering and copyable code snippet.
+---
+
+## Installation
+
+<InstallBlock name="badge-preview" />
+
+## Usage
+
+<CodeLine code={`import { BadgePreview } from "@/components/badge-preview"`} />
+
+### Basic preview
+
+<BadgePreview
+  src="/npm/react.svg"
+  code='<BadgePreview src="https://shieldcn.dev/npm/react.svg" alt="React" />'
+/>
+
+### With code snippet
+
+Shows a copyable code block below the badge preview.
+
+<BadgePreview
+  src="/npm/react.svg?variant=branded"
+  code='![React](https://shieldcn.dev/npm/react.svg?variant=branded)'
+/>
+
+### With label
+
+<BadgePreview
+  src="/github/stars/vercel/next.js.svg?variant=outline"
+  code='![stars](https://shieldcn.dev/github/stars/vercel/next.js.svg?variant=outline)'
+/>
+
+### Dark and light modes
+
+<BadgePreviewGroup>
+  <BadgePreviewCard
+    title="Dark background"
+    src="/npm/react.svg"
+    code='<BadgePreview src="..." mode="dark" />'
+  />
+  <BadgePreviewCard
+    title="Light background"
+    src="/npm/react.svg?mode=light"
+    code='<BadgePreview src="..." mode="light" />'
+  />
+</BadgePreviewGroup>
+
+### Variant grid
+
+Use `BadgePreviewGroup` and `BadgePreviewCard` to show multiple variants:
+
+<BadgePreviewGroup>
+  <BadgePreviewCard
+    title="Default"
+    src="/npm/react.svg"
+    code='![npm](https://shieldcn.dev/npm/react.svg)'
+  />
+  <BadgePreviewCard
+    title="Branded"
+    src="/npm/react.svg?variant=branded"
+    code='![npm](https://shieldcn.dev/npm/react.svg?variant=branded)'
+  />
+  <BadgePreviewCard
+    title="Outline"
+    src="/npm/react.svg?variant=outline"
+    code='![npm](https://shieldcn.dev/npm/react.svg?variant=outline)'
+  />
+  <BadgePreviewCard
+    title="Ghost"
+    src="/npm/react.svg?variant=ghost"
+    code='![npm](https://shieldcn.dev/npm/react.svg?variant=ghost)'
+  />
+</BadgePreviewGroup>
+
+## API Reference
+
+<ApiRefTable
+  title="BadgePreview"
+  props={[
+    {
+      name: "src",
+      type: "string",
+      required: true,
+      description: "Badge image URL.",
+    },
+    {
+      name: "alt",
+      type: "string",
+      description: 'Accessible alt text. Defaults to "badge".',
+    },
+    {
+      name: "code",
+      type: "string",
+      description: "Code snippet to display below the badge.",
+    },
+    {
+      name: "label",
+      type: "string",
+      description: "Label displayed above the badge.",
+    },
+    {
+      name: "mode",
+      type: '"dark" | "light"',
+      description: 'Background mode. Defaults to "dark".',
+    },
+    {
+      name: "className",
+      type: "string",
+      description: "Additional class names.",
+    },
+  ]}
+/>

--- a/content/docs/registry/index.mdx
+++ b/content/docs/registry/index.mdx
@@ -1,0 +1,76 @@
+---
+title: Registry
+description: Install React helpers for shieldcn badges via the shadcn registry.
+---
+
+shieldcn is a Markdown badge service first — every badge is a URL you drop into a README, docs page, or anywhere Markdown renders.
+
+But if you're building with React, you can also install lightweight helpers via the [shadcn registry](https://ui.shadcn.com/docs/registry). These components make it easy to render, layout, and preview shieldcn badges in your app.
+
+## Setup
+
+Add the shieldcn registry to your `components.json`:
+
+<CodeLine code={`"registries": { "@shieldcn": "https://shieldcn.dev/r/{name}.json" }`} language="json" />
+
+Then install any component:
+
+<InstallBlock name="readme-badge" />
+
+## Available components
+
+### ReadmeBadge
+
+Renders a shieldcn badge image with optional link wrapping. Works with any badge URL.
+
+<InstallBlock name="readme-badge" />
+
+<CodeLine code={`import { ReadmeBadge } from "@/components/readme-badge"`} />
+
+<BadgePreviewGroup>
+  <BadgePreviewCard
+    title="Basic"
+    src="/npm/react.svg?variant=branded"
+    code='<ReadmeBadge src="https://shieldcn.dev/npm/react.svg?variant=branded" alt="React" />'
+  />
+  <BadgePreviewCard
+    title="With link"
+    src="/github/stars/vercel/next.js.svg?variant=outline"
+    code='<ReadmeBadge src="https://shieldcn.dev/github/stars/vercel/next.js.svg" alt="stars" href="https://github.com/vercel/next.js" />'
+  />
+</BadgePreviewGroup>
+
+### ReadmeBadgeRow
+
+Horizontal layout wrapper for multiple badges with consistent spacing and wrapping.
+
+<InstallBlock name="readme-badge-row" />
+
+<CodeLine code={`import { ReadmeBadgeRow } from "@/components/readme-badge-row"`} />
+
+<BadgePreview
+  src="/npm/react.svg"
+  code='<ReadmeBadgeRow>
+  <ReadmeBadge src="https://shieldcn.dev/npm/react.svg" alt="npm" />
+  <ReadmeBadge src="https://shieldcn.dev/github/stars/vercel/next.js.svg" alt="stars" />
+  <ReadmeBadge src="https://shieldcn.dev/badge/build-passing-green.svg" alt="build" />
+</ReadmeBadgeRow>'
+/>
+
+### BadgePreview
+
+Visual badge preview with live rendering and optional copyable code snippet. Great for docs pages and badge builders.
+
+<InstallBlock name="badge-preview" />
+
+<CodeLine code={`import { BadgePreview } from "@/components/badge-preview"`} />
+
+## Not a replacement for URLs
+
+These components don't replace the badge service. They're convenience wrappers for rendering shieldcn badge URLs in React apps.
+
+The core product is still the URL:
+
+<CodeLine code="https://shieldcn.dev/npm/react.svg" language="text" />
+
+That works everywhere — GitHub READMEs, npm pages, docs sites, forums, and anywhere else Markdown renders.

--- a/content/docs/registry/meta.json
+++ b/content/docs/registry/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Registry",
+  "pages": ["---Setup---", "...", "---Components---", "readme-badge", "readme-badge-row", "badge-preview"]
+}

--- a/content/docs/registry/readme-badge-row.mdx
+++ b/content/docs/registry/readme-badge-row.mdx
@@ -1,0 +1,107 @@
+---
+title: ReadmeBadgeRow
+description: Horizontal layout wrapper for multiple badges with spacing and alignment.
+---
+
+## Installation
+
+<InstallBlock name="readme-badge-row" />
+
+## Usage
+
+<CodeLine code={`import { ReadmeBadge } from "@/components/readme-badge"`} />
+<CodeLine code={`import { ReadmeBadgeRow } from "@/components/readme-badge-row"`} />
+
+### Basic row
+
+<BadgePreview
+  src="/npm/react.svg"
+  code='<ReadmeBadgeRow>
+  <ReadmeBadge src="https://shieldcn.dev/npm/react.svg" alt="npm" />
+  <ReadmeBadge src="https://shieldcn.dev/github/stars/vercel/next.js.svg" alt="stars" />
+  <ReadmeBadge src="https://shieldcn.dev/badge/build-passing-green.svg" alt="build" />
+</ReadmeBadgeRow>'
+/>
+
+### Alignment
+
+<BadgePreviewGroup>
+  <BadgePreviewCard
+    title="Left (default)"
+    src="/badge/left-aligned-blue.svg"
+    code='<ReadmeBadgeRow align="left">...</ReadmeBadgeRow>'
+  />
+  <BadgePreviewCard
+    title="Center"
+    src="/badge/centered-blue.svg"
+    code='<ReadmeBadgeRow align="center">...</ReadmeBadgeRow>'
+  />
+  <BadgePreviewCard
+    title="Right"
+    src="/badge/right-aligned-blue.svg"
+    code='<ReadmeBadgeRow align="right">...</ReadmeBadgeRow>'
+  />
+</BadgePreviewGroup>
+
+### Gap sizes
+
+<BadgePreviewGroup>
+  <BadgePreviewCard
+    title="xs"
+    src="/badge/gap-xs-green.svg?variant=outline"
+    code='<ReadmeBadgeRow gap="xs">...</ReadmeBadgeRow>'
+  />
+  <BadgePreviewCard
+    title="sm (default)"
+    src="/badge/gap-sm-green.svg?variant=outline"
+    code='<ReadmeBadgeRow gap="sm">...</ReadmeBadgeRow>'
+  />
+  <BadgePreviewCard
+    title="md"
+    src="/badge/gap-md-green.svg?variant=outline"
+    code='<ReadmeBadgeRow gap="md">...</ReadmeBadgeRow>'
+  />
+  <BadgePreviewCard
+    title="lg"
+    src="/badge/gap-lg-green.svg?variant=outline"
+    code='<ReadmeBadgeRow gap="lg">...</ReadmeBadgeRow>'
+  />
+</BadgePreviewGroup>
+
+### Works with any children
+
+`ReadmeBadgeRow` works with any inline elements, not just `ReadmeBadge`:
+
+<CodeLine code={`<ReadmeBadgeRow>
+  <img src="https://shieldcn.dev/npm/react.svg" alt="React" />
+  <img src="https://shields.io/badge/foo-bar-blue" alt="shields" />
+</ReadmeBadgeRow>`} />
+
+## API Reference
+
+<ApiRefTable
+  title="ReadmeBadgeRow"
+  props={[
+    {
+      name: "gap",
+      type: '"xs" | "sm" | "md" | "lg"',
+      description: 'Spacing between badges. Defaults to "sm".',
+    },
+    {
+      name: "align",
+      type: '"left" | "center" | "right"',
+      description: 'Horizontal alignment. Defaults to "left".',
+    },
+    {
+      name: "className",
+      type: "string",
+      description: "Additional class names for the wrapper.",
+    },
+    {
+      name: "children",
+      type: "ReactNode",
+      required: true,
+      description: "Badge elements or any inline children.",
+    },
+  ]}
+/>

--- a/content/docs/registry/readme-badge.mdx
+++ b/content/docs/registry/readme-badge.mdx
@@ -1,0 +1,126 @@
+---
+title: ReadmeBadge
+description: Render a shieldcn badge image with optional link wrapping.
+---
+
+## Installation
+
+<InstallBlock name="readme-badge" />
+
+## Usage
+
+<CodeLine code={`import { ReadmeBadge } from "@/components/readme-badge"`} />
+
+### Basic badge
+
+<BadgePreviewGroup>
+  <BadgePreviewCard
+    title="npm version"
+    src="/npm/react.svg"
+    code='<ReadmeBadge src="https://shieldcn.dev/npm/react.svg" alt="React npm version" />'
+  />
+  <BadgePreviewCard
+    title="Branded"
+    src="/npm/react.svg?variant=branded"
+    code='<ReadmeBadge src="https://shieldcn.dev/npm/react.svg?variant=branded" alt="React" />'
+  />
+</BadgePreviewGroup>
+
+### Badge with link
+
+Wraps the badge in an anchor tag that opens in a new tab.
+
+<BadgePreview
+  src="/github/stars/vercel/next.js.svg?variant=outline"
+  code='<ReadmeBadge
+  src="https://shieldcn.dev/github/stars/vercel/next.js.svg"
+  alt="Next.js GitHub stars"
+  href="https://github.com/vercel/next.js"
+/>'
+/>
+
+### Custom height
+
+<BadgePreview
+  src="/npm/react.svg?size=lg"
+  code='<ReadmeBadge
+  src="https://shieldcn.dev/npm/react.svg?size=lg"
+  alt="React"
+  height={28}
+/>'
+/>
+
+### Variants
+
+<BadgePreviewGroup>
+  <BadgePreviewCard
+    title="Default"
+    src="/npm/react.svg"
+    code='<ReadmeBadge src="...?variant=default" />'
+  />
+  <BadgePreviewCard
+    title="Secondary"
+    src="/npm/react.svg?variant=secondary"
+    code='<ReadmeBadge src="...?variant=secondary" />'
+  />
+  <BadgePreviewCard
+    title="Outline"
+    src="/npm/react.svg?variant=outline"
+    code='<ReadmeBadge src="...?variant=outline" />'
+  />
+  <BadgePreviewCard
+    title="Ghost"
+    src="/npm/react.svg?variant=ghost"
+    code='<ReadmeBadge src="...?variant=ghost" />'
+  />
+  <BadgePreviewCard
+    title="Destructive"
+    src="/npm/react.svg?variant=destructive"
+    code='<ReadmeBadge src="...?variant=destructive" />'
+  />
+  <BadgePreviewCard
+    title="Branded"
+    src="/npm/react.svg?variant=branded"
+    code='<ReadmeBadge src="...?variant=branded" />'
+  />
+</BadgePreviewGroup>
+
+## API Reference
+
+<ApiRefTable
+  title="ReadmeBadge"
+  props={[
+    {
+      name: "src",
+      type: "string",
+      required: true,
+      description: "Badge image URL.",
+    },
+    {
+      name: "alt",
+      type: "string",
+      required: true,
+      description: "Accessible alt text.",
+    },
+    {
+      name: "href",
+      type: "string",
+      description: "Optional link URL. Wraps badge in an anchor tag.",
+    },
+    {
+      name: "height",
+      type: "number",
+      description: "Image height in pixels. Defaults to 20.",
+    },
+    {
+      name: "className",
+      type: "string",
+      description: "Class name for the outer element (link or image).",
+    },
+    {
+      name: "imgClassName",
+      type: "string",
+      description: "Class name for the img element when wrapped in a link.",
+    },
+  ]}
+/>

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -1,0 +1,71 @@
+/**
+ * shieldcn
+ * lib/registry
+ *
+ * Registry item lookup and JSON response builder.
+ * Reads component source files from disk and inlines them
+ * into the shadcn registry JSON format.
+ */
+
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import registryData from "@/registry.json"
+
+interface RegistryFile {
+  path: string
+  type: string
+  target?: string
+}
+
+interface RegistryItem {
+  name: string
+  type: string
+  title: string
+  description: string
+  dependencies?: string[]
+  registryDependencies?: string[]
+  categories?: string[]
+  files: RegistryFile[]
+}
+
+/**
+ * Look up a registry item by name.
+ */
+export function getRegistryItem(name: string): RegistryItem | null {
+  return (
+    (registryData.items as RegistryItem[]).find(
+      (item) => item.name === name
+    ) ?? null
+  )
+}
+
+/**
+ * Get all registry item names for static route generation.
+ */
+export function getAllItemNames(): string[] {
+  return (registryData.items as RegistryItem[]).map((item) => item.name)
+}
+
+/**
+ * Build a full registry item JSON response with inlined file contents.
+ * Used by the /r/[name] route handler.
+ */
+export function buildRegistryItemResponse(name: string): object | null {
+  const item = getRegistryItem(name)
+  if (!item) return null
+
+  const filesWithContent = item.files.map((file) => {
+    const filePath = join(process.cwd(), file.path)
+    const content = readFileSync(filePath, "utf-8")
+    return {
+      ...file,
+      content,
+    }
+  })
+
+  return {
+    $schema: "https://ui.shadcn.com/schema/registry-item.json",
+    ...item,
+    files: filesWithContent,
+  }
+}

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -4,6 +4,7 @@ import { BadgePreview, BadgePreviewGroup, BadgePreviewCard } from "@/components/
 import { CodeBlock } from "@/components/code-block"
 import { CodeLine } from "@/components/code-line"
 import { ApiRefTable } from "@/components/api-ref-table"
+import { InstallBlock } from "@/components/install-block"
 
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
@@ -21,6 +22,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     CodeBlock,
     CodeLine,
     ApiRefTable,
+    InstallBlock,
   }
 }
 

--- a/registry.json
+++ b/registry.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry.json",
+  "name": "shieldcn",
+  "homepage": "https://shieldcn.dev",
+  "items": [
+    {
+      "name": "readme-badge",
+      "type": "registry:component",
+      "title": "Readme Badge",
+      "description": "Renders a shieldcn badge image with optional link wrapping. Works with any badge URL — shieldcn, shields.io, or custom images.",
+      "dependencies": [],
+      "registryDependencies": [],
+      "categories": ["badges", "readme"],
+      "files": [
+        {
+          "path": "registry/readme-badge/readme-badge.tsx",
+          "type": "registry:component"
+        }
+      ]
+    },
+    {
+      "name": "readme-badge-row",
+      "type": "registry:component",
+      "title": "Readme Badge Row",
+      "description": "Horizontal layout wrapper for multiple badges with consistent spacing, wrapping, and alignment. Pairs with ReadmeBadge.",
+      "dependencies": [],
+      "registryDependencies": [],
+      "categories": ["badges", "readme", "layout"],
+      "files": [
+        {
+          "path": "registry/readme-badge-row/readme-badge-row.tsx",
+          "type": "registry:component"
+        }
+      ]
+    },
+    {
+      "name": "badge-preview",
+      "type": "registry:component",
+      "title": "Badge Preview",
+      "description": "Visual badge preview with live image rendering and optional copyable code snippet. Ideal for documentation pages, badge builders, and app UIs.",
+      "dependencies": [],
+      "registryDependencies": [],
+      "categories": ["badges", "docs"],
+      "files": [
+        {
+          "path": "registry/badge-preview/badge-preview.tsx",
+          "type": "registry:component"
+        }
+      ]
+    }
+  ]
+}

--- a/registry/badge-preview/badge-preview.tsx
+++ b/registry/badge-preview/badge-preview.tsx
@@ -1,0 +1,114 @@
+/**
+ * shieldcn
+ * BadgePreview
+ * by Justin Levine
+ * shieldcn.dev
+ *
+ * Visual badge preview component for documentation pages and app UIs.
+ * Renders a live badge image with an optional copyable code snippet below.
+ *
+ * Props:
+ * - src: badge image URL
+ * - alt?: accessible alt text (default "badge")
+ * - code?: code snippet to display below the badge
+ * - label?: optional label above the badge
+ * - mode?: background mode ("dark" | "light", default "dark")
+ * - className?: additional class names
+ */
+
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+interface BadgePreviewProps extends React.ComponentProps<"div"> {
+  /** Badge image URL. */
+  src: string
+  /** Accessible alt text. @default "badge" */
+  alt?: string
+  /** Code snippet to display below the badge. */
+  code?: string
+  /** Optional label above the badge. */
+  label?: string
+  /** Background mode. @default "dark" */
+  mode?: "dark" | "light"
+  /** Additional class names. */
+  className?: string
+}
+
+function BadgePreview({
+  src,
+  alt = "badge",
+  code,
+  label,
+  mode = "dark",
+  className,
+  ...props
+}: BadgePreviewProps) {
+  const [copied, setCopied] = React.useState(false)
+
+  const handleCopy = React.useCallback(() => {
+    if (!code) return
+    navigator.clipboard.writeText(code)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }, [code])
+
+  return (
+    <div
+      data-slot="badge-preview"
+      className={cn(
+        "overflow-hidden rounded-lg border border-border",
+        className
+      )}
+      {...props}
+    >
+      {label && (
+        <div className="border-b border-border px-4 py-2">
+          <span className="text-xs font-medium text-muted-foreground">
+            {label}
+          </span>
+        </div>
+      )}
+
+      <div
+        className={cn(
+          "flex items-center justify-center px-6 py-8",
+          mode === "dark" ? "bg-zinc-950" : "bg-zinc-100"
+        )}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={src}
+          alt={alt}
+          className="inline-block max-w-full"
+          loading="lazy"
+          decoding="async"
+        />
+      </div>
+
+      {code && (
+        <div className="relative border-t border-border bg-muted/30">
+          <pre className="overflow-x-auto px-4 py-3">
+            <code className="text-xs text-muted-foreground">{code}</code>
+          </pre>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className={cn(
+              "absolute right-2 top-2 rounded-md border border-border px-2 py-1 text-[10px] font-medium transition-colors",
+              copied
+                ? "bg-primary text-primary-foreground"
+                : "bg-background text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+            )}
+          >
+            {copied ? "Copied" : "Copy"}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export { BadgePreview }
+export type { BadgePreviewProps }

--- a/registry/readme-badge-row/readme-badge-row.tsx
+++ b/registry/readme-badge-row/readme-badge-row.tsx
@@ -1,0 +1,67 @@
+/**
+ * shieldcn
+ * ReadmeBadgeRow
+ * by Justin Levine
+ * shieldcn.dev
+ *
+ * Horizontal layout wrapper for multiple badges with consistent spacing,
+ * wrapping, and alignment. Works with ReadmeBadge or any inline elements.
+ *
+ * Props:
+ * - gap?: spacing between badges ("xs" | "sm" | "md" | "lg", default "sm")
+ * - align?: horizontal alignment ("left" | "center" | "right", default "left")
+ * - className?: additional class names
+ * - children: badge elements
+ */
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+const gapMap = {
+  xs: "gap-1",
+  sm: "gap-2",
+  md: "gap-3",
+  lg: "gap-4",
+} as const
+
+const alignMap = {
+  left: "justify-start",
+  center: "justify-center",
+  right: "justify-end",
+} as const
+
+interface ReadmeBadgeRowProps extends React.ComponentProps<"div"> {
+  /** Spacing between badges. @default "sm" */
+  gap?: keyof typeof gapMap
+  /** Horizontal alignment. @default "left" */
+  align?: keyof typeof alignMap
+  /** Additional class names. */
+  className?: string
+  children: React.ReactNode
+}
+
+function ReadmeBadgeRow({
+  gap = "sm",
+  align = "left",
+  className,
+  children,
+  ...props
+}: ReadmeBadgeRowProps) {
+  return (
+    <div
+      data-slot="readme-badge-row"
+      className={cn(
+        "flex flex-wrap items-center",
+        gapMap[gap],
+        alignMap[align],
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+export { ReadmeBadgeRow }
+export type { ReadmeBadgeRowProps }

--- a/registry/readme-badge/readme-badge.tsx
+++ b/registry/readme-badge/readme-badge.tsx
@@ -1,0 +1,79 @@
+/**
+ * shieldcn
+ * ReadmeBadge
+ * by Justin Levine
+ * shieldcn.dev
+ *
+ * Renders a shieldcn badge image with optional link wrapping.
+ * Works with any shieldcn badge URL or any image URL.
+ *
+ * Props:
+ * - src: badge image URL (shieldcn, shields.io, or any image)
+ * - alt: accessible alt text for the badge
+ * - href?: optional link URL — wraps the badge in an anchor tag
+ * - height?: image height in pixels (default 20)
+ * - className?: class name for the outer element (link or image)
+ * - imgClassName?: class name for the img element (when href is set)
+ */
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+interface ReadmeBadgeProps extends React.ComponentProps<"img"> {
+  /** Badge image URL. */
+  src: string
+  /** Accessible alt text. */
+  alt: string
+  /** Optional link — wraps badge in an anchor. */
+  href?: string
+  /** Image height in pixels. @default 20 */
+  height?: number
+  /** Class name for the outer element. */
+  className?: string
+  /** Class name for the img element when wrapped in a link. */
+  imgClassName?: string
+}
+
+function ReadmeBadge({
+  src,
+  alt,
+  href,
+  height = 20,
+  className,
+  imgClassName,
+  ...props
+}: ReadmeBadgeProps) {
+  const img = (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={src}
+      alt={alt}
+      height={height}
+      className={cn(
+        "inline-block align-middle",
+        href ? imgClassName : className
+      )}
+      loading="lazy"
+      decoding="async"
+      {...props}
+    />
+  )
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={cn("inline-flex", className)}
+      >
+        {img}
+      </a>
+    )
+  }
+
+  return img
+}
+
+export { ReadmeBadge }
+export type { ReadmeBadgeProps }


### PR DESCRIPTION
## Summary
- Add shadcn-compatible registry with 3 installable components
  - `@shieldcn/readme-badge`
  - `@shieldcn/readme-badge-row`
  - `@shieldcn/badge-preview`
- Registry route at `/r/{name}.json` with OpenPanel download tracking
- Registry docs with InstallBlock, CodeLine, BadgePreview, and ApiRefTable
- Sidebar updated with Registry section
- Auto-generated `/sitemap.xml` and `/robots.txt`
- `REGISTRY_PLAN.md` with strategy and architecture

## Install
```bash
pnpm dlx shadcn@latest add @shieldcn/readme-badge
```

## Testing
- `pnpm tsc --noEmit` ✓
- `pnpm build` ✓