### PR TITLE
feat(gen): add interactive product tour to badge generator

### DIFF
--- a/app/gen/generator-client.tsx
+++ b/app/gen/generator-client.tsx
@@ -48,6 +48,7 @@ import { Separator } from "@/components/ui/separator"
 import { ColorInput } from "@/components/color-input"
 import { SvgIconUpload } from "@/components/svg-icon-upload"
 import { cn } from "@/lib/utils"
+import { TOUR_STEP_IDS } from "@/lib/tour-constants"
 
 const VARIANTS: Variant[] = [
   "default",
@@ -333,7 +334,7 @@ export default function GeneratorApp() {
         <TabsContent value="url">
           <Card>
             <CardContent>
-              <div className="space-y-2">
+              <div id={TOUR_STEP_IDS.URL_INPUT} className="space-y-2">
                 <Label htmlFor="url-input" className="text-xs text-muted-foreground">
                   GitHub repository URL or owner/repo
                 </Label>
@@ -564,7 +565,7 @@ function ResultsPanel({
       )}
 
       {/* Global defaults */}
-      <div className="space-y-3">
+      <div id={TOUR_STEP_IDS.GLOBAL_DEFAULTS} className="space-y-3">
         <h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
           Global defaults
         </h3>
@@ -602,14 +603,18 @@ function ResultsPanel({
         if (!items || items.length === 0) return null
         const visible = items.filter((b) => b.enabled)
         if (visible.length === 0) return null
+        const isFirst = GROUP_ORDER.indexOf(group) === GROUP_ORDER.findIndex((g) => {
+          const items2 = byGroup.get(g)
+          return items2 && items2.some((b) => b.enabled)
+        })
         return (
-          <div key={group} className="space-y-3">
+          <div key={group} id={isFirst ? TOUR_STEP_IDS.BADGE_GROUP : undefined} className="space-y-3">
             <div className="flex items-baseline gap-2">
               <h3 className="text-sm font-semibold">{GROUP_TITLES[group]}</h3>
               <span className="text-xs text-muted-foreground">{visible.length}</span>
             </div>
             <div className="flex flex-wrap gap-2">
-              {visible.map((badge) => (
+              {visible.map((badge, badgeIdx) => (
                 <BadgeItem
                   key={badge.id}
                   badge={badge}
@@ -618,6 +623,7 @@ function ResultsPanel({
                   onUpdateOverrides={(patch) => updateOverrides(badge.id, patch)}
                   onRemove={() => removeBadge(badge.id)}
                   onCopy={onCopy}
+                  tourId={isFirst && badgeIdx === 0 ? TOUR_STEP_IDS.BADGE_POPOVER : undefined}
                 />
               ))}
             </div>
@@ -638,7 +644,7 @@ function ResultsPanel({
           rows={Math.min(Math.max(enabledBadges.length, 4), 16)}
           className="font-mono text-xs"
         />
-        <div className="flex flex-wrap gap-2">
+        <div id={TOUR_STEP_IDS.COPY_ACTIONS} className="flex flex-wrap gap-2">
           <Button size="sm" onClick={() => onCopy(markdown)}>
             <Copy className="size-3.5" />
             Copy markdown
@@ -692,6 +698,7 @@ function BadgeItem({
   onUpdateOverrides,
   onRemove,
   onCopy,
+  tourId,
 }: {
   badge: Badge
   global: GlobalSettings
@@ -699,6 +706,7 @@ function BadgeItem({
   onUpdateOverrides: (patch: Overrides) => void
   onRemove: () => void
   onCopy: (text: string) => void
+  tourId?: string
 }) {
   const [open, setOpen] = useState(false)
   const url = badgeUrl(badge, global)
@@ -720,6 +728,7 @@ function BadgeItem({
       <PopoverTrigger asChild>
         <button
           type="button"
+          id={tourId}
           className={cn(
             "inline-flex items-center rounded-md border border-transparent p-0.5 transition-colors hover:border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
             open && "border-primary",

--- a/app/gen/generator-tour.tsx
+++ b/app/gen/generator-tour.tsx
@@ -1,0 +1,228 @@
+// shieldcn — app/gen/generator-tour.tsx
+// Tour overlay + provider for the badge generator page
+
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { useOpenPanel } from "@openpanel/nextjs"
+import { TourProvider, useTour, TourAlertDialog, type TourStep } from "@/components/tour"
+import { TOUR_STEP_IDS } from "@/lib/tour-constants"
+
+const STORAGE_KEY = "shieldcn-gen-tour-completed"
+
+const steps: TourStep[] = [
+  {
+    selectorId: TOUR_STEP_IDS.URL_INPUT,
+    position: "bottom",
+    content: (
+      <div className="space-y-2">
+        <p className="text-sm font-semibold">Enter your repo</p>
+        <p className="text-xs text-muted-foreground">
+          Paste a GitHub URL or type <code className="rounded bg-muted px-1 text-[11px]">owner/repo</code> and
+          hit Generate. We&apos;ll detect your stack and create badges automatically.
+        </p>
+      </div>
+    ),
+  },
+  {
+    selectorId: TOUR_STEP_IDS.GLOBAL_DEFAULTS,
+    position: "top",
+    content: (
+      <div className="space-y-2">
+        <p className="text-sm font-semibold">Customize the look</p>
+        <p className="text-xs text-muted-foreground">
+          Change variant, size, theme, and mode to style all your badges at once.
+          These settings apply globally.
+        </p>
+      </div>
+    ),
+  },
+  {
+    selectorId: TOUR_STEP_IDS.BADGE_GROUP,
+    position: "top",
+    content: (
+      <div className="space-y-2">
+        <p className="text-sm font-semibold">Your badges</p>
+        <p className="text-xs text-muted-foreground">
+          Badges are grouped by category. Click any badge to customize it individually.
+        </p>
+      </div>
+    ),
+  },
+  {
+    selectorId: TOUR_STEP_IDS.BADGE_POPOVER,
+    position: "bottom",
+    content: (
+      <div className="space-y-2">
+        <p className="text-sm font-semibold">Customize each badge</p>
+        <p className="text-xs text-muted-foreground">
+          Override the variant, colors, icon, or label for this specific badge.
+          Hit the red button to remove it from your set.
+        </p>
+      </div>
+    ),
+  },
+  {
+    selectorId: TOUR_STEP_IDS.COPY_ACTIONS,
+    position: "top",
+    content: (
+      <div className="space-y-2">
+        <p className="text-sm font-semibold">Copy &amp; go</p>
+        <p className="text-xs text-muted-foreground">
+          Copy the markdown, download it as a file, or save the config to reload later.
+        </p>
+        <p className="text-[11px] text-muted-foreground/60">
+          Press <kbd className="rounded border border-border bg-muted px-1 py-0.5 font-mono text-[10px]">→</kbd> or <span className="font-medium text-primary">Finish</span> to close the tour.
+        </p>
+      </div>
+    ),
+  },
+]
+
+export function GeneratorTourProvider({ children }: { children: React.ReactNode }) {
+  const { track } = useOpenPanel()
+  return (
+    <TourProvider
+      onComplete={() => {
+        localStorage.setItem(STORAGE_KEY, "true")
+        track("tour_completed", { tour: "generator" })
+      }}
+      className="rounded-lg"
+    >
+      {children}
+      <GeneratorTourTrigger />
+    </TourProvider>
+  )
+}
+
+import type React from "react"
+import { CircleHelp } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export function TourReplayButton() {
+  const { setIsTourCompleted, startTour, isTourCompleted, setSteps } = useTour()
+  const hasReset = useRef(false)
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className="gap-1.5 text-xs text-muted-foreground"
+      onClick={() => {
+        // Reset tour state and re-trigger
+        localStorage.removeItem(STORAGE_KEY)
+        setIsTourCompleted(false)
+        if (!hasReset.current) {
+          hasReset.current = true
+          setSteps(steps)
+        }
+        setTimeout(() => startTour(), 100)
+      }}
+    >
+      <CircleHelp className="size-3.5" />
+      How to use
+    </Button>
+  )
+}
+
+function GeneratorTourTrigger() {
+  const op = useOpenPanel()
+  const { setSteps, isTourCompleted, setIsTourCompleted, currentStep, isActive } = useTour()
+  const [showDialog, setShowDialog] = useState(false)
+  const hasFilledInput = useRef(false)
+
+  useEffect(() => {
+    // Check localStorage for completion
+    const completed = localStorage.getItem(STORAGE_KEY) === "true"
+    if (completed) {
+      setIsTourCompleted(true)
+      return
+    }
+
+    setSteps(steps)
+
+    // Delay to let the page render
+    const timer = setTimeout(() => {
+      setShowDialog(true)
+    }, 500)
+
+    return () => clearTimeout(timer)
+  }, [setSteps, setIsTourCompleted])
+
+  // When entering the badge popover step, click the first badge to open it
+  useEffect(() => {
+    if (!isActive || currentStep !== 3) return
+    const badge = document.getElementById(TOUR_STEP_IDS.BADGE_POPOVER)
+    if (badge) {
+      badge.click()
+    }
+  }, [isActive, currentStep])
+
+  // When leaving the badge popover step, close the popover and scroll down
+  useEffect(() => {
+    if (!isActive || currentStep !== 4) return
+
+    // Close the popover by clicking its trigger (toggle)
+    requestAnimationFrame(() => {
+      const badge = document.getElementById(TOUR_STEP_IDS.BADGE_POPOVER)
+      if (badge) badge.click()
+    })
+
+    // Scroll the copy actions into view
+    setTimeout(() => {
+      const el = document.getElementById(TOUR_STEP_IDS.COPY_ACTIONS)
+      if (el) {
+        el.scrollIntoView({ behavior: "smooth", block: "center" })
+      }
+    }, 150)
+  }, [isActive, currentStep])
+
+  // When tour starts (step 0), fill the input and trigger generate
+  useEffect(() => {
+    if (!isActive || currentStep !== 0 || hasFilledInput.current) return
+    hasFilledInput.current = true
+
+    const input = document.querySelector<HTMLInputElement>("#url-input")
+    if (!input) return
+
+    // Type out the demo text character by character
+    const demo = "vercel/next.js"
+    let i = 0
+    input.focus()
+
+    const nativeSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set
+    const typeChar = () => {
+      if (i < demo.length) {
+        i++
+        nativeSetter?.call(input, demo.slice(0, i))
+        input.dispatchEvent(new Event("input", { bubbles: true }))
+        setTimeout(typeChar, 40 + Math.random() * 30)
+      } else {
+        // Press enter after typing
+        setTimeout(() => {
+          input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }))
+        }, 300)
+      }
+    }
+    setTimeout(typeChar, 400)
+  }, [isActive, currentStep])
+
+  // Persist completion to localStorage
+  useEffect(() => {
+    if (isTourCompleted) {
+      localStorage.setItem(STORAGE_KEY, "true")
+    }
+  }, [isTourCompleted])
+
+  const handleOpenChange = (open: boolean) => {
+    setShowDialog(open)
+    if (!open) {
+      // User skipped — remember it
+      localStorage.setItem(STORAGE_KEY, "true")
+      setIsTourCompleted(true)
+      op.track("tour_skipped", { tour: "generator" })
+    }
+  }
+
+  return <TourAlertDialog isOpen={showDialog} setIsOpen={handleOpenChange} />
+}

--- a/app/gen/page.tsx
+++ b/app/gen/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next"
 import { Suspense } from "react"
 import { SiteShell } from "@/components/site-shell"
 import GeneratorClient from "./generator-client"
+import { GeneratorTourProvider, TourReplayButton } from "./generator-tour"
 import { pageMetadata } from "@/lib/metadata"
 
 export const metadata: Metadata = pageMetadata({
@@ -16,47 +17,52 @@ export default function GeneratorPage() {
     <SiteShell>
       <main className="min-w-0 flex-1">
         <div className="mx-auto max-w-4xl px-6 py-12 md:px-10">
-          <header className="mb-10 flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
-            <div>
-              <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
-                Generator
-              </h1>
-              <p className="text-sm text-muted-foreground">
-                Auto-generate{" "}
-                <a
-                  href="https://shieldcn.dev"
-                  className="underline underline-offset-2 hover:text-foreground"
-                >
-                  shieldcn
-                </a>{" "}
-                badges from a GitHub URL.
-              </p>
-            </div>
-            <p className="text-xs text-muted-foreground">
-              By{" "}
-              <a
-                href="https://github.com/k33bs"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="underline underline-offset-2 hover:text-foreground"
-              >
-                @k33bs
-              </a>
-              {" · "}
-              <a
-                href="https://github.com/k33bs/shieldcngen"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="underline underline-offset-2 hover:text-foreground"
-              >
-                Source
-              </a>
-            </p>
-          </header>
+          <GeneratorTourProvider>
+            <header className="mb-10 flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+              <div>
+                <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+                  Generator
+                </h1>
+                <p className="text-sm text-muted-foreground">
+                  Auto-generate{" "}
+                  <a
+                    href="https://shieldcn.dev"
+                    className="underline underline-offset-2 hover:text-foreground"
+                  >
+                    shieldcn
+                  </a>{" "}
+                  badges from a GitHub URL.
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <TourReplayButton />
+                <span className="text-xs text-muted-foreground">
+                  By{" "}
+                  <a
+                    href="https://github.com/k33bs"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline underline-offset-2 hover:text-foreground"
+                  >
+                    @k33bs
+                  </a>
+                  {" · "}
+                  <a
+                    href="https://github.com/k33bs/shieldcngen"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline underline-offset-2 hover:text-foreground"
+                  >
+                    Source
+                  </a>
+                </span>
+              </div>
+            </header>
 
-          <Suspense>
-            <GeneratorClient />
-          </Suspense>
+            <Suspense>
+              <GeneratorClient />
+            </Suspense>
+          </GeneratorTourProvider>
         </div>
       </main>
     </SiteShell>

--- a/components/tour.tsx
+++ b/components/tour.tsx
@@ -1,0 +1,467 @@
+"use client";
+
+import { AnimatePresence, motion } from "motion/react";
+import type React from "react";
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useState,
+} from "react";
+
+import {
+	AlertDialog,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+import { Sparkles } from "lucide-react";
+
+export interface TourStep {
+	content: React.ReactNode;
+	selectorId: string;
+	width?: number;
+	height?: number;
+	onClickWithinArea?: () => void;
+	position?: "top" | "bottom" | "left" | "right";
+}
+
+interface TourContextType {
+	currentStep: number;
+	totalSteps: number;
+	nextStep: () => void;
+	previousStep: () => void;
+	endTour: () => void;
+	isActive: boolean;
+	startTour: () => void;
+	setSteps: (steps: TourStep[]) => void;
+	steps: TourStep[];
+	isTourCompleted: boolean;
+	setIsTourCompleted: (completed: boolean) => void;
+}
+
+interface TourProviderProps {
+	children: React.ReactNode;
+	onComplete?: () => void;
+	className?: string;
+	isTourCompleted?: boolean;
+}
+
+const TourContext = createContext<TourContextType | null>(null);
+
+const PADDING = 16;
+const HIGHLIGHT_PAD = 8;
+const CONTENT_WIDTH = 300;
+const CONTENT_HEIGHT = 200;
+
+function getElementPosition(id: string) {
+	const element = document.getElementById(id);
+	if (!element) return null;
+	const rect = element.getBoundingClientRect();
+	return {
+		top: rect.top + window.scrollY,
+		left: rect.left + window.scrollX,
+		width: rect.width,
+		height: rect.height,
+	};
+}
+
+function calculateContentPosition(
+	elementPos: { top: number; left: number; width: number; height: number },
+	position: "top" | "bottom" | "left" | "right" = "bottom",
+) {
+	const viewportWidth = window.innerWidth;
+	const viewportHeight = window.innerHeight;
+
+	let left = elementPos.left;
+	let top = elementPos.top;
+
+	switch (position) {
+		case "top":
+			top = elementPos.top - CONTENT_HEIGHT - PADDING;
+			left = elementPos.left + elementPos.width / 2 - CONTENT_WIDTH / 2;
+			break;
+		case "bottom":
+			top = elementPos.top + elementPos.height + PADDING;
+			left = elementPos.left + elementPos.width / 2 - CONTENT_WIDTH / 2;
+			break;
+		case "left":
+			left = elementPos.left - CONTENT_WIDTH - PADDING;
+			top = elementPos.top + elementPos.height / 2 - CONTENT_HEIGHT / 2;
+			break;
+		case "right":
+			left = elementPos.left + elementPos.width + PADDING;
+			top = elementPos.top + elementPos.height / 2 - CONTENT_HEIGHT / 2;
+			break;
+	}
+
+	const scrollY = typeof window !== "undefined" ? window.scrollY : 0;
+
+	return {
+		top: Math.max(
+			scrollY + PADDING,
+			Math.min(top, scrollY + viewportHeight - CONTENT_HEIGHT - PADDING),
+		),
+		left: Math.max(
+			PADDING,
+			Math.min(left, viewportWidth - CONTENT_WIDTH - PADDING),
+		),
+		width: CONTENT_WIDTH,
+		height: CONTENT_HEIGHT,
+	};
+}
+
+export function TourProvider({
+	children,
+	onComplete,
+	className,
+	isTourCompleted = false,
+}: TourProviderProps) {
+	const [steps, setSteps] = useState<TourStep[]>([]);
+	const [currentStep, setCurrentStep] = useState(-1);
+	const [elementPosition, setElementPosition] = useState<{
+		top: number;
+		left: number;
+		width: number;
+		height: number;
+	} | null>(null);
+	const [isCompleted, setIsCompleted] = useState(isTourCompleted);
+
+	const updateElementPosition = useCallback(() => {
+		if (currentStep >= 0 && currentStep < steps.length) {
+			const position = getElementPosition(steps[currentStep]?.selectorId ?? "");
+			if (position) {
+				setElementPosition(position);
+			}
+		}
+	}, [currentStep, steps]);
+
+	useEffect(() => {
+		updateElementPosition();
+		window.addEventListener("resize", updateElementPosition);
+		window.addEventListener("scroll", updateElementPosition);
+
+		return () => {
+			window.removeEventListener("resize", updateElementPosition);
+			window.removeEventListener("scroll", updateElementPosition);
+		};
+	}, [updateElementPosition]);
+
+	const nextStep = useCallback(async () => {
+		setCurrentStep((prev) => {
+			if (prev >= steps.length - 1) {
+				return -1;
+			}
+			return prev + 1;
+		});
+
+		if (currentStep === steps.length - 1) {
+			setIsTourCompleted(true);
+			onComplete?.();
+		}
+	}, [steps.length, onComplete, currentStep]);
+
+	const previousStep = useCallback(() => {
+		setCurrentStep((prev) => (prev > 0 ? prev - 1 : prev));
+	}, []);
+
+	const endTour = useCallback(() => {
+		setCurrentStep(-1);
+	}, []);
+
+	const startTour = useCallback(() => {
+		if (isTourCompleted) {
+			return;
+		}
+		setCurrentStep(0);
+	}, [isTourCompleted]);
+
+	const handleClick = useCallback(
+		(e: MouseEvent) => {
+			if (
+				currentStep >= 0 &&
+				elementPosition &&
+				steps[currentStep]?.onClickWithinArea
+			) {
+				const clickX = e.clientX + window.scrollX;
+				const clickY = e.clientY + window.scrollY;
+
+				const isWithinBounds =
+					clickX >= elementPosition.left &&
+					clickX <=
+						elementPosition.left +
+							(steps[currentStep]?.width || elementPosition.width) &&
+					clickY >= elementPosition.top &&
+					clickY <=
+						elementPosition.top +
+							(steps[currentStep]?.height || elementPosition.height);
+
+				if (isWithinBounds) {
+					steps[currentStep].onClickWithinArea?.();
+				}
+			}
+		},
+		[currentStep, elementPosition, steps],
+	);
+
+	useEffect(() => {
+		window.addEventListener("click", handleClick);
+		return () => {
+			window.removeEventListener("click", handleClick);
+		};
+	}, [handleClick]);
+
+	const setIsTourCompleted = useCallback((completed: boolean) => {
+		setIsCompleted(completed);
+	}, []);
+
+	// Arrow key navigation
+	useEffect(() => {
+		if (currentStep < 0) return;
+		const handler = (e: KeyboardEvent) => {
+			if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+				e.preventDefault();
+				nextStep();
+			} else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+				e.preventDefault();
+				previousStep();
+			} else if (e.key === "Escape") {
+				e.preventDefault();
+				endTour();
+			}
+		};
+		window.addEventListener("keydown", handler);
+		return () => window.removeEventListener("keydown", handler);
+	}, [currentStep, nextStep, previousStep, endTour]);
+
+	return (
+		<TourContext.Provider
+			value={{
+				currentStep,
+				totalSteps: steps.length,
+				nextStep,
+				previousStep,
+				endTour,
+				isActive: currentStep >= 0,
+				startTour,
+				setSteps,
+				steps,
+				isTourCompleted: isCompleted,
+				setIsTourCompleted,
+			}}
+		>
+			{children}
+			<AnimatePresence>
+				{currentStep >= 0 && elementPosition && (
+					<>
+						<motion.div
+							initial={{ opacity: 0 }}
+							animate={{ opacity: 1 }}
+							exit={{ opacity: 0 }}
+							className="absolute inset-0 z-50 overflow-hidden bg-black/50"
+							style={{
+								clipPath: `polygon(
+                  0% 0%,
+                  0% 100%,
+                  100% 100%,
+                  100% 0%,
+                  ${elementPosition.left - HIGHLIGHT_PAD}px 0%,
+                  ${elementPosition.left - HIGHLIGHT_PAD}px ${elementPosition.top - HIGHLIGHT_PAD}px,
+                  ${elementPosition.left + (steps[currentStep]?.width || elementPosition.width) + HIGHLIGHT_PAD}px ${elementPosition.top - HIGHLIGHT_PAD}px,
+                  ${elementPosition.left + (steps[currentStep]?.width || elementPosition.width) + HIGHLIGHT_PAD}px ${elementPosition.top + (steps[currentStep]?.height || elementPosition.height) + HIGHLIGHT_PAD}px,
+                  ${elementPosition.left - HIGHLIGHT_PAD}px ${elementPosition.top + (steps[currentStep]?.height || elementPosition.height) + HIGHLIGHT_PAD}px,
+                  ${elementPosition.left - HIGHLIGHT_PAD}px 0%
+                )`,
+							}}
+						/>
+						<motion.div
+							initial={{ opacity: 0, scale: 0.95 }}
+							animate={{ opacity: 1, scale: 1 }}
+							exit={{ opacity: 0, scale: 0.95 }}
+							style={{
+								position: "absolute",
+								top: elementPosition.top - HIGHLIGHT_PAD,
+								left: elementPosition.left - HIGHLIGHT_PAD,
+								width: (steps[currentStep]?.width || elementPosition.width) + HIGHLIGHT_PAD * 2,
+								height: (steps[currentStep]?.height || elementPosition.height) + HIGHLIGHT_PAD * 2,
+							}}
+							className={cn(
+								"z-[100] border-2 border-muted-foreground",
+								className,
+							)}
+						/>
+
+						{/* Pulsing dot cursor */}
+						<motion.div
+							initial={{ opacity: 0 }}
+							animate={{
+								opacity: 1,
+								top: elementPosition.top + (steps[currentStep]?.height || elementPosition.height) / 2,
+								left: elementPosition.left + (steps[currentStep]?.width || elementPosition.width) / 2,
+							}}
+							exit={{ opacity: 0 }}
+							transition={{
+								type: "spring",
+								stiffness: 120,
+								damping: 20,
+								opacity: { duration: 0.2 },
+							}}
+							style={{ position: "absolute", transform: "translate(-50%, -50%)" }}
+							className="z-[101] pointer-events-none"
+						>
+							<span className="relative flex size-3">
+								<span className="absolute inline-flex size-full animate-ping rounded-full bg-primary opacity-75" />
+								<span className="relative inline-flex size-3 rounded-full bg-primary" />
+							</span>
+						</motion.div>
+
+						<motion.div
+							initial={{ opacity: 0, y: 10, top: 50, right: 50 }}
+							animate={{
+								opacity: 1,
+								y: 0,
+								top: calculateContentPosition(
+									elementPosition,
+									steps[currentStep]?.position,
+								).top,
+								left: calculateContentPosition(
+									elementPosition,
+									steps[currentStep]?.position,
+								).left,
+							}}
+							transition={{
+								duration: 0.8,
+								ease: [0.16, 1, 0.3, 1],
+								opacity: { duration: 0.4 },
+							}}
+							exit={{ opacity: 0, y: 10 }}
+							style={{
+								position: "absolute",
+								width: calculateContentPosition(
+									elementPosition,
+									steps[currentStep]?.position,
+								).width,
+							}}
+							className="bg-background relative z-[100] rounded-lg border p-4 shadow-lg"
+						>
+							<div className="text-muted-foreground absolute right-4 top-4 text-xs">
+								{currentStep + 1} / {steps.length}
+							</div>
+							<AnimatePresence mode="wait">
+								<div>
+									<motion.div
+										key={`tour-content-${currentStep}`}
+										initial={{ opacity: 0, scale: 0.95, filter: "blur(4px)" }}
+										animate={{ opacity: 1, scale: 1, filter: "blur(0px)" }}
+										exit={{ opacity: 0, scale: 0.95, filter: "blur(4px)" }}
+										className="overflow-hidden"
+										transition={{
+											duration: 0.2,
+											height: {
+												duration: 0.4,
+											},
+										}}
+									>
+										{steps[currentStep]?.content}
+									</motion.div>
+									<div className="mt-4 flex items-center justify-between">
+										{currentStep > 0 ? (
+											<button
+												onClick={previousStep}
+												className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+											>
+												<kbd className="inline-flex items-center rounded border border-border bg-muted px-1 py-0.5 font-mono text-[10px]">←</kbd>
+												Prev
+											</button>
+										) : (
+											<button
+												onClick={endTour}
+												className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+											>
+												<kbd className="inline-flex items-center rounded border border-border bg-muted px-1 py-0.5 font-mono text-[10px]">esc</kbd>
+											</button>
+										)}
+										<button
+											onClick={nextStep}
+											className="flex items-center gap-1.5 text-sm font-medium text-primary hover:text-primary/90"
+										>
+											{currentStep === steps.length - 1 ? "Finish" : "Next"}
+											<kbd className="inline-flex items-center rounded border border-border bg-muted px-1 py-0.5 font-mono text-[10px] text-muted-foreground">→</kbd>
+										</button>
+									</div>
+								</div>
+							</AnimatePresence>
+						</motion.div>
+					</>
+				)}
+			</AnimatePresence>
+		</TourContext.Provider>
+	);
+}
+
+export function useTour() {
+	const context = useContext(TourContext);
+	if (!context) {
+		throw new Error("useTour must be used within a TourProvider");
+	}
+	return context;
+}
+
+export function TourAlertDialog({
+	isOpen,
+	setIsOpen,
+}: { isOpen: boolean; setIsOpen: (isOpen: boolean) => void }) {
+	const { startTour, steps, isTourCompleted, currentStep } = useTour();
+
+	useEffect(() => {
+		if (!isOpen || isTourCompleted || steps.length === 0 || currentStep > -1) return;
+		const handler = (e: KeyboardEvent) => {
+			if (e.key === "Enter") {
+				e.preventDefault();
+				startTour();
+			} else if (e.key === "Escape") {
+				e.preventDefault();
+				setIsOpen(false);
+			}
+		};
+		window.addEventListener("keydown", handler);
+		return () => window.removeEventListener("keydown", handler);
+	}, [isOpen, isTourCompleted, steps.length, currentStep, startTour, setIsOpen]);
+
+	if (isTourCompleted || steps.length === 0 || currentStep > -1) {
+		return null;
+	}
+	const handleSkip = async () => {
+		setIsOpen(false);
+	};
+
+	return (
+		<AlertDialog open={isOpen}>
+			<AlertDialogContent className="max-w-md p-6">
+				<AlertDialogHeader className="text-center">
+					<AlertDialogTitle className="text-center text-lg font-semibold">
+						Quick tour?
+					</AlertDialogTitle>
+					<AlertDialogDescription className="text-muted-foreground text-center text-sm">
+						We&apos;ll walk you through the generator in 4 quick steps.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				<div className="mt-3 space-y-2">
+					<Button onClick={startTour} className="w-full gap-2">
+						Show me around
+						<kbd className="inline-flex items-center rounded border border-primary-foreground/20 bg-primary-foreground/10 px-1.5 py-0.5 font-mono text-[10px]">↵</kbd>
+					</Button>
+					<Button onClick={handleSkip} variant="ghost" className="w-full gap-2">
+						Skip, I&apos;ll figure it out
+						<kbd className="inline-flex items-center rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">esc</kbd>
+					</Button>
+				</div>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -1,0 +1,196 @@
+"use client"
+
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
+  size?: "default" | "sm"
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[size=default]:sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-6 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "text-lg font-semibold sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogMedia({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "mb-2 inline-flex size-16 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Action
+        data-slot="alert-dialog-action"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  variant = "outline",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Cancel
+        data-slot="alert-dialog-cancel"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/lib/tour-constants.ts
+++ b/lib/tour-constants.ts
@@ -1,0 +1,10 @@
+// shieldcn — lib/tour-constants.ts
+// Tour step IDs for the badge generator
+
+export const TOUR_STEP_IDS = {
+  URL_INPUT: "tour-url-input",
+  GLOBAL_DEFAULTS: "tour-global-defaults",
+  BADGE_GROUP: "tour-badge-group",
+  BADGE_POPOVER: "tour-badge-popover",
+  COPY_ACTIONS: "tour-copy-actions",
+}


### PR DESCRIPTION
## What

Add a 5-step interactive product tour to the badge generator page using [shadcn-tour](https://github.com/NiazMorshed2007/shadcn-tour).

## Why

New users landing on `/gen` don't always know the workflow. The tour walks them through it once, then stays out of the way.

## Steps

1. **Enter your repo** — auto-types `vercel/next.js` and hits Enter
2. **Customize the look** — highlights global defaults (variant, size, theme, mode)
3. **Your badges** — highlights the first badge group
4. **Customize each badge** — auto-clicks the first badge to open its popover
5. **Copy & go** — closes popover, scrolls to and highlights the copy/download buttons

## UX details

- **"Show me around" ⏎ / "Skip, I'll figure it out" esc** — dialog on first visit with keyboard shortcuts
- **Arrow keys** — ← prev, → next, Escape to exit during tour
- **Kbd hints** in tour step navigation
- **Pulsing dot** cursor that springs between highlighted elements
- **Highlight padding** — 8px breathing room around highlighted areas
- **Scroll-aware positioning** — tooltip stays near the highlighted element even when scrolled
- **localStorage persistence** — skipping or completing remembers the choice
- **"How to use" button** in page header to replay anytime
- **OpenPanel events** — `tour_completed` and `tour_skipped`

## Type

- [x] `feat` — New feature

## Checklist

- [x] Branch follows conventional naming
- [x] Commits follow Conventional Commits
- [x] Tested locally with `pnpm dev`
- [x] Build passes (`pnpm next build`)