### PR TITLE
feat: badge generator, color picker, and gradient nav link

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ If those env vars are missing, analytics stays disabled.
 - **[shadcn/ui](https://ui.shadcn.com)** — the design system these badges are built on.
 - **[Satori](https://github.com/vercel/satori)** — Vercel's JSX-to-SVG engine that makes rendering React components as badge images possible.
 - **[jal-co/ui](https://ui.justinlevine.me)** — the component library powering the docs site.
+- **[@k33bs](https://github.com/k33bs)** — creator of [shieldcngen](https://github.com/k33bs/shieldcngen), the badge generator tool powering the [`/gen`](https://shieldcn.dev/gen) page.
 
 ## Contributing
 

--- a/app/gen/generator-client.tsx
+++ b/app/gen/generator-client.tsx
@@ -1,0 +1,905 @@
+"use client"
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+import { Copy, Download, FileUp, RefreshCw, Trash2, X } from "lucide-react"
+import {
+  badgeHtml,
+  badgeMarkdown,
+  badgeUrl,
+  DEFAULT_GLOBAL,
+  type Badge,
+  type BadgeGroup,
+  type GlobalSettings,
+  type Mode,
+  type Overrides,
+  type Size,
+  type Theme,
+  type Variant,
+} from "@/lib/gen/shieldcn"
+import { deserialize, mergeRefresh, serialize, type Config } from "@/lib/gen/config"
+import { inspect, type InspectResult } from "@/lib/gen/detect"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Label } from "@/components/ui/label"
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
+import { Card, CardContent } from "@/components/ui/card"
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover"
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select"
+import { Separator } from "@/components/ui/separator"
+import { ColorInput } from "@/components/color-input"
+import { cn } from "@/lib/utils"
+
+const VARIANTS: Variant[] = [
+  "default",
+  "secondary",
+  "outline",
+  "ghost",
+  "destructive",
+  "branded",
+]
+const SIZES: Size[] = ["xs", "sm", "default", "lg"]
+const MODES: Mode[] = ["dark", "light"]
+const THEMES: Theme[] = [
+  "none",
+  "zinc",
+  "slate",
+  "stone",
+  "neutral",
+  "gray",
+  "blue",
+  "green",
+  "rose",
+  "orange",
+  "amber",
+  "violet",
+  "purple",
+  "red",
+  "cyan",
+  "emerald",
+]
+
+const GROUP_TITLES: Record<BadgeGroup, string> = {
+  github: "GitHub",
+  package: "Package",
+  tooling: "Tooling",
+  stack: "Stack",
+  modern: "Modern",
+  community: "Community",
+}
+
+const GROUP_ORDER: BadgeGroup[] = [
+  "github",
+  "package",
+  "tooling",
+  "stack",
+  "modern",
+  "community",
+]
+
+export default function GeneratorApp() {
+  const [inputUrl, setInputUrl] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [config, setConfig] = useState<Config | null>(null)
+  const [notes, setNotes] = useState<string[]>([])
+  const [shieldsIoUrls, setShieldsIoUrls] = useState<string[]>([])
+  const [refreshDiff, setRefreshDiff] = useState<
+    { added: string[]; refreshed: string[]; missing: string[] } | null
+  >(null)
+
+  const updateGlobal = useCallback((patch: Partial<GlobalSettings>) => {
+    setConfig((c) => (c ? { ...c, global: { ...c.global, ...patch } } : c))
+  }, [])
+
+  const updateBadge = useCallback((id: string, patch: Partial<Badge>) => {
+    setConfig((c) => {
+      if (!c) return c
+      return {
+        ...c,
+        badges: c.badges.map((b) => (b.id === id ? { ...b, ...patch } : b)),
+      }
+    })
+  }, [])
+
+  const updateOverrides = useCallback((id: string, patch: Overrides) => {
+    setConfig((c) => {
+      if (!c) return c
+      return {
+        ...c,
+        badges: c.badges.map((b) =>
+          b.id === id ? { ...b, overrides: { ...b.overrides, ...patch } } : b,
+        ),
+      }
+    })
+  }, [])
+
+  const removeBadge = useCallback((id: string) => {
+    setConfig((c) => {
+      if (!c) return c
+      return {
+        ...c,
+        badges: c.badges.map((b) => (b.id === id ? { ...b, enabled: false } : b)),
+      }
+    })
+  }, [])
+
+  const inspectAbortRef = useRef<AbortController | null>(null)
+
+  const runInspect = useCallback(async (url: string): Promise<InspectResult | null> => {
+    inspectAbortRef.current?.abort()
+    const controller = new AbortController()
+    inspectAbortRef.current = controller
+
+    setLoading(true)
+    setError(null)
+    setRefreshDiff(null)
+    try {
+      const result = await inspect(url, controller.signal)
+      if (controller.signal.aborted) return null
+      if ("error" in result) {
+        setError(result.error)
+        return null
+      }
+      return result
+    } catch (e) {
+      if (controller.signal.aborted) return null
+      setError((e as Error).message)
+      return null
+    } finally {
+      if (inspectAbortRef.current === controller) {
+        setLoading(false)
+        inspectAbortRef.current = null
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      inspectAbortRef.current?.abort()
+    }
+  }, [])
+
+  const handleGenerate = useCallback(async () => {
+    if (!inputUrl.trim()) return
+    const result = await runInspect(inputUrl.trim())
+    if (!result) return
+    setConfig({
+      version: 1,
+      source: { type: "github", ...result.source },
+      global: DEFAULT_GLOBAL,
+      badges: result.badges,
+      generatedAt: new Date().toISOString(),
+    })
+    setNotes(result.notes)
+    setShieldsIoUrls(result.existingShieldsIoUrls)
+  }, [inputUrl, runInspect])
+
+  const handleConfigUpload = useCallback(async (file: File) => {
+    setError(null)
+    try {
+      const text = await file.text()
+      const parsed = deserialize(text)
+      if (!parsed.ok) {
+        setError(parsed.error)
+        return
+      }
+      setConfig(parsed.config)
+      setInputUrl(parsed.config.source.url)
+      setNotes([])
+      setShieldsIoUrls([])
+      setRefreshDiff(null)
+    } catch (e) {
+      setError((e as Error).message)
+    }
+  }, [])
+
+  const configRef = useRef<Config | null>(null)
+  useEffect(() => {
+    configRef.current = config
+  }, [config])
+
+  const handleRefresh = useCallback(async () => {
+    const sourceUrl = configRef.current?.source.url
+    if (!sourceUrl) return
+    const result = await runInspect(sourceUrl)
+    if (!result) return
+    const latest = configRef.current
+    if (!latest) return
+    const merged = mergeRefresh(latest, {
+      badges: result.badges,
+      source: { type: "github", ...result.source },
+    })
+    setConfig(merged.config)
+    setNotes(result.notes)
+    setShieldsIoUrls(result.existingShieldsIoUrls)
+    setRefreshDiff(merged.diff)
+  }, [runInspect])
+
+  const markdown = useMemo(() => {
+    if (!config) return ""
+    return config.badges
+      .filter((b) => b.enabled)
+      .map((b) => badgeMarkdown(b, config.global))
+      .join("\n")
+  }, [config])
+
+  const enabledBadges = useMemo(
+    () => (config ? config.badges.filter((b) => b.enabled) : []),
+    [config],
+  )
+
+  const copy = useCallback(async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text)
+    } catch {
+      /* ignore */
+    }
+  }, [])
+
+  const downloadText = useCallback(
+    (text: string, filename: string, type: string) => {
+      const blob = new Blob([text], { type })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement("a")
+      a.href = url
+      a.download = filename
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      URL.revokeObjectURL(url)
+    },
+    [],
+  )
+
+  return (
+    <div className="space-y-6">
+      <Tabs defaultValue="url">
+        <TabsList>
+          <TabsTrigger value="url">From GitHub URL</TabsTrigger>
+          <TabsTrigger value="config">From config file</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="url">
+          <Card>
+            <CardContent>
+              <div className="space-y-2">
+                <Label htmlFor="url-input" className="text-xs text-muted-foreground">
+                  GitHub repository URL or owner/repo
+                </Label>
+                <div className="flex gap-2">
+                  <Input
+                    id="url-input"
+                    type="text"
+                    placeholder="vercel/next.js or https://github.com/vercel/next.js"
+                    value={inputUrl}
+                    onChange={(e) => setInputUrl(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") void handleGenerate()
+                    }}
+                    className="flex-1"
+                  />
+                  <Button
+                    onClick={() => void handleGenerate()}
+                    disabled={loading || !inputUrl.trim()}
+                  >
+                    {loading ? "Generating…" : "Generate"}
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="config">
+          <ConfigDropZone onFile={handleConfigUpload} />
+        </TabsContent>
+      </Tabs>
+
+      {error && (
+        <div className="rounded-md border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-red-400">
+          {error}
+        </div>
+      )}
+
+      {config && (
+        <ResultsPanel
+          config={config}
+          notes={notes}
+          shieldsIoUrls={shieldsIoUrls}
+          refreshDiff={refreshDiff}
+          markdown={markdown}
+          enabledBadges={enabledBadges}
+          updateGlobal={updateGlobal}
+          updateBadge={updateBadge}
+          updateOverrides={updateOverrides}
+          removeBadge={removeBadge}
+          onRefresh={() => void handleRefresh()}
+          onCopy={copy}
+          onDownload={downloadText}
+          loading={loading}
+        />
+      )}
+    </div>
+  )
+}
+
+/* ── Config drop zone ─────────────────────────────── */
+
+function ConfigDropZone({ onFile }: { onFile: (f: File) => void }) {
+  const [dragOver, setDragOver] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  return (
+    <Card
+      className={cn(
+        "border-dashed transition-colors",
+        dragOver && "border-primary",
+      )}
+      onDragOver={(e) => {
+        e.preventDefault()
+        setDragOver(true)
+      }}
+      onDragLeave={() => setDragOver(false)}
+      onDrop={(e) => {
+        e.preventDefault()
+        setDragOver(false)
+        const file = e.dataTransfer.files?.[0]
+        if (file) onFile(file)
+      }}
+    >
+      <CardContent className="flex flex-col items-center gap-3 py-8 text-center">
+        <FileUp className="size-8 text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">
+          Drop a <code className="rounded bg-muted px-1.5 py-0.5 text-xs">.shieldcngen.json</code> file here, or
+        </p>
+        <Button variant="outline" size="sm" onClick={() => inputRef.current?.click()}>
+          Choose a file
+        </Button>
+        <input
+          ref={inputRef}
+          type="file"
+          accept=".json,application/json"
+          className="hidden"
+          onChange={(e) => {
+            const file = e.target.files?.[0]
+            if (file) onFile(file)
+            e.target.value = ""
+          }}
+        />
+      </CardContent>
+    </Card>
+  )
+}
+
+/* ── Global select ────────────────────────────────── */
+
+function GlobalSelect({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string
+  value: string
+  options: readonly string[]
+  onChange: (v: string) => void
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label className="text-xs uppercase tracking-wider text-muted-foreground">
+        {label}
+      </Label>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger className="w-full">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((opt) => (
+            <SelectItem key={opt} value={opt}>
+              {opt}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
+/* ── Results panel ────────────────────────────────── */
+
+type ResultsPanelProps = {
+  config: Config
+  notes: string[]
+  shieldsIoUrls: string[]
+  refreshDiff: { added: string[]; refreshed: string[]; missing: string[] } | null
+  markdown: string
+  enabledBadges: Badge[]
+  updateGlobal: (patch: Partial<GlobalSettings>) => void
+  updateBadge: (id: string, patch: Partial<Badge>) => void
+  updateOverrides: (id: string, patch: Overrides) => void
+  removeBadge: (id: string) => void
+  onRefresh: () => void
+  onCopy: (text: string) => void
+  onDownload: (text: string, filename: string, type: string) => void
+  loading: boolean
+}
+
+function ResultsPanel({
+  config,
+  notes,
+  shieldsIoUrls,
+  refreshDiff,
+  markdown,
+  enabledBadges,
+  updateGlobal,
+  updateBadge,
+  updateOverrides,
+  removeBadge,
+  onRefresh,
+  onCopy,
+  onDownload,
+  loading,
+}: ResultsPanelProps) {
+  const byGroup = useMemo(() => {
+    const map = new Map<BadgeGroup, Badge[]>()
+    for (const b of config.badges) {
+      const arr = map.get(b.group) ?? []
+      arr.push(b)
+      map.set(b.group, arr)
+    }
+    return map
+  }, [config.badges])
+
+  const downloadConfig = useCallback(() => {
+    const safeName = `${config.source.owner}-${config.source.repo}.shieldcngen.json`
+    onDownload(serialize(config), safeName, "application/json")
+  }, [config, onDownload])
+
+  const downloadMarkdown = useCallback(() => {
+    onDownload(markdown + "\n", "badges.md", "text/markdown")
+  }, [markdown, onDownload])
+
+  return (
+    <div className="space-y-6">
+      {/* Status */}
+      <div className="text-sm text-muted-foreground">
+        Detected <strong className="text-foreground">{enabledBadges.length}</strong> badge
+        {enabledBadges.length === 1 ? "" : "s"} for{" "}
+        <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+          {config.source.owner}/{config.source.repo}
+        </code>
+        {refreshDiff && (
+          <>
+            {" · "}
+            <span className="text-emerald-400">+{refreshDiff.added.length} new</span>
+            {refreshDiff.missing.length > 0 && (
+              <>
+                {" · "}
+                <span className="text-red-400">
+                  {refreshDiff.missing.length} no longer detected
+                </span>
+              </>
+            )}
+          </>
+        )}
+      </div>
+
+      {notes.length > 0 && (
+        <div className="space-y-1 text-xs text-muted-foreground">
+          {notes.map((n) => (
+            <div key={n}>· {n}</div>
+          ))}
+        </div>
+      )}
+
+      {/* Global defaults */}
+      <div className="space-y-3">
+        <h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Global defaults
+        </h3>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <GlobalSelect
+            label="Variant"
+            value={config.global.variant}
+            options={VARIANTS}
+            onChange={(v) => updateGlobal({ variant: v as Variant })}
+          />
+          <GlobalSelect
+            label="Size"
+            value={config.global.size}
+            options={SIZES}
+            onChange={(v) => updateGlobal({ size: v as Size })}
+          />
+          <GlobalSelect
+            label="Theme"
+            value={config.global.theme}
+            options={THEMES}
+            onChange={(v) => updateGlobal({ theme: v as Theme })}
+          />
+          <GlobalSelect
+            label="Mode"
+            value={config.global.mode}
+            options={MODES}
+            onChange={(v) => updateGlobal({ mode: v as Mode })}
+          />
+        </div>
+      </div>
+
+      {/* Badge groups */}
+      {GROUP_ORDER.map((group) => {
+        const items = byGroup.get(group)
+        if (!items || items.length === 0) return null
+        const visible = items.filter((b) => b.enabled)
+        if (visible.length === 0) return null
+        return (
+          <div key={group} className="space-y-3">
+            <div className="flex items-baseline gap-2">
+              <h3 className="text-sm font-semibold">{GROUP_TITLES[group]}</h3>
+              <span className="text-xs text-muted-foreground">{visible.length}</span>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {visible.map((badge) => (
+                <BadgeItem
+                  key={badge.id}
+                  badge={badge}
+                  global={config.global}
+                  onUpdate={(patch) => updateBadge(badge.id, patch)}
+                  onUpdateOverrides={(patch) => updateOverrides(badge.id, patch)}
+                  onRemove={() => removeBadge(badge.id)}
+                  onCopy={onCopy}
+                />
+              ))}
+            </div>
+          </div>
+        )
+      })}
+
+      <Separator />
+
+      {/* Markdown output */}
+      <div className="space-y-3">
+        <h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Markdown output
+        </h3>
+        <Textarea
+          readOnly
+          value={markdown}
+          rows={Math.min(Math.max(enabledBadges.length, 4), 16)}
+          className="font-mono text-xs"
+        />
+        <div className="flex flex-wrap gap-2">
+          <Button size="sm" onClick={() => onCopy(markdown)}>
+            <Copy className="size-3.5" />
+            Copy markdown
+          </Button>
+          <Button variant="outline" size="sm" onClick={downloadMarkdown}>
+            <Download className="size-3.5" />
+            Download .md
+          </Button>
+          <Button variant="outline" size="sm" onClick={downloadConfig}>
+            <Download className="size-3.5" />
+            Download config
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onRefresh}
+            disabled={loading}
+          >
+            <RefreshCw className={cn("size-3.5", loading && "animate-spin")} />
+            {loading ? "Refreshing…" : "Refresh from GitHub"}
+          </Button>
+        </div>
+      </div>
+
+      {/* Existing shields.io badges */}
+      {shieldsIoUrls.length > 0 && (
+        <details className="text-xs text-muted-foreground">
+          <summary className="cursor-pointer">
+            {shieldsIoUrls.length} existing shields.io badge
+            {shieldsIoUrls.length === 1 ? "" : "s"} found in README
+          </summary>
+          <ul className="mt-2 space-y-1">
+            {shieldsIoUrls.map((u) => (
+              <li key={u}>
+                <code className="text-[11px] break-all">{u}</code>
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  )
+}
+
+/* ── Badge item with popover ──────────────────────── */
+
+function BadgeItem({
+  badge,
+  global,
+  onUpdate,
+  onUpdateOverrides,
+  onRemove,
+  onCopy,
+}: {
+  badge: Badge
+  global: GlobalSettings
+  onUpdate: (patch: Partial<Badge>) => void
+  onUpdateOverrides: (patch: Overrides) => void
+  onRemove: () => void
+  onCopy: (text: string) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const url = badgeUrl(badge, global)
+  const md = badgeMarkdown(badge, global)
+  const html = badgeHtml(badge, global)
+
+  const setOverride = (key: keyof Overrides, value: string | number | boolean | undefined) => {
+    if (value === "" || value === undefined) {
+      const next = { ...badge.overrides }
+      delete next[key]
+      onUpdate({ overrides: next })
+    } else {
+      onUpdateOverrides({ [key]: value } as Overrides)
+    }
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "inline-flex items-center rounded-md border border-transparent p-0.5 transition-colors hover:border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+            open && "border-primary",
+            !badge.enabled && "opacity-30 grayscale-[60%]",
+          )}
+        >
+          <img src={url} alt={badge.label} loading="lazy" className="block max-h-10" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80 space-y-3" align="start">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium">{badge.label}</span>
+          <Button variant="ghost" size="icon-xs" onClick={() => setOpen(false)}>
+            <X className="size-3" />
+          </Button>
+        </div>
+
+        {/* Override selects */}
+        <div className="grid grid-cols-2 gap-2">
+          <OverrideSelect
+            label="Variant"
+            value={badge.overrides.variant ?? ""}
+            options={VARIANTS}
+            onChange={(v) => setOverride("variant", v)}
+          />
+          <OverrideSelect
+            label="Size"
+            value={badge.overrides.size ?? ""}
+            options={SIZES}
+            onChange={(v) => setOverride("size", v)}
+          />
+          <OverrideSelect
+            label="Theme"
+            value={badge.overrides.theme ?? ""}
+            options={THEMES}
+            onChange={(v) => setOverride("theme", v)}
+          />
+          <OverrideSelect
+            label="Mode"
+            value={badge.overrides.mode ?? ""}
+            options={MODES}
+            onChange={(v) => setOverride("mode", v)}
+          />
+        </div>
+
+        {/* Colors */}
+        <div className="grid grid-cols-2 gap-2">
+          <ColorField
+            label="Value color"
+            value={badge.overrides.color ?? ""}
+            onChange={(v) => setOverride("color", v)}
+          />
+          <ColorField
+            label="Label color"
+            value={badge.overrides.labelColor ?? ""}
+            onChange={(v) => setOverride("labelColor", v)}
+          />
+        </div>
+
+        {/* Advanced */}
+        <details className="group">
+          <summary className="cursor-pointer text-xs text-muted-foreground">
+            Advanced
+          </summary>
+          <div className="mt-2 space-y-2">
+            <div className="grid grid-cols-2 gap-2">
+              <ColorField
+                label="Value text"
+                value={badge.overrides.valueColor ?? ""}
+                onChange={(v) => setOverride("valueColor", v)}
+              />
+              <ColorField
+                label="Label text"
+                value={badge.overrides.labelTextColor ?? ""}
+                onChange={(v) => setOverride("labelTextColor", v)}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label className="text-[11px] uppercase tracking-wider text-muted-foreground">
+                Custom label
+              </Label>
+              <Input
+                placeholder="(default)"
+                value={badge.overrides.label ?? ""}
+                onChange={(e) => setOverride("label", e.target.value)}
+                className="h-7 text-xs"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <div className="space-y-1">
+                <Label className="text-[11px] uppercase tracking-wider text-muted-foreground">
+                  Logo
+                </Label>
+                <Input
+                  placeholder="slug or lucide:name"
+                  value={
+                    typeof badge.overrides.logo === "string"
+                      ? badge.overrides.logo
+                      : badge.overrides.logo === false
+                        ? "false"
+                        : ""
+                  }
+                  onChange={(e) => {
+                    const raw = e.target.value.trim()
+                    if (raw === "false") setOverride("logo", false)
+                    else setOverride("logo", raw)
+                  }}
+                  className="h-7 text-xs"
+                />
+              </div>
+              <ColorField
+                label="Logo color"
+                value={badge.overrides.logoColor ?? ""}
+                onChange={(v) => setOverride("logoColor", v)}
+              />
+            </div>
+          </div>
+        </details>
+
+        <Separator />
+
+        {/* Embed */}
+        <div className="space-y-1.5">
+          <Label className="text-[11px] uppercase tracking-wider text-muted-foreground">
+            Embed
+          </Label>
+          <EmbedField label="Markdown" value={md} onCopy={onCopy} />
+          <EmbedField label="HTML" value={html} onCopy={onCopy} />
+          <EmbedField label="URL" value={url} onCopy={onCopy} />
+        </div>
+
+        <Separator />
+
+        {/* Remove */}
+        <Button
+          variant="destructive"
+          size="sm"
+          className="w-full"
+          onClick={() => {
+            onRemove()
+            setOpen(false)
+          }}
+        >
+          <Trash2 className="size-3.5" />
+          Remove this badge
+        </Button>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+/* ── Override select (with global fallback) ───────── */
+
+function OverrideSelect({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string
+  value: string
+  options: readonly string[]
+  onChange: (v: string) => void
+}) {
+  return (
+    <div className="space-y-1">
+      <Label className="text-[11px] uppercase tracking-wider text-muted-foreground">
+        {label}
+      </Label>
+      <Select
+        value={value || "__global__"}
+        onValueChange={(v) => onChange(v === "__global__" ? "" : v)}
+      >
+        <SelectTrigger className="h-7 w-full text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="__global__">(global)</SelectItem>
+          {options.map((opt) => (
+            <SelectItem key={opt} value={opt}>
+              {opt}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
+/* ── Embed field ──────────────────────────────────── */
+
+function EmbedField({
+  label,
+  value,
+  onCopy,
+}: {
+  label: string
+  value: string
+  onCopy: (text: string) => void
+}) {
+  return (
+    <div className="flex gap-1.5">
+      <Textarea
+        readOnly
+        value={value}
+        rows={1}
+        aria-label={label}
+        className="h-7 min-h-0 flex-1 resize-none py-1 font-mono text-[11px]"
+      />
+      <Button variant="outline" size="icon-xs" onClick={() => onCopy(value)} title={`Copy ${label}`}>
+        <Copy className="size-3" />
+      </Button>
+    </div>
+  )
+}
+
+/* ── Color field ──────────────────────────────────── */
+
+function ColorField({
+  label,
+  value,
+  onChange,
+}: {
+  label: string
+  value: string
+  onChange: (v: string) => void
+}) {
+  return (
+    <div className="space-y-1">
+      <Label className="text-[11px] uppercase tracking-wider text-muted-foreground">
+        {label}
+      </Label>
+      <ColorInput value={value} onChange={onChange} placeholder="(none)" />
+    </div>
+  )
+}

--- a/app/gen/page.tsx
+++ b/app/gen/page.tsx
@@ -1,0 +1,59 @@
+import type { Metadata } from "next"
+import { SiteShell } from "@/components/site-shell"
+import GeneratorClient from "./generator-client"
+
+export const metadata: Metadata = {
+  title: "Generator",
+  description:
+    "Auto-generate shieldcn badges for any GitHub repo. Detects your stack, lets you customize, and exports markdown.",
+}
+
+export default function GeneratorPage() {
+  return (
+    <SiteShell>
+      <main className="min-w-0 flex-1">
+        <div className="mx-auto max-w-4xl px-6 py-12 md:px-10">
+          <header className="mb-10 flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+            <div>
+              <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+                Generator
+              </h1>
+              <p className="text-sm text-muted-foreground">
+                Auto-generate{" "}
+                <a
+                  href="https://shieldcn.dev"
+                  className="underline underline-offset-2 hover:text-foreground"
+                >
+                  shieldcn
+                </a>{" "}
+                badges from a GitHub URL.
+              </p>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              By{" "}
+              <a
+                href="https://github.com/k33bs"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline underline-offset-2 hover:text-foreground"
+              >
+                @k33bs
+              </a>
+              {" · "}
+              <a
+                href="https://github.com/k33bs/shieldcngen"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline underline-offset-2 hover:text-foreground"
+              >
+                Source
+              </a>
+            </p>
+          </header>
+
+          <GeneratorClient />
+        </div>
+      </main>
+    </SiteShell>
+  )
+}

--- a/components/badge-builder.tsx
+++ b/components/badge-builder.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useEffect, useMemo } from "react"
 import { Copy, Check } from "lucide-react"
 import { LogoPicker } from "@/components/logo-picker"
+import { ColorInput } from "@/components/color-input"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -263,7 +264,7 @@ export function BadgeBuilder() {
         </Field>
 
         <Field label="Logo color" hint="hex">
-          <Input value={s.logoColor} onChange={e => set("logoColor", e.target.value)} placeholder="auto" />
+          <ColorInput value={s.logoColor} onChange={v => set("logoColor", v)} placeholder="auto" />
         </Field>
 
         <Field label="Flags">
@@ -287,10 +288,10 @@ export function BadgeBuilder() {
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 rounded-md border border-border/60 bg-muted/20 p-4">
           <p className="col-span-full text-xs font-medium uppercase tracking-wider text-muted-foreground">Split colors</p>
           <Field label="Left background" hint="hex without #">
-            <Input value={s.leftBg} onChange={e => set("leftBg", e.target.value)} placeholder="auto (secondary)" />
+            <ColorInput value={s.leftBg} onChange={v => set("leftBg", v)} placeholder="auto (secondary)" />
           </Field>
           <Field label="Right background" hint="hex without #">
-            <Input value={s.rightBg} onChange={e => set("rightBg", e.target.value)} placeholder="auto (status/theme)" />
+            <ColorInput value={s.rightBg} onChange={v => set("rightBg", v)} placeholder="auto (status/theme)" />
           </Field>
           <Field label="Label override">
             <Input value={s.label} onChange={e => set("label", e.target.value)} placeholder="left side text" />
@@ -310,13 +311,13 @@ export function BadgeBuilder() {
       {showCustomize && (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 rounded-md border border-border/60 bg-muted/20 p-4">
           <Field label="Badge bg color" hint="hex without #">
-            <Input value={s.color} onChange={e => set("color", e.target.value)} placeholder="auto" />
+            <ColorInput value={s.color} onChange={v => set("color", v)} placeholder="auto" />
           </Field>
           <Field label="Value text color" hint="hex without #">
-            <Input value={s.valueColor} onChange={e => set("valueColor", e.target.value)} placeholder="auto" />
+            <ColorInput value={s.valueColor} onChange={v => set("valueColor", v)} placeholder="auto" />
           </Field>
           <Field label="Label text color" hint="hex without #">
-            <Input value={s.labelTextColor} onChange={e => set("labelTextColor", e.target.value)} placeholder="auto" />
+            <ColorInput value={s.labelTextColor} onChange={v => set("labelTextColor", v)} placeholder="auto" />
           </Field>
           <Field label="Label opacity" hint="0–1">
             <Input value={s.labelOpacity} onChange={e => set("labelOpacity", e.target.value)} placeholder="0.7" />

--- a/components/badge-sandbox.tsx
+++ b/components/badge-sandbox.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useMemo, useEffect } from "react"
 import { Copy, Check, Play } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { ColorInput } from "@/components/color-input"
 import { Label } from "@/components/ui/label"
 import { Badge } from "@/components/ui/badge"
 import {
@@ -268,7 +269,7 @@ export function BadgeSandbox({
           </SField>
 
           <SField label="logoColor">
-            <Input value={logoColor} onChange={e => setLogoColor(e.target.value)} placeholder="auto" />
+            <ColorInput value={logoColor} onChange={setLogoColor} placeholder="auto" />
           </SField>
 
           <SField label="label">
@@ -302,9 +303,9 @@ export function BadgeSandbox({
 
         {showAdvanced && (
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-            <SField label="color"><Input value={color} onChange={e => setColor(e.target.value)} placeholder="hex" /></SField>
-            <SField label="valueColor"><Input value={valueColor} onChange={e => setValueColor(e.target.value)} placeholder="hex" /></SField>
-            <SField label="labelTextColor"><Input value={labelTextColor} onChange={e => setLabelTextColor(e.target.value)} placeholder="hex" /></SField>
+            <SField label="color"><ColorInput value={color} onChange={setColor} placeholder="hex" /></SField>
+            <SField label="valueColor"><ColorInput value={valueColor} onChange={setValueColor} placeholder="hex" /></SField>
+            <SField label="labelTextColor"><ColorInput value={labelTextColor} onChange={setLabelTextColor} placeholder="hex" /></SField>
             <SField label="labelOpacity"><Input value={labelOpacity} onChange={e => setLabelOpacity(e.target.value)} placeholder="0–1" /></SField>
           </div>
         )}

--- a/components/color-input.tsx
+++ b/components/color-input.tsx
@@ -1,0 +1,384 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { Pipette } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import { cn } from "@/lib/utils"
+
+// ---------------------------------------------------------------------------
+// Color conversion helpers
+// ---------------------------------------------------------------------------
+
+function hexToHsl(hex: string): [number, number, number] {
+  const r = parseInt(hex.slice(0, 2), 16) / 255
+  const g = parseInt(hex.slice(2, 4), 16) / 255
+  const b = parseInt(hex.slice(4, 6), 16) / 255
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+  const l = (max + min) / 2
+  if (max === min) return [0, 0, l]
+  const d = max - min
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min)
+  let h = 0
+  if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6
+  else if (max === g) h = ((b - r) / d + 2) / 6
+  else h = ((r - g) / d + 4) / 6
+  return [h * 360, s * 100, l * 100]
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+  const s1 = s / 100
+  const l1 = l / 100
+  const a = s1 * Math.min(l1, 1 - l1)
+  const f = (n: number) => {
+    const k = (n + h / 30) % 12
+    const color = l1 - a * Math.max(Math.min(k - 3, 9 - k, 1), -1)
+    return Math.round(255 * Math.max(0, Math.min(1, color)))
+      .toString(16)
+      .padStart(2, "0")
+  }
+  return `${f(0)}${f(8)}${f(4)}`
+}
+
+function isValidHex(v: string): boolean {
+  return /^[0-9a-fA-F]{6}$/.test(v)
+}
+
+// ---------------------------------------------------------------------------
+// ColorInput — swatch + hex input + popover picker
+// ---------------------------------------------------------------------------
+
+export function ColorInput({
+  value,
+  onChange,
+  placeholder = "auto",
+}: {
+  value: string
+  onChange: (v: string) => void
+  placeholder?: string
+}) {
+  const [open, setOpen] = useState(false)
+
+  const displayColor = value && isValidHex(value) ? `#${value}` : undefined
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              "size-9 shrink-0 cursor-pointer rounded-md border border-input transition-colors hover:border-ring",
+              !displayColor && "bg-transparent",
+            )}
+            style={displayColor ? { backgroundColor: displayColor } : undefined}
+            aria-label="Pick color"
+          >
+            {!displayColor && (
+              <span className="flex size-full items-center justify-center text-[10px] text-muted-foreground">
+                —
+              </span>
+            )}
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className="w-64 p-3" align="start">
+          <ColorPicker
+            value={value}
+            onChange={(v) => {
+              onChange(v)
+            }}
+          />
+        </PopoverContent>
+      </Popover>
+      <Input
+        value={value}
+        onChange={(e) => onChange(e.target.value.replace(/^#/, ""))}
+        placeholder={placeholder}
+        className="flex-1 font-mono"
+      />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// ColorPicker — HSL canvas + hue slider + eyedropper + presets
+// ---------------------------------------------------------------------------
+
+const PRESETS = [
+  "ef4444", "f97316", "eab308", "22c55e", "06b6d4",
+  "3b82f6", "8b5cf6", "ec4899", "ffffff", "000000",
+]
+
+function ColorPicker({
+  value,
+  onChange,
+}: {
+  value: string
+  onChange: (v: string) => void
+}) {
+  const hex = value && isValidHex(value) ? value : "3b82f6"
+  const [h, s, l] = hexToHsl(hex)
+
+  const [hue, setHue] = useState(h)
+  const [sat, setSat] = useState(s)
+  const [lit, setLit] = useState(l)
+
+  // Sync internal state when external value changes
+  const prevValue = useRef(value)
+  useEffect(() => {
+    if (value !== prevValue.current) {
+      prevValue.current = value
+      if (value && isValidHex(value)) {
+        const [nh, ns, nl] = hexToHsl(value)
+        setHue(nh)
+        setSat(ns)
+        setLit(nl)
+      }
+    }
+  }, [value])
+
+  const emit = useCallback(
+    (h2: number, s2: number, l2: number) => {
+      const newHex = hslToHex(h2, s2, l2)
+      prevValue.current = newHex
+      onChange(newHex)
+    },
+    [onChange],
+  )
+
+  // --- Canvas (saturation/lightness) ---
+  const canvasRef = useRef<HTMLDivElement>(null)
+  const draggingCanvas = useRef(false)
+
+  const handleCanvasMove = useCallback(
+    (clientX: number, clientY: number) => {
+      const el = canvasRef.current
+      if (!el) return
+      const rect = el.getBoundingClientRect()
+      const x = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width))
+      const y = Math.max(0, Math.min(1, (clientY - rect.top) / rect.height))
+      const newSat = x * 100
+      const newLit = (1 - y) * 50 + (1 - x) * (1 - y) * 50
+      // Simplified: top-left is white, top-right is hue, bottom is black
+      // Use HSB-to-HSL: s = x*100, b = (1-y)*100, then convert
+      const b = (1 - y) * 100
+      const hslL = (b * (200 - x * 100)) / 200
+      const hslS = hslL === 0 || hslL === 100 ? 0 : (b - hslL) / Math.min(hslL, 100 - hslL) * 100
+      setSat(Math.max(0, Math.min(100, hslS)))
+      setLit(Math.max(0, Math.min(100, hslL)))
+      emit(hue, Math.max(0, Math.min(100, hslS)), Math.max(0, Math.min(100, hslL)))
+    },
+    [hue, emit],
+  )
+
+  useEffect(() => {
+    const onMove = (e: PointerEvent) => {
+      if (!draggingCanvas.current) return
+      e.preventDefault()
+      handleCanvasMove(e.clientX, e.clientY)
+    }
+    const onUp = () => {
+      draggingCanvas.current = false
+    }
+    window.addEventListener("pointermove", onMove)
+    window.addEventListener("pointerup", onUp)
+    return () => {
+      window.removeEventListener("pointermove", onMove)
+      window.removeEventListener("pointerup", onUp)
+    }
+  }, [handleCanvasMove])
+
+  // Convert current HSL back to HSB for canvas thumb position
+  const hsbS = (() => {
+    const l1 = lit / 100
+    const s1 = sat / 100
+    const v = l1 + s1 * Math.min(l1, 1 - l1)
+    return v === 0 ? 0 : 2 * (1 - l1 / v)
+  })()
+  const hsbB = (() => {
+    const l1 = lit / 100
+    const s1 = sat / 100
+    return l1 + s1 * Math.min(l1, 1 - l1)
+  })()
+  const thumbX = hsbS * 100
+  const thumbY = (1 - hsbB) * 100
+
+  // --- Hue slider ---
+  const hueRef = useRef<HTMLDivElement>(null)
+  const draggingHue = useRef(false)
+
+  const handleHueMove = useCallback(
+    (clientX: number) => {
+      const el = hueRef.current
+      if (!el) return
+      const rect = el.getBoundingClientRect()
+      const x = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width))
+      const newHue = x * 360
+      setHue(newHue)
+      emit(newHue, sat, lit)
+    },
+    [sat, lit, emit],
+  )
+
+  useEffect(() => {
+    const onMove = (e: PointerEvent) => {
+      if (!draggingHue.current) return
+      e.preventDefault()
+      handleHueMove(e.clientX)
+    }
+    const onUp = () => {
+      draggingHue.current = false
+    }
+    window.addEventListener("pointermove", onMove)
+    window.addEventListener("pointerup", onUp)
+    return () => {
+      window.removeEventListener("pointermove", onMove)
+      window.removeEventListener("pointerup", onUp)
+    }
+  }, [handleHueMove])
+
+  // --- Eyedropper ---
+  const [hasEyedropper] = useState(() =>
+    typeof window !== "undefined" && "EyeDropper" in window,
+  )
+
+  const handleEyedropper = useCallback(async () => {
+    try {
+      // @ts-expect-error EyeDropper API not in all TS libs
+      const dropper = new window.EyeDropper()
+      const result = await dropper.open()
+      const picked = result.sRGBHex.replace(/^#/, "")
+      if (isValidHex(picked)) {
+        const [nh, ns, nl] = hexToHsl(picked)
+        setHue(nh)
+        setSat(ns)
+        setLit(nl)
+        prevValue.current = picked
+        onChange(picked)
+      }
+    } catch {
+      /* user cancelled */
+    }
+  }, [onChange])
+
+  // --- Hex input ---
+  const [hexInput, setHexInput] = useState(hex)
+  useEffect(() => {
+    setHexInput(value && isValidHex(value) ? value : hex)
+  }, [value, hex])
+
+  return (
+    <div className="space-y-3">
+      {/* SL Canvas */}
+      <div
+        ref={canvasRef}
+        className="relative h-36 w-full cursor-crosshair overflow-hidden rounded-md border border-input"
+        style={{
+          background: `
+            linear-gradient(to bottom, transparent, #000),
+            linear-gradient(to right, #fff, hsl(${hue}, 100%, 50%))
+          `,
+        }}
+        onPointerDown={(e) => {
+          draggingCanvas.current = true
+          handleCanvasMove(e.clientX, e.clientY)
+        }}
+      >
+        <div
+          className="pointer-events-none absolute size-3.5 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white shadow-[0_0_0_1px_rgba(0,0,0,0.3)]"
+          style={{
+            left: `${thumbX}%`,
+            top: `${thumbY}%`,
+          }}
+        />
+      </div>
+
+      {/* Hue slider */}
+      <div
+        ref={hueRef}
+        className="relative h-3 w-full cursor-pointer rounded-full border border-input"
+        style={{
+          background:
+            "linear-gradient(to right, #f00, #ff0, #0f0, #0ff, #00f, #f0f, #f00)",
+        }}
+        onPointerDown={(e) => {
+          draggingHue.current = true
+          handleHueMove(e.clientX)
+        }}
+      >
+        <div
+          className="pointer-events-none absolute top-1/2 size-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white shadow-[0_0_0_1px_rgba(0,0,0,0.3)]"
+          style={{
+            left: `${(hue / 360) * 100}%`,
+            backgroundColor: `hsl(${hue}, 100%, 50%)`,
+          }}
+        />
+      </div>
+
+      {/* Hex input + eyedropper */}
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs text-muted-foreground">#</span>
+        <Input
+          value={hexInput}
+          onChange={(e) => {
+            const raw = e.target.value.replace(/^#/, "").slice(0, 6)
+            setHexInput(raw)
+            if (isValidHex(raw)) {
+              const [nh, ns, nl] = hexToHsl(raw)
+              setHue(nh)
+              setSat(ns)
+              setLit(nl)
+              prevValue.current = raw
+              onChange(raw)
+            }
+          }}
+          className="h-7 flex-1 font-mono text-xs"
+          maxLength={6}
+        />
+        {hasEyedropper && (
+          <Button
+            type="button"
+            variant="outline"
+            size="icon-xs"
+            onClick={() => void handleEyedropper()}
+            title="Pick color from screen"
+          >
+            <Pipette className="size-3" />
+          </Button>
+        )}
+      </div>
+
+      {/* Presets */}
+      <div className="flex flex-wrap gap-1">
+        {PRESETS.map((preset) => (
+          <button
+            key={preset}
+            type="button"
+            className={cn(
+              "size-5 rounded-sm border transition-transform hover:scale-110",
+              value === preset
+                ? "border-ring ring-1 ring-ring"
+                : "border-input",
+            )}
+            style={{ backgroundColor: `#${preset}` }}
+            onClick={() => {
+              const [nh, ns, nl] = hexToHsl(preset)
+              setHue(nh)
+              setSat(ns)
+              setLit(nl)
+              prevValue.current = preset
+              onChange(preset)
+            }}
+            title={`#${preset}`}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -60,6 +60,12 @@ export function SiteFooter() {
               >
                 Token Pool
               </Link>
+              <Link
+                href="/gen"
+                className="text-muted-foreground hover:text-foreground"
+              >
+                Generator
+              </Link>
             </div>
 
             <div className="flex flex-col gap-2">
@@ -101,7 +107,7 @@ export function SiteFooter() {
             <a href="https://shields.io" target="_blank" rel="noopener noreferrer" className="underline underline-offset-2 hover:text-foreground">shields.io</a>
             {" "}&{" "}
             <a href="https://badgen.net" target="_blank" rel="noopener noreferrer" className="underline underline-offset-2 hover:text-foreground">badgen.net</a>
-            .
+.
           </p>
 
           <div className="flex items-center gap-3">

--- a/components/gradient-text.tsx
+++ b/components/gradient-text.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+
+/**
+ * Text that reveals a flowing animated gradient on hover.
+ */
+export function GradientText({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      className={cn("gradient-flow-hover inline-block", className)}
+      {...props}
+    >
+      {children}
+      <style>{`
+        @keyframes gradient-flow {
+          0% { background-position: 0% 50%; }
+          100% { background-position: 200% 50%; }
+        }
+        .gradient-flow-hover {
+          background-image: linear-gradient(
+            90deg,
+            #f97316, #ec4899, #8b5cf6, #3b82f6,
+            #06b6d4, #22c55e, #f97316, #ec4899,
+            #8b5cf6, #3b82f6, #06b6d4, #22c55e, #f97316
+          );
+          background-size: 200% 100%;
+          -webkit-background-clip: text;
+          background-clip: text;
+          animation: gradient-flow 3s linear infinite;
+          transition: -webkit-text-fill-color 0.2s;
+        }
+        .gradient-flow-hover:hover,
+        *:hover > .gradient-flow-hover {
+          -webkit-text-fill-color: transparent;
+        }
+      `}</style>
+    </span>
+  )
+}

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link"
-import { Heart } from "lucide-react"
+import { Heart, Wand2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { ThemeSwitcher } from "@/components/theme-switcher"
 import { MobileNav } from "@/components/mobile-nav"
@@ -25,6 +25,12 @@ export function SiteHeader() {
         </Button>
         <Button variant="ghost" size="sm" asChild>
           <Link href="/showcase">Showcase</Link>
+        </Button>
+        <Button variant="ghost" size="sm" asChild>
+          <Link href="/gen">
+            <Wand2 className="size-3.5" />
+            Generator
+          </Link>
         </Button>
 
       </nav>

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link"
-import { Heart, Wand2 } from "lucide-react"
+import { Heart } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { GradientText } from "@/components/gradient-text"
 import { ThemeSwitcher } from "@/components/theme-switcher"
 import { MobileNav } from "@/components/mobile-nav"
 import { ShieldcnLogo } from "@/components/shieldcn-logo"
@@ -26,10 +27,9 @@ export function SiteHeader() {
         <Button variant="ghost" size="sm" asChild>
           <Link href="/showcase">Showcase</Link>
         </Button>
-        <Button variant="ghost" size="sm" asChild>
+        <Button variant="ghost" size="sm" asChild className="focus-visible:ring-border">
           <Link href="/gen">
-            <Wand2 className="size-3.5" />
-            Generator
+            <GradientText>Generator</GradientText>
           </Link>
         </Button>
 

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/lib/gen/brands.ts
+++ b/lib/gen/brands.ts
@@ -1,0 +1,155 @@
+export type Brand = {
+  slug: string;
+  color: string;
+  label: string;
+};
+
+// Map of npm package name → brand. Matches both exact names and scoped prefixes
+// (see matchBrand). Colors are official brand colors, hex without '#'.
+export const BRANDS: Record<string, Brand> = {
+  // React ecosystem
+  react: { slug: 'react', color: '61DAFB', label: 'React' },
+  'react-dom': { slug: 'react', color: '61DAFB', label: 'React' },
+  next: { slug: 'nextdotjs', color: '000000', label: 'Next.js' },
+  '@next/env': { slug: 'nextdotjs', color: '000000', label: 'Next.js' },
+  '@t3-oss/env-nextjs': { slug: 'nextdotjs', color: '000000', label: 'Next.js' },
+  astro: { slug: 'astro', color: 'BC52EE', label: 'Astro' },
+  '@astrojs/cloudflare': { slug: 'astro', color: 'BC52EE', label: 'Astro' },
+  svelte: { slug: 'svelte', color: 'FF3E00', label: 'Svelte' },
+  '@sveltejs/kit': { slug: 'svelte', color: 'FF3E00', label: 'SvelteKit' },
+  vue: { slug: 'vuedotjs', color: '4FC08D', label: 'Vue' },
+  nuxt: { slug: 'nuxt', color: '00DC82', label: 'Nuxt' },
+  'solid-js': { slug: 'solid', color: '2C4F7C', label: 'Solid' },
+  '@builder.io/qwik': { slug: 'qwik', color: '18B6F6', label: 'Qwik' },
+
+  // CSS / UI
+  tailwindcss: { slug: 'tailwindcss', color: '06B6D4', label: 'Tailwind CSS' },
+  unocss: { slug: 'unocss', color: '333333', label: 'UnoCSS' },
+  '@radix-ui/react': { slug: 'radixui', color: '000000', label: 'Radix UI' },
+  '@shadcn/ui': { slug: 'shadcnui', color: '000000', label: 'shadcn/ui' },
+
+  // TypeScript & tools
+  typescript: { slug: 'typescript', color: '3178C6', label: 'TypeScript' },
+  '@biomejs/biome': { slug: 'biome', color: '60A5FA', label: 'Biome' },
+  eslint: { slug: 'eslint', color: '4B32C3', label: 'ESLint' },
+  prettier: { slug: 'prettier', color: 'F7B93E', label: 'Prettier' },
+
+  // Build tools
+  vite: { slug: 'vite', color: '646CFF', label: 'Vite' },
+  webpack: { slug: 'webpack', color: '8DD6F9', label: 'Webpack' },
+  rollup: { slug: 'rollupdotjs', color: 'EC4A3F', label: 'Rollup' },
+  esbuild: { slug: 'esbuild', color: 'FFCF00', label: 'esbuild' },
+  turbo: { slug: 'turborepo', color: 'EF4444', label: 'Turborepo' },
+  nx: { slug: 'nx', color: '143055', label: 'Nx' },
+  '@changesets/cli': { slug: 'changesets', color: '5846F5', label: 'Changesets' },
+
+  // Testing
+  vitest: { slug: 'vitest', color: '6E9F18', label: 'Vitest' },
+  playwright: { slug: 'playwright', color: '2EAD33', label: 'Playwright' },
+  '@playwright/test': { slug: 'playwright', color: '2EAD33', label: 'Playwright' },
+  jest: { slug: 'jest', color: 'C21325', label: 'Jest' },
+  cypress: { slug: 'cypress', color: '69D3A7', label: 'Cypress' },
+
+  // Databases & ORMs
+  prisma: { slug: 'prisma', color: '2D3748', label: 'Prisma' },
+  'drizzle-orm': { slug: 'drizzle', color: 'C5F74F', label: 'Drizzle' },
+  'drizzle-kit': { slug: 'drizzle', color: 'C5F74F', label: 'Drizzle' },
+  kysely: { slug: 'kysely', color: '1E88E5', label: 'Kysely' },
+  typeorm: { slug: 'typeorm', color: 'FE0902', label: 'TypeORM' },
+  mongoose: { slug: 'mongodb', color: '47A248', label: 'Mongoose' },
+  postgres: { slug: 'postgresql', color: '4169E1', label: 'PostgreSQL' },
+  pg: { slug: 'postgresql', color: '4169E1', label: 'PostgreSQL' },
+  mongodb: { slug: 'mongodb', color: '47A248', label: 'MongoDB' },
+  mysql2: { slug: 'mysql', color: '4479A1', label: 'MySQL' },
+  redis: { slug: 'redis', color: 'FF4438', label: 'Redis' },
+  ioredis: { slug: 'redis', color: 'FF4438', label: 'Redis' },
+
+  // Validation
+  zod: { slug: 'zod', color: '3E67B1', label: 'Zod' },
+  valibot: { slug: 'valibot', color: '0284C7', label: 'Valibot' },
+  arktype: { slug: 'typescript', color: '3178C6', label: 'ArkType' },
+
+  // API / RPC
+  '@trpc/server': { slug: 'trpc', color: '398CCB', label: 'tRPC' },
+  '@trpc/client': { slug: 'trpc', color: '398CCB', label: 'tRPC' },
+  graphql: { slug: 'graphql', color: 'E10098', label: 'GraphQL' },
+
+  // State / data
+  '@tanstack/react-query': { slug: 'reactquery', color: 'FF4154', label: 'TanStack Query' },
+  '@tanstack/query-core': { slug: 'reactquery', color: 'FF4154', label: 'TanStack Query' },
+  zustand: { slug: 'zustand', color: 'FFB800', label: 'Zustand' },
+  jotai: { slug: 'jotai', color: '000000', label: 'Jotai' },
+
+  // Realtime
+  'socket.io': { slug: 'socketdotio', color: '010101', label: 'Socket.IO' },
+  'socket.io-client': { slug: 'socketdotio', color: '010101', label: 'Socket.IO' },
+
+  // Backend infra
+  supabase: { slug: 'supabase', color: '3FCF8E', label: 'Supabase' },
+  '@supabase/supabase-js': { slug: 'supabase', color: '3FCF8E', label: 'Supabase' },
+  firebase: { slug: 'firebase', color: 'DD2C00', label: 'Firebase' },
+  '@firebase/app': { slug: 'firebase', color: 'DD2C00', label: 'Firebase' },
+  convex: { slug: 'convex', color: 'EE342F', label: 'Convex' },
+  'better-auth': { slug: 'lucide:lock-keyhole', color: '000000', label: 'Better Auth' },
+
+  // Payment
+  stripe: { slug: 'stripe', color: '635BFF', label: 'Stripe' },
+  '@stripe/stripe-js': { slug: 'stripe', color: '635BFF', label: 'Stripe' },
+
+  // Comms
+  twilio: { slug: 'twilio', color: 'F22F46', label: 'Twilio' },
+
+  // AI
+  openai: { slug: 'openai', color: '412991', label: 'OpenAI' },
+  '@anthropic-ai/sdk': { slug: 'anthropic', color: 'D97757', label: 'Anthropic' },
+  langchain: { slug: 'langchain', color: '1C3C3C', label: 'LangChain' },
+  '@langchain/core': { slug: 'langchain', color: '1C3C3C', label: 'LangChain' },
+  '@ai-sdk/openai': { slug: 'openai', color: '412991', label: 'AI SDK · OpenAI' },
+  '@ai-sdk/anthropic': { slug: 'anthropic', color: 'D97757', label: 'AI SDK · Anthropic' },
+  ai: { slug: 'vercel', color: '000000', label: 'AI SDK' },
+
+  // Hosting runtime libs
+  '@cloudflare/workers-types': { slug: 'cloudflare', color: 'F38020', label: 'Cloudflare Workers' },
+  wrangler: { slug: 'cloudflare', color: 'F38020', label: 'Cloudflare Workers' },
+
+  // Docs / content
+  '@docusaurus/core': { slug: 'docusaurus', color: '3ECC5F', label: 'Docusaurus' },
+  vitepress: { slug: 'vitepress', color: '5E72E4', label: 'VitePress' },
+  storybook: { slug: 'storybook', color: 'FF4785', label: 'Storybook' },
+
+  // Pre-commit / quality
+  husky: { slug: 'husky', color: '3B82F6', label: 'Husky' },
+  'lint-staged': { slug: 'git', color: 'F05032', label: 'lint-staged' },
+
+  // Misc
+  '@octokit/rest': { slug: 'github', color: '181717', label: 'Octokit' },
+  '@linear/sdk': { slug: 'linear', color: '5E6AD2', label: 'Linear' },
+};
+
+export function matchBrand(pkg: string): Brand | undefined {
+  if (BRANDS[pkg]) return BRANDS[pkg];
+  // scoped prefix match: "@ai-sdk/openai" → try "@ai-sdk/openai" exact above,
+  // then try other scoped-variant keys
+  if (pkg.startsWith('@ai-sdk/')) {
+    return BRANDS['@ai-sdk/openai'];
+  }
+  if (pkg.startsWith('@supabase/')) {
+    return BRANDS['@supabase/supabase-js'];
+  }
+  if (pkg.startsWith('@firebase/')) {
+    return BRANDS['@firebase/app'];
+  }
+  if (pkg.startsWith('@radix-ui/')) {
+    return BRANDS['@radix-ui/react'];
+  }
+  if (pkg.startsWith('@trpc/')) {
+    return BRANDS['@trpc/server'];
+  }
+  if (pkg.startsWith('@langchain/')) {
+    return BRANDS['@langchain/core'];
+  }
+  if (pkg.startsWith('@tanstack/')) {
+    return BRANDS['@tanstack/react-query'];
+  }
+  return undefined;
+}

--- a/lib/gen/config.ts
+++ b/lib/gen/config.ts
@@ -1,0 +1,168 @@
+import type { Badge, BadgeGroup, GlobalSettings } from './shieldcn';
+import { DEFAULT_GLOBAL } from './shieldcn';
+
+export type Config = {
+  version: 1;
+  source: { type: 'github'; url: string; owner: string; repo: string };
+  global: GlobalSettings;
+  badges: Badge[];
+  generatedAt: string;
+};
+
+const VALID_GROUPS: BadgeGroup[] = [
+  'github',
+  'package',
+  'tooling',
+  'stack',
+  'modern',
+  'community',
+];
+
+export function serialize(config: Config): string {
+  return JSON.stringify(config, null, 2);
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+function safeLinkUrl(url: unknown): string | undefined {
+  if (typeof url !== 'string') return undefined;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'https:' || parsed.protocol === 'http:' ? url : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function validateBadge(raw: unknown): Badge | null {
+  if (!isPlainObject(raw)) return null;
+  if (typeof raw.id !== 'string' || !raw.id) return null;
+  if (typeof raw.label !== 'string') return null;
+  if (typeof raw.path !== 'string' || !raw.path.startsWith('/')) return null;
+  if (!VALID_GROUPS.includes(raw.group as BadgeGroup)) return null;
+  const query = isPlainObject(raw.query) ? raw.query : {};
+  const overrides = isPlainObject(raw.overrides) ? raw.overrides : {};
+  // Strip any non-string query values defensively.
+  const safeQuery: Record<string, string> = {};
+  for (const [k, v] of Object.entries(query)) {
+    if (typeof v === 'string') safeQuery[k] = v;
+  }
+  return {
+    id: raw.id,
+    group: raw.group as BadgeGroup,
+    label: raw.label,
+    path: raw.path,
+    query: safeQuery,
+    overrides: overrides as Badge['overrides'],
+    enabled: raw.enabled !== false,
+    linkUrl: safeLinkUrl(raw.linkUrl),
+  };
+}
+
+export function deserialize(raw: string):
+  | { ok: true; config: Config }
+  | { ok: false; error: string } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    return { ok: false, error: `Not valid JSON: ${(e as Error).message}` };
+  }
+  if (!isPlainObject(parsed)) {
+    return { ok: false, error: 'JSON must be an object' };
+  }
+  if (parsed.version !== 1) {
+    return { ok: false, error: `Unsupported config version: ${parsed.version ?? 'missing'}` };
+  }
+  const source = parsed.source as Partial<Config['source']> | undefined;
+  if (!isPlainObject(source) || typeof source.owner !== 'string' || typeof source.repo !== 'string') {
+    return { ok: false, error: 'Missing source.owner / source.repo' };
+  }
+  if (!Array.isArray(parsed.badges)) {
+    return { ok: false, error: 'badges must be an array' };
+  }
+
+  const badges: Badge[] = [];
+  let droppedCount = 0;
+  for (const raw of parsed.badges) {
+    const valid = validateBadge(raw);
+    if (valid) badges.push(valid);
+    else droppedCount++;
+  }
+
+  const safeUrl = typeof source.url === 'string'
+    ? safeLinkUrl(source.url) ?? `https://github.com/${source.owner}/${source.repo}`
+    : `https://github.com/${source.owner}/${source.repo}`;
+
+  const config: Config = {
+    version: 1,
+    source: { type: 'github', owner: source.owner, repo: source.repo, url: safeUrl },
+    global: { ...DEFAULT_GLOBAL, ...(isPlainObject(parsed.global) ? parsed.global : {}) },
+    badges,
+    generatedAt:
+      typeof parsed.generatedAt === 'string' ? parsed.generatedAt : new Date().toISOString(),
+  };
+
+  if (droppedCount > 0) {
+    // Surface as a soft warning but still load — best-effort.
+    console.warn(`[shieldcngen] Dropped ${droppedCount} malformed badge(s) from config`);
+  }
+
+  return { ok: true, config };
+}
+
+/**
+ * Merge freshly-detected badges into a saved config.
+ * - Existing IDs: keep the user's `enabled` and `overrides`; refresh `path` / `query` / `label` from fresh.
+ * - New IDs: add with enabled: true.
+ * - Saved enabled-true badges not in fresh results: kept as-is (user can delete manually).
+ * - Saved enabled-false badges not in fresh results: dropped (no longer detected and user didn't want them anyway).
+ */
+export function mergeRefresh(
+  saved: Config,
+  fresh: { badges: Badge[]; source: Config['source'] },
+): { config: Config; diff: { added: string[]; refreshed: string[]; missing: string[] } } {
+  const freshMap = new Map(fresh.badges.map((b) => [b.id, b]));
+  const savedMap = new Map(saved.badges.map((b) => [b.id, b]));
+
+  const added: string[] = [];
+  const refreshed: string[] = [];
+  const missing: string[] = [];
+
+  const resultBadges: Badge[] = [];
+
+  for (const freshBadge of fresh.badges) {
+    const prior = savedMap.get(freshBadge.id);
+    if (prior) {
+      resultBadges.push({
+        ...freshBadge,
+        enabled: prior.enabled,
+        overrides: prior.overrides,
+      });
+      refreshed.push(freshBadge.id);
+    } else {
+      resultBadges.push(freshBadge);
+      added.push(freshBadge.id);
+    }
+  }
+
+  for (const [id, savedBadge] of savedMap) {
+    if (freshMap.has(id)) continue;
+    if (savedBadge.enabled) {
+      resultBadges.push(savedBadge);
+      missing.push(id);
+    }
+  }
+
+  return {
+    config: {
+      ...saved,
+      source: fresh.source,
+      badges: resultBadges,
+      generatedAt: new Date().toISOString(),
+    },
+    diff: { added, refreshed, missing },
+  };
+}

--- a/lib/gen/detect.ts
+++ b/lib/gen/detect.ts
@@ -1,0 +1,648 @@
+import type { Badge } from './shieldcn';
+import { staticBadgePath } from './shieldcn';
+import { matchBrand } from './brands';
+
+export type InspectResult = {
+  source: { owner: string; repo: string; url: string };
+  badges: Badge[];
+  notes: string[];
+  existingShieldsIoUrls: string[];
+};
+
+type PackageJson = {
+  name?: string;
+  version?: string;
+  private?: boolean;
+  license?: string;
+  type?: string;
+  types?: string;
+  typings?: string;
+  bin?: unknown;
+  sideEffects?: unknown;
+  workspaces?: unknown;
+  exports?: unknown;
+  engines?: Record<string, string>;
+  packageManager?: string;
+  homepage?: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+};
+
+const RAW = 'https://raw.githubusercontent.com';
+const NPM = 'https://registry.npmjs.org';
+const BRAND_CAP = 9;
+
+// Probe list — runs client-side via parallel HEAD requests, so we can be
+// generous (no Cloudflare subrequest limit applies). Common config-file
+// variants are included to avoid false negatives.
+const PROBE_FILES = [
+  // Lockfiles
+  'pnpm-lock.yaml',
+  'yarn.lock',
+  'bun.lock',
+  'bun.lockb',
+  'package-lock.json',
+  // Container / runtime
+  'Dockerfile',
+  'docker-compose.yml',
+  'docker-compose.yaml',
+  '.nvmrc',
+  // TS / lint / format
+  'tsconfig.json',
+  'biome.json',
+  '.prettierrc',
+  '.prettierrc.json',
+  'prettier.config.js',
+  '.eslintrc.json',
+  '.eslintrc.js',
+  '.eslintrc.cjs',
+  'eslint.config.js',
+  'eslint.config.mjs',
+  // Bundler / framework
+  'vite.config.ts',
+  'vite.config.js',
+  'vite.config.mjs',
+  'next.config.ts',
+  'next.config.js',
+  'next.config.mjs',
+  'nuxt.config.ts',
+  'nuxt.config.js',
+  'astro.config.mjs',
+  'astro.config.ts',
+  'svelte.config.js',
+  'svelte.config.ts',
+  'tailwind.config.ts',
+  'tailwind.config.js',
+  'unocss.config.ts',
+  'unocss.config.js',
+  // Build / monorepo
+  'turbo.json',
+  'nx.json',
+  '.changeset/README.md',
+  '.storybook/main.ts',
+  '.storybook/main.js',
+  // Testing
+  'vitest.config.ts',
+  'vitest.config.js',
+  'playwright.config.ts',
+  'playwright.config.js',
+  'jest.config.js',
+  'jest.config.ts',
+  'cypress.config.ts',
+  'cypress.config.js',
+  // Deployment
+  'wrangler.toml',
+  'wrangler.jsonc',
+  'vercel.json',
+  'netlify.toml',
+  'fly.toml',
+  // AI / modern signals
+  'AGENTS.md',
+  'llms.txt',
+  '.claude/CLAUDE.md',
+  '.cursor/rules',
+  'mcp.json',
+  'mcp-server.json',
+] as const;
+
+type ProbeKey = (typeof PROBE_FILES)[number];
+type ProbeResult = Record<ProbeKey, boolean>;
+
+function isAbort(e: unknown): boolean {
+  return (
+    e instanceof Error &&
+    (e.name === 'AbortError' || (typeof DOMException !== 'undefined' && e instanceof DOMException && e.name === 'AbortError'))
+  );
+}
+
+async function fetchText(url: string, signal?: AbortSignal): Promise<string | null> {
+  try {
+    const res = await fetch(url, { signal });
+    if (!res.ok) return null;
+    return await res.text();
+  } catch (e) {
+    if (isAbort(e)) throw e;
+    return null;
+  }
+}
+
+async function fetchJson<T = unknown>(url: string, signal?: AbortSignal): Promise<T | null> {
+  try {
+    const res = await fetch(url, { signal });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch (e) {
+    if (isAbort(e)) throw e;
+    return null;
+  }
+}
+
+async function probeExists(url: string, signal?: AbortSignal): Promise<boolean> {
+  try {
+    const res = await fetch(url, { method: 'HEAD', signal });
+    return res.ok;
+  } catch (e) {
+    if (isAbort(e)) throw e;
+    return false;
+  }
+}
+
+function rawUrl(owner: string, repo: string, path: string): string {
+  return `${RAW}/${owner}/${repo}/HEAD/${path}`;
+}
+
+function parseGithubUrl(input: string):
+  | { owner: string; repo: string; url: string }
+  | { error: string } {
+  const trimmed = input.trim();
+  if (!trimmed) return { error: 'URL is required' };
+
+  const ownerRepoOnly = /^([\w.-]+)\/([\w.-]+)$/;
+  const m1 = trimmed.match(ownerRepoOnly);
+  if (m1) {
+    const owner = m1[1]!;
+    const repo = m1[2]!.replace(/\.git$/, '');
+    return { owner, repo, url: `https://github.com/${owner}/${repo}` };
+  }
+
+  try {
+    const u = new URL(trimmed.startsWith('http') ? trimmed : `https://${trimmed}`);
+    if (!/^github\.com$/i.test(u.hostname)) {
+      return { error: 'URL must be a github.com repository' };
+    }
+    const parts = u.pathname.replace(/^\/+|\/+$/g, '').split('/');
+    if (parts.length < 2) return { error: 'Could not parse owner/repo from URL' };
+    const owner = parts[0]!;
+    const repo = parts[1]!.replace(/\.git$/, '');
+    return { owner, repo, url: `https://github.com/${owner}/${repo}` };
+  } catch {
+    return { error: 'Invalid URL' };
+  }
+}
+
+function extractDiscordInvite(readme: string): string | null {
+  const re = /discord\.(?:gg|com\/invite)\/([a-zA-Z0-9-]+)/i;
+  const m = readme.match(re);
+  return m ? m[1]! : null;
+}
+
+function extractShieldsIoUrls(readme: string): string[] {
+  const re = /https?:\/\/img\.shields\.io\/[^\s)"'>]+/g;
+  return Array.from(new Set(readme.match(re) ?? []));
+}
+
+async function getPackageJson(
+  owner: string,
+  repo: string,
+  signal?: AbortSignal,
+): Promise<PackageJson | null> {
+  const raw = await fetchText(rawUrl(owner, repo, 'package.json'), signal);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as PackageJson;
+  } catch {
+    return null;
+  }
+}
+
+const README_CANDIDATES = ['README.md', 'readme.md', 'Readme.md', 'README.MD', 'README.markdown'] as const;
+
+async function getReadme(
+  owner: string,
+  repo: string,
+  signal?: AbortSignal,
+): Promise<string | null> {
+  for (const path of README_CANDIDATES) {
+    const text = await fetchText(rawUrl(owner, repo, path), signal);
+    if (text) return text;
+  }
+  return null;
+}
+
+async function probeAllFiles(
+  owner: string,
+  repo: string,
+  signal?: AbortSignal,
+): Promise<ProbeResult> {
+  const entries = await Promise.all(
+    PROBE_FILES.map(async (path) => {
+      const exists = await probeExists(rawUrl(owner, repo, path), signal);
+      return [path, exists] as const;
+    }),
+  );
+  return Object.fromEntries(entries) as ProbeResult;
+}
+
+function githubMetricBadges(owner: string, repo: string): Badge[] {
+  const mk = (
+    id: string,
+    label: string,
+    path: string,
+    query: Record<string, string> = {},
+  ): Badge => ({
+    id,
+    group: 'github',
+    label,
+    path,
+    query,
+    overrides: {},
+    enabled: true,
+  });
+  const p = (m: string) => `/github/${m}/${owner}/${repo}.svg`;
+  return [
+    mk('github.stars', 'GitHub Stars', p('stars'), { variant: 'outline' }),
+    mk('github.forks', 'GitHub Forks', p('forks'), { variant: 'outline' }),
+    mk('github.watchers', 'Watchers', p('watchers'), { variant: 'outline' }),
+    mk('github.branches', 'Branches', p('branches'), { variant: 'ghost' }),
+    mk('github.contributors', 'Contributors', p('contributors'), {
+      theme: 'emerald',
+    }),
+    mk('github.last-commit', 'Last commit', p('last-commit'), {
+      variant: 'secondary',
+    }),
+    mk('github.commits', 'Commits', p('commits'), { variant: 'secondary' }),
+    mk('github.open-issues', 'Open issues', p('open-issues'), {
+      variant: 'secondary',
+    }),
+    mk('github.closed-issues', 'Closed issues', p('closed-issues'), {
+      variant: 'ghost',
+    }),
+    mk('github.open-prs', 'Open PRs', p('open-prs'), { variant: 'secondary' }),
+    mk('github.closed-prs', 'Closed PRs', p('closed-prs'), { variant: 'ghost' }),
+    mk('github.merged-prs', 'Merged PRs', p('merged-prs'), { variant: 'ghost' }),
+    mk('github.release', 'Release', p('release')),
+    mk('github.ci', 'CI', p('ci'), { variant: 'secondary' }),
+    mk('github.license', 'License', p('license'), { variant: 'ghost' }),
+  ];
+}
+
+function npmBadges(pkg: string): Badge[] {
+  const mk = (
+    id: string,
+    label: string,
+    path: string,
+    query: Record<string, string> = {},
+  ): Badge => ({
+    id,
+    group: 'package',
+    label,
+    path,
+    query,
+    overrides: {},
+    enabled: true,
+  });
+  return [
+    mk('npm.version', 'npm Version', `/npm/${pkg}.svg`, { variant: 'secondary' }),
+    mk('npm.dw', 'npm Weekly Downloads', `/npm/dw/${pkg}.svg`),
+    mk('npm.dm', 'npm Monthly Downloads', `/npm/dm/${pkg}.svg`, {
+      variant: 'ghost',
+    }),
+    mk('npm.dt', 'npm Total Downloads', `/npm/dt/${pkg}.svg`, {
+      variant: 'outline',
+    }),
+    mk('npm.dependents', 'npm Dependents', `/npm/dependents/${pkg}.svg`, {
+      variant: 'outline',
+    }),
+    mk('npm.types', 'npm Types', `/npm/types/${pkg}.svg`, { theme: 'blue' }),
+    mk('npm.node', 'npm Node', `/npm/node/${pkg}.svg`, { variant: 'outline' }),
+    mk('npm.license', 'npm License', `/npm/license/${pkg}.svg`, {
+      variant: 'ghost',
+    }),
+  ];
+}
+
+function privatePackageBadge(): Badge {
+  return {
+    id: 'package.private',
+    group: 'package',
+    label: 'Private package',
+    path: staticBadgePath('Private', 'package', 'red'),
+    query: { variant: 'outline' },
+    overrides: {},
+    enabled: true,
+  };
+}
+
+type ToolingRule = {
+  id: string;
+  category: string;
+  name: string;
+  slug: string;
+  color: string;
+  requires: ProbeKey[];
+};
+
+const TOOLING_RULES: ToolingRule[] = [
+  // Package managers
+  { id: 'tooling.pnpm', category: 'Package mgr', name: 'pnpm', slug: 'pnpm', color: 'F69220', requires: ['pnpm-lock.yaml'] },
+  { id: 'tooling.bun', category: 'Package mgr', name: 'Bun', slug: 'bun', color: '000000', requires: ['bun.lock', 'bun.lockb'] },
+  { id: 'tooling.yarn', category: 'Package mgr', name: 'Yarn', slug: 'yarn', color: '2C8EBB', requires: ['yarn.lock'] },
+  { id: 'tooling.npm', category: 'Package mgr', name: 'npm', slug: 'npm', color: 'CB3837', requires: ['package-lock.json'] },
+  // Container
+  { id: 'tooling.docker', category: 'Container', name: 'Docker', slug: 'docker', color: '2496ED', requires: ['Dockerfile', 'docker-compose.yml', 'docker-compose.yaml'] },
+  // Language / lint / format
+  { id: 'tooling.typescript', category: 'Language', name: 'TypeScript', slug: 'typescript', color: '3178C6', requires: ['tsconfig.json'] },
+  { id: 'tooling.biome', category: 'Lint', name: 'Biome', slug: 'biome', color: '60A5FA', requires: ['biome.json'] },
+  { id: 'tooling.eslint', category: 'Lint', name: 'ESLint', slug: 'eslint', color: '4B32C3', requires: ['.eslintrc.json', '.eslintrc.js', '.eslintrc.cjs', 'eslint.config.js', 'eslint.config.mjs'] },
+  { id: 'tooling.prettier', category: 'Format', name: 'Prettier', slug: 'prettier', color: 'F7B93E', requires: ['.prettierrc', '.prettierrc.json', 'prettier.config.js'] },
+  // Frameworks / bundlers
+  { id: 'tooling.vite', category: 'Bundler', name: 'Vite', slug: 'vite', color: '646CFF', requires: ['vite.config.ts', 'vite.config.js', 'vite.config.mjs'] },
+  { id: 'tooling.nextjs', category: 'Framework', name: 'Next.js', slug: 'nextdotjs', color: '000000', requires: ['next.config.ts', 'next.config.js', 'next.config.mjs'] },
+  { id: 'tooling.nuxt', category: 'Framework', name: 'Nuxt', slug: 'nuxt', color: '00DC82', requires: ['nuxt.config.ts', 'nuxt.config.js'] },
+  { id: 'tooling.astro', category: 'Framework', name: 'Astro', slug: 'astro', color: 'BC52EE', requires: ['astro.config.mjs', 'astro.config.ts'] },
+  { id: 'tooling.svelte', category: 'Framework', name: 'Svelte', slug: 'svelte', color: 'FF3E00', requires: ['svelte.config.js', 'svelte.config.ts'] },
+  { id: 'tooling.tailwind', category: 'CSS', name: 'Tailwind', slug: 'tailwindcss', color: '06B6D4', requires: ['tailwind.config.ts', 'tailwind.config.js'] },
+  { id: 'tooling.unocss', category: 'CSS', name: 'UnoCSS', slug: 'unocss', color: '333333', requires: ['unocss.config.ts', 'unocss.config.js'] },
+  // Monorepo / build
+  { id: 'tooling.turbo', category: 'Monorepo', name: 'Turborepo', slug: 'turborepo', color: 'EF4444', requires: ['turbo.json'] },
+  { id: 'tooling.nx', category: 'Monorepo', name: 'Nx', slug: 'nx', color: '143055', requires: ['nx.json'] },
+  { id: 'tooling.changesets', category: 'Releases', name: 'Changesets', slug: 'changesets', color: '5846F5', requires: ['.changeset/README.md'] },
+  { id: 'tooling.storybook', category: 'Docs', name: 'Storybook', slug: 'storybook', color: 'FF4785', requires: ['.storybook/main.ts', '.storybook/main.js'] },
+  // Tests
+  { id: 'tooling.vitest', category: 'Tests', name: 'Vitest', slug: 'vitest', color: '6E9F18', requires: ['vitest.config.ts', 'vitest.config.js'] },
+  { id: 'tooling.playwright', category: 'Tests', name: 'Playwright', slug: 'playwright', color: '2EAD33', requires: ['playwright.config.ts', 'playwright.config.js'] },
+  { id: 'tooling.jest', category: 'Tests', name: 'Jest', slug: 'jest', color: 'C21325', requires: ['jest.config.js', 'jest.config.ts'] },
+  { id: 'tooling.cypress', category: 'Tests', name: 'Cypress', slug: 'cypress', color: '69D3A7', requires: ['cypress.config.ts', 'cypress.config.js'] },
+  // Hosting
+  { id: 'tooling.cloudflare', category: 'Hosting', name: 'Cloudflare Workers', slug: 'cloudflare', color: 'F38020', requires: ['wrangler.toml', 'wrangler.jsonc'] },
+  { id: 'tooling.vercel', category: 'Hosting', name: 'Vercel', slug: 'vercel', color: '000000', requires: ['vercel.json'] },
+  { id: 'tooling.netlify', category: 'Hosting', name: 'Netlify', slug: 'netlify', color: '00AD9F', requires: ['netlify.toml'] },
+  { id: 'tooling.fly', category: 'Hosting', name: 'Fly.io', slug: 'flydotio', color: '24175B', requires: ['fly.toml'] },
+];
+
+function toolingBadges(probes: ProbeResult): Badge[] {
+  const found: Badge[] = [];
+  const seenSlugs = new Set<string>();
+  for (const rule of TOOLING_RULES) {
+    if (!rule.requires.some((f) => probes[f])) continue;
+    if (seenSlugs.has(rule.slug)) continue;
+    seenSlugs.add(rule.slug);
+    found.push({
+      id: rule.id,
+      group: 'tooling',
+      label: `${rule.category} · ${rule.name}`,
+      path: staticBadgePath(rule.category, rule.name, rule.color),
+      query: { logo: rule.slug, variant: 'branded' },
+      overrides: {},
+      enabled: true,
+    });
+  }
+  return found;
+}
+
+function stackBadges(pkg: PackageJson, toolingSlugs: Set<string>): Badge[] {
+  const deps = {
+    ...pkg.dependencies,
+    ...pkg.devDependencies,
+    ...pkg.peerDependencies,
+  };
+  const out: Badge[] = [];
+  const seen = new Set<string>();
+  for (const name of Object.keys(deps)) {
+    const brand = matchBrand(name);
+    if (!brand) continue;
+    if (toolingSlugs.has(brand.slug)) continue;
+    if (seen.has(brand.slug)) continue;
+    seen.add(brand.slug);
+    out.push({
+      id: `stack.${brand.slug}`,
+      group: 'stack',
+      label: brand.label,
+      path: staticBadgePath('Stack', brand.label, brand.color),
+      query: { logo: brand.slug, variant: 'branded' },
+      overrides: {},
+      enabled: true,
+    });
+    if (out.length >= BRAND_CAP) break;
+  }
+  return out;
+}
+
+function modernBadges(pkg: PackageJson, probes: ProbeResult): Badge[] {
+  const out: Badge[] = [];
+
+  const add = (
+    id: string,
+    label: string,
+    message: string,
+    color: string,
+    variant = 'outline',
+  ) =>
+    out.push({
+      id,
+      group: 'modern',
+      label: `${label} ${message}`.trim(),
+      path: staticBadgePath(label, message, color),
+      query: { variant },
+      overrides: {},
+      enabled: true,
+    });
+
+  if (pkg.type === 'module') add('modern.esm', 'ESM', 'only', '16a34a');
+
+  if (pkg.sideEffects === false) add('modern.tree-shakeable', 'Tree-shakeable', 'yes', '16a34a');
+
+  if (pkg.bin) add('modern.cli', 'CLI', 'tool', '7c3aed');
+
+  if (pkg.workspaces) add('modern.monorepo', 'Monorepo', 'yes', '2563eb');
+
+  if (pkg.exports && typeof pkg.exports === 'object') {
+    const serialized = JSON.stringify(pkg.exports);
+    if (serialized.includes('import') && serialized.includes('require')) {
+      add('modern.dual-package', 'Dual package', 'ESM+CJS', '2563eb');
+    }
+  }
+
+  if (probes['AGENTS.md']) add('modern.agents-md', 'Agent-friendly', 'AGENTS.md', 'D97757');
+  if (probes['llms.txt']) add('modern.llms-txt', 'LLM-indexed', 'llms.txt', '7C3AED');
+  if (probes['.claude/CLAUDE.md']) add('modern.claude', 'Claude Code', 'ready', 'D97757');
+  if (probes['.cursor/rules']) add('modern.cursor', 'Cursor', 'ready', '000000');
+  if (probes['mcp.json']) add('modern.mcp', 'MCP', 'server', '111827');
+
+  return out;
+}
+
+async function communityBadges(
+  owner: string,
+  repo: string,
+  pkg: PackageJson | null,
+  readme: string | null,
+  signal?: AbortSignal,
+): Promise<Badge[]> {
+  const out: Badge[] = [];
+  if (readme) {
+    const code = extractDiscordInvite(readme);
+    if (code) {
+      out.push({
+        id: 'community.discord-members',
+        group: 'community',
+        label: 'Discord Members',
+        path: `/discord/members/${code}.svg`,
+        query: { variant: 'outline' },
+        overrides: {},
+        enabled: true,
+      });
+      out.push({
+        id: 'community.discord-online',
+        group: 'community',
+        label: 'Discord Online',
+        path: `/discord/online-members/${code}.svg`,
+        query: { variant: 'branded' },
+        overrides: {},
+        enabled: true,
+      });
+    }
+  }
+
+  const fundingText = await fetchText(rawUrl(owner, repo, '.github/FUNDING.yml'), signal);
+  if (fundingText) {
+    let data: Record<string, unknown> | null = null;
+    try {
+      const { parse: parseYaml } = await import('yaml');
+      data = parseYaml(fundingText) as Record<string, unknown>;
+    } catch {
+      data = null;
+    }
+    if (data) {
+      if (data.github) {
+        out.push({
+          id: 'community.sponsor-github',
+          group: 'community',
+          label: 'GitHub Sponsors',
+          path: staticBadgePath('Sponsor', 'GitHub', 'ea4aaa'),
+          query: { logo: 'githubsponsors', variant: 'outline' },
+          overrides: {},
+          enabled: true,
+        });
+      }
+      if (data.open_collective) {
+        out.push({
+          id: 'community.sponsor-opencollective',
+          group: 'community',
+          label: 'Open Collective',
+          path: staticBadgePath('Open Collective', 'sponsor', '7FADF2'),
+          query: { logo: 'opencollective', variant: 'outline' },
+          overrides: {},
+          enabled: true,
+        });
+      }
+      if (data.patreon) {
+        out.push({
+          id: 'community.sponsor-patreon',
+          group: 'community',
+          label: 'Patreon',
+          path: staticBadgePath('Patreon', 'sponsor', 'FF424D'),
+          query: { logo: 'patreon', variant: 'outline' },
+          overrides: {},
+          enabled: true,
+        });
+      }
+      if (data.ko_fi) {
+        out.push({
+          id: 'community.sponsor-kofi',
+          group: 'community',
+          label: 'Ko-fi',
+          path: staticBadgePath('Ko-fi', 'sponsor', 'FF5E5B'),
+          query: { logo: 'kofi', variant: 'outline' },
+          overrides: {},
+          enabled: true,
+        });
+      }
+    }
+  }
+
+  if (pkg?.homepage && /^https?:\/\//.test(pkg.homepage)) {
+    out.push({
+      id: 'community.homepage',
+      group: 'community',
+      label: 'Homepage',
+      path: staticBadgePath('Homepage', 'link', '2563eb'),
+      query: { variant: 'ghost' },
+      overrides: {},
+      enabled: true,
+      linkUrl: pkg.homepage,
+    });
+  }
+
+  return out;
+}
+
+export async function inspect(
+  urlOrSlug: string,
+  externalSignal?: AbortSignal,
+): Promise<InspectResult | { error: string }> {
+  const parsed = parseGithubUrl(urlOrSlug);
+  if ('error' in parsed) return { error: parsed.error };
+  const { owner, repo, url } = parsed;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new DOMException('Timeout', 'AbortError')), 15_000);
+  if (externalSignal) {
+    if (externalSignal.aborted) controller.abort(externalSignal.reason);
+    else externalSignal.addEventListener('abort', () => controller.abort(externalSignal.reason));
+  }
+  const signal = controller.signal;
+
+  try {
+    const [pkg, readme, probes] = await Promise.all([
+      getPackageJson(owner, repo, signal),
+      getReadme(owner, repo, signal),
+      probeAllFiles(owner, repo, signal),
+    ]);
+
+    const notes: string[] = [];
+    const badges: Badge[] = [];
+
+    badges.push(...githubMetricBadges(owner, repo));
+
+    if (pkg) {
+      if (pkg.private === true) {
+        badges.push(privatePackageBadge());
+        notes.push('package.json is private — npm badges suppressed.');
+      } else if (pkg.name) {
+        // npm registry accepts both `react` and `@scope/name` directly without encoding
+        const npmInfo = await fetchJson<{ name?: string }>(
+          `${NPM}/${pkg.name}`,
+          signal,
+        );
+        if (npmInfo && npmInfo.name) {
+          badges.push(...npmBadges(pkg.name));
+        } else {
+          notes.push(`Package "${pkg.name}" not found on npm — npm badges skipped.`);
+        }
+      }
+    } else {
+      notes.push('No package.json detected — npm badges skipped.');
+    }
+
+    const toolBadges = toolingBadges(probes);
+    const toolingSlugs = new Set(
+      toolBadges.map((b) => b.query.logo).filter((v): v is string => !!v),
+    );
+    badges.push(...toolBadges);
+
+    if (pkg) {
+      badges.push(...stackBadges(pkg, toolingSlugs));
+      badges.push(...modernBadges(pkg, probes));
+    } else {
+      // package.json missing — only emit probe-based modern badges
+      badges.push(...modernBadges({}, probes));
+    }
+
+    badges.push(...(await communityBadges(owner, repo, pkg, readme, signal)));
+
+    const existingShieldsIoUrls = readme ? extractShieldsIoUrls(readme) : [];
+
+    return { source: { owner, repo, url }, badges, notes, existingShieldsIoUrls };
+  } catch (e) {
+    if (isAbort(e)) {
+      return { error: signal.reason?.message ?? 'Request was cancelled' };
+    }
+    throw e;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export { parseGithubUrl };

--- a/lib/gen/shieldcn.ts
+++ b/lib/gen/shieldcn.ts
@@ -1,0 +1,172 @@
+export const SHIELDCN_BASE = 'https://www.shieldcn.dev';
+
+export type Variant =
+  | 'default'
+  | 'secondary'
+  | 'outline'
+  | 'ghost'
+  | 'destructive'
+  | 'branded';
+
+export type Size = 'xs' | 'sm' | 'default' | 'lg';
+
+export type Mode = 'dark' | 'light';
+
+export type Theme =
+  | 'none'
+  | 'zinc'
+  | 'slate'
+  | 'stone'
+  | 'neutral'
+  | 'gray'
+  | 'blue'
+  | 'green'
+  | 'rose'
+  | 'orange'
+  | 'amber'
+  | 'violet'
+  | 'purple'
+  | 'red'
+  | 'cyan'
+  | 'emerald';
+
+export type Overrides = Partial<{
+  variant: Variant;
+  size: Size;
+  mode: Mode;
+  theme: Theme;
+  color: string;
+  labelColor: string;
+  valueColor: string;
+  labelTextColor: string;
+  labelOpacity: number;
+  logo: string | false;
+  logoColor: string;
+  label: string;
+  split: boolean;
+  statusDot: boolean;
+  height: number;
+  fontSize: number;
+  radius: number;
+  padX: number;
+  iconSize: number;
+  gap: number;
+  labelGap: number;
+}>;
+
+export type GlobalSettings = {
+  variant: Variant;
+  size: Size;
+  mode: Mode;
+  theme: Theme;
+};
+
+export const DEFAULT_GLOBAL: GlobalSettings = {
+  variant: 'default',
+  size: 'sm',
+  mode: 'dark',
+  theme: 'none',
+};
+
+export type BadgeGroup =
+  | 'github'
+  | 'package'
+  | 'stack'
+  | 'tooling'
+  | 'modern'
+  | 'community';
+
+export type Badge = {
+  id: string;
+  group: BadgeGroup;
+  label: string;
+  path: string;
+  query: Record<string, string>;
+  overrides: Overrides;
+  enabled: boolean;
+  linkUrl?: string;
+};
+
+function stripHash(v: string): string {
+  return v.startsWith('#') ? v.slice(1) : v;
+}
+
+const COLOR_FIELDS: (keyof Overrides)[] = [
+  'color',
+  'labelColor',
+  'valueColor',
+  'labelTextColor',
+  'logoColor',
+];
+
+export function mergeQuery(
+  badge: Badge,
+  global: GlobalSettings,
+): Record<string, string> {
+  const merged: Record<string, string> = { ...badge.query };
+
+  if (global.variant !== 'default' && !merged.variant) merged.variant = global.variant;
+  if (global.size !== 'default' && !merged.size) merged.size = global.size;
+  if (global.mode !== 'dark' && !merged.mode) merged.mode = global.mode;
+  if (global.theme !== 'none' && !merged.theme) merged.theme = global.theme;
+
+  for (const [rawKey, rawVal] of Object.entries(badge.overrides)) {
+    if (rawVal === undefined || rawVal === null || rawVal === '') continue;
+    const key = rawKey as keyof Overrides;
+    if (key === 'theme' && rawVal === 'none') {
+      delete merged.theme;
+      continue;
+    }
+    let value: string;
+    if (typeof rawVal === 'boolean') {
+      value = rawVal ? 'true' : 'false';
+    } else if (typeof rawVal === 'number') {
+      value = String(rawVal);
+    } else {
+      value = String(rawVal);
+    }
+    if (COLOR_FIELDS.includes(key)) value = stripHash(value);
+    merged[key] = value;
+  }
+
+  return merged;
+}
+
+export function badgeUrl(badge: Badge, global: GlobalSettings): string {
+  const qs = new URLSearchParams(mergeQuery(badge, global)).toString();
+  return `${SHIELDCN_BASE}${badge.path}${qs ? `?${qs}` : ''}`;
+}
+
+export function badgeMarkdown(badge: Badge, global: GlobalSettings): string {
+  const url = badgeUrl(badge, global);
+  const alt = badge.label.replace(/[\[\]]/g, '');
+  const img = `![${alt}](${url})`;
+  return badge.linkUrl ? `[${img}](${badge.linkUrl})` : img;
+}
+
+export function badgeHtml(badge: Badge, global: GlobalSettings): string {
+  const url = badgeUrl(badge, global);
+  const alt = badge.label.replace(/"/g, '&quot;');
+  const img = `<img src="${url}" alt="${alt}" />`;
+  return badge.linkUrl ? `<a href="${badge.linkUrl}">${img}</a>` : img;
+}
+
+const ENCODE_MAP: Array<[RegExp, string]> = [
+  [/_/g, '__'],
+  [/-/g, '--'],
+];
+
+export function encodeStaticSegment(raw: string): string {
+  let s = raw;
+  for (const [re, rep] of ENCODE_MAP) s = s.replace(re, rep);
+  return s.replace(/ /g, '_');
+}
+
+export function staticBadgePath(
+  label: string,
+  message: string,
+  color: string,
+): string {
+  const enc = (s: string) => encodeURIComponent(encodeStaticSegment(s));
+  return `/badge/${enc(label)}-${enc(message)}-${stripHash(color)}.svg`;
+}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "shiki": "^4.0.2",
     "simple-icons": "^16.17.0",
     "tailwind-merge": "^3.5.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4


### PR DESCRIPTION
## Summary

- **Badge Generator** — ports [shieldcngen](https://github.com/k33bs/shieldcngen) as a first-party `/gen` page, fully rewritten with shadcn/ui components (Tabs, Card, Input, Select, Popover, Button, Textarea)
- **Color Picker** — new `<ColorInput>` component with HSL saturation/lightness canvas, hue slider, eyedropper (EyeDropper API), preset swatches, and hex input. Replaces plain text inputs for all color fields across badge-builder, badge-sandbox, and generator
- **Gradient Nav Link** — `<GradientText>` component with flowing rainbow gradient that reveals on hover, used on the Generator nav link
- **@k33bs credit** — added to README credits and generator page header

## Changes

### New files
- `app/gen/page.tsx` — generator page at `/gen`
- `app/gen/generator-client.tsx` — full generator client component
- `lib/gen/` — ported detection, config, brands, and shieldcn URL builder libs
- `components/color-input.tsx` — color picker component
- `components/gradient-text.tsx` — gradient text hover effect
- `components/ui/card.tsx`, `components/ui/textarea.tsx` — new shadcn components

### Modified files
- `components/site-header.tsx` — Generator link with gradient text
- `components/badge-builder.tsx` — color fields use ColorInput
- `components/badge-sandbox.tsx` — color fields use ColorInput
- `components/footer.tsx` — Generator link in footer nav
- `README.md` — @k33bs credit in credits section