### PR TITLE
feat: add agent skill for shieldcn badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,18 @@ Three icon libraries (40,000+ icons) plus custom SVG upload:
 - **Shields.io compatible** — same URL patterns for static/dynamic badges, same text encoding, shields.io JSON endpoint support
 - **Open source, never paywalled** — every badge type, every variant, every icon source is free
 
+## Agent skill
+
+Install the shieldcn skill to let AI coding agents (Claude Code, Cursor, Codex, and [40+ more](https://github.com/vercel-labs/skills#supported-agents)) add badges to your projects:
+
+```bash
+npx skills add jal-co/shieldcn
+```
+
+Once installed, ask your agent to _"add shieldcn badges to the README"_ — it knows all providers, URL patterns, and query parameters.
+
+Learn more in the [skill docs](https://shieldcn.dev/docs/skill).
+
 ## Local development
 
 ```bash

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -67,6 +67,12 @@ export function SiteFooter() {
               >
                 Generator
               </Link>
+              <Link
+                href="/docs/skill"
+                className="text-muted-foreground hover:text-foreground"
+              >
+                Agent Skill
+              </Link>
             </div>
 
             <div className="flex flex-col gap-2">

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -22,6 +22,7 @@ const docsNav: NavGroup[] = [
     title: "Getting Started",
     items: [
       { title: "Introduction", href: "/docs" },
+      { title: "Agent Skill", href: "/docs/skill" },
       { title: "API Reference", href: "/docs/api-reference" },
       { title: "Token Pool", href: "/token-pool" },
       { title: "Sponsor", href: "/sponsor" },

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "---Getting Started---",
     "index",
+    "skill",
     "---Badges---",
     "...badges",
     "---Customization---",

--- a/content/docs/skill.mdx
+++ b/content/docs/skill.mdx
@@ -1,0 +1,61 @@
+---
+title: Agent Skill
+description: Install the shieldcn agent skill to let AI coding agents add badges to your projects.
+---
+
+## What is it?
+
+The shieldcn agent skill gives AI coding agents the knowledge to add beautiful [shadcn/ui](https://ui.shadcn.com)-styled badges to README files, docs, and markdown. It works with any agent that supports the [Agent Skills](https://agentskills.io) specification — Claude Code, Cursor, Windsurf, Codex, and [40+ more](https://github.com/vercel-labs/skills#supported-agents).
+
+## Install
+
+<CodeLine language="bash" code="npx skills add jal-co/shieldcn" />
+
+This installs the `shieldcn-badges` skill to your coding agent.
+
+### Install to a specific agent
+
+<CodeLine language="bash" code="npx skills add jal-co/shieldcn -a claude-code" />
+
+<CodeLine language="bash" code="npx skills add jal-co/shieldcn -a cursor" />
+
+### Install globally (available in all projects)
+
+<CodeLine language="bash" code="npx skills add jal-co/shieldcn -g" />
+
+## Usage
+
+Once installed, ask your coding agent to add badges. The skill triggers automatically for requests like:
+
+- _"Add npm and GitHub badges to the README"_
+- _"Add a CI status badge for this repo"_
+- _"Add shieldcn badges to the docs"_
+- _"Set up a badge row with stars, license, and version"_
+
+The agent knows all shieldcn providers, URL patterns, variants, and query parameters — no manual lookup needed.
+
+## What the skill covers
+
+- **All providers** — npm, GitHub, PyPI, Crates.io, Docker Hub, Discord, Bluesky, YouTube, Codecov, and 20+ more
+- **URL patterns** — correct endpoint format for every badge type
+- **Query parameters** — variants, sizes, icons, colors, themes, split mode
+- **Markdown patterns** — proper `<img>` and `<a>` wrapping for GitHub READMEs
+- **Best practices** — centering, linking, variant selection, badge row composition
+
+## Example output
+
+An agent using this skill might produce:
+
+<CodeLine language="markdown" code={`<p align="center">
+  <a href="https://www.npmjs.com/package/your-package"><img src="https://shieldcn.dev/npm/your-package.svg" alt="npm" /></a>
+  <a href="https://github.com/you/repo/stargazers"><img src="https://shieldcn.dev/github/stars/you/repo.svg" alt="stars" /></a>
+  <a href="https://github.com/you/repo"><img src="https://shieldcn.dev/github/license/you/repo.svg" alt="license" /></a>
+</p>`} />
+
+## Learn more
+
+- [Full docs](/docs) — all badge types, interactive sandboxes, copy-paste examples
+- [API reference](/docs/api-reference) — every endpoint and query parameter
+- [Badge builder](https://shieldcn.dev) — interactive UI for composing badges
+- [GitHub repo](https://github.com/jal-co/shieldcn) — source code and contributing guide
+- [skills.sh](https://skills.sh) — the agent skills ecosystem

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -181,10 +181,33 @@ Three icon libraries with 40,000+ icons total, plus custom SVG upload.
 - Dark and light mode
 - Free, open source, MIT licensed
 
+## Agent skill
+
+Install the shieldcn agent skill to let AI coding agents add badges to projects:
+
+```bash
+npx skills add jal-co/shieldcn
+```
+
+Works with Claude Code, Cursor, Codex, Windsurf, and 40+ more agents via [skills.sh](https://skills.sh). The skill teaches agents all shieldcn providers, URL patterns, query parameters, and markdown best practices for badge rows.
+
+Install globally to use across all projects:
+
+```bash
+npx skills add jal-co/shieldcn -g
+```
+
+Install to a specific agent:
+
+```bash
+npx skills add jal-co/shieldcn -a claude-code
+```
+
 ## Links
 
 - Homepage: https://shieldcn.dev
 - Documentation: https://shieldcn.dev/docs
+- Agent Skill: https://shieldcn.dev/docs/skill
 - API Reference: https://shieldcn.dev/docs/api-reference
 - Showcase: https://shieldcn.dev/showcase
 - Badge Generator: https://shieldcn.dev/gen

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -16,10 +16,21 @@ Add a badge to any markdown file:
 
 No configuration, no API keys, no build step.
 
+## Agent skill
+
+Install the shieldcn agent skill to let AI coding agents add badges to projects:
+
+```bash
+npx skills add jal-co/shieldcn
+```
+
+Works with Claude Code, Cursor, Codex, Windsurf, and 40+ more agents via skills.sh.
+
 ## Links
 
 - Homepage: https://shieldcn.dev
 - Documentation: https://shieldcn.dev/docs
+- Agent Skill: https://shieldcn.dev/docs/skill
 - API Reference: https://shieldcn.dev/docs/api-reference
 - Showcase: https://shieldcn.dev/showcase
 - Badge Generator: https://shieldcn.dev/gen

--- a/skills/shieldcn-badges/SKILL.md
+++ b/skills/shieldcn-badges/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: shieldcn-badges
+description: Add beautiful shadcn/ui-styled README badges to projects using shieldcn. Use when adding badges, shields, or status indicators to README files, docs, or markdown. Triggers include "add badges", "add shields", "readme badges", "npm badge", "GitHub stars badge", "CI badge", "shieldcn", or any request to add project status badges to documentation.
+metadata:
+  author: jal-co
+  version: "1.0.0"
+---
+
+# shieldcn Badges
+
+Add beautiful [shadcn/ui](https://ui.shadcn.com)-styled badges to READMEs and docs using [shieldcn](https://shieldcn.dev) — a free, open-source shields.io alternative.
+
+Base URL: `https://shieldcn.dev`
+
+## Badge URL format
+
+```
+https://shieldcn.dev/{provider}/{...params}.svg     → SVG (default, for READMEs)
+https://shieldcn.dev/{provider}/{...params}.png     → PNG
+https://shieldcn.dev/{provider}/{...params}.json    → raw data
+```
+
+## Markdown pattern
+
+```md
+[![alt](https://shieldcn.dev/{provider}/{params}.svg)](https://link)
+
+<!-- or without link -->
+![alt](https://shieldcn.dev/{provider}/{params}.svg)
+```
+
+## Providers & endpoints
+
+### Package registries
+
+| Provider | Endpoint | Example |
+|----------|----------|---------|
+| npm version | `/npm/{package}` | `/npm/react` |
+| npm version (tag) | `/npm/v/{package}/{tag}` | `/npm/v/next/canary` |
+| npm downloads/wk | `/npm/dw/{package}` | `/npm/dw/react` |
+| npm downloads/mo | `/npm/dm/{package}` | `/npm/dm/react` |
+| npm downloads/yr | `/npm/dy/{package}` | `/npm/dy/react` |
+| npm total downloads | `/npm/dt/{package}` | `/npm/dt/react` |
+| npm license | `/npm/license/{package}` | `/npm/license/react` |
+| npm types | `/npm/types/{package}` | `/npm/types/react` |
+| npm dependents | `/npm/dependents/{package}` | `/npm/dependents/react` |
+| npm scoped | `/npm/v/@scope/pkg` | `/npm/v/@types/node` |
+| PyPI version | `/pypi/{package}` | `/pypi/flask` |
+| PyPI downloads/mo | `/pypi/dm/{package}` | `/pypi/dm/flask` |
+| Crates.io version | `/crates/{crate}` | `/crates/serde` |
+| Docker Hub pulls | `/docker/pulls/{image}` | `/docker/pulls/library/nginx` |
+| JSR version | `/jsr/{@scope}/{name}` | `/jsr/@std/path` |
+| Bundlephobia minzip | `/bundlephobia/minzip/{package}` | `/bundlephobia/minzip/react` |
+| Homebrew version | `/homebrew/{formula}` | `/homebrew/node` |
+| Maven version | `/maven/{groupId}/{artifactId}` | `/maven/org.apache.maven/maven-core` |
+| Packagist version | `/packagist/v/{vendor}/{package}` | `/packagist/v/laravel/framework` |
+| RubyGems version | `/rubygems/{gem}` | `/rubygems/rails` |
+| NuGet version | `/nuget/{package}` | `/nuget/Newtonsoft.Json` |
+| Pub.dev version | `/pub/{package}` | `/pub/flutter` |
+| CocoaPods version | `/cocoapods/{pod}` | `/cocoapods/Alamofire` |
+
+### GitHub
+
+Both formats work: `/github/{topic}/{owner}/{repo}` or `/github/{owner}/{repo}/{topic}`
+
+| Badge | Endpoint | Example |
+|-------|----------|---------|
+| Stars | `/github/stars/{owner}/{repo}` | `/github/stars/vercel/next.js` |
+| Forks | `/github/forks/{owner}/{repo}` | `/github/forks/vercel/next.js` |
+| License | `/github/license/{owner}/{repo}` | `/github/license/vercel/next.js` |
+| Release | `/github/release/{owner}/{repo}` | `/github/release/vercel/next.js` |
+| CI status | `/github/ci/{owner}/{repo}` | `/github/ci/vercel/next.js` |
+| Issues | `/github/issues/{owner}/{repo}` | `/github/issues/vercel/next.js` |
+| Open PRs | `/github/open-prs/{owner}/{repo}` | `/github/open-prs/vercel/next.js` |
+| Contributors | `/github/contributors/{owner}/{repo}` | `/github/contributors/vercel/next.js` |
+| Last commit | `/github/last-commit/{owner}/{repo}` | `/github/last-commit/vercel/next.js` |
+| Watchers | `/github/watchers/{owner}/{repo}` | `/github/watchers/vercel/next.js` |
+| Downloads | `/github/dt/{owner}/{repo}` | `/github/dt/vercel/next.js` |
+| Dependabot | `/github/dependabot/{owner}/{repo}` | `/github/dependabot/vercel/next.js` |
+
+CI supports `?workflow=name&branch=main` query params.
+
+### Social
+
+| Provider | Endpoint | Example |
+|----------|----------|---------|
+| Discord online | `/discord/{serverId}` | `/discord/1316199667142496307` |
+| Discord by invite | `/discord/members/{inviteCode}` | `/discord/members/nextjs` |
+| Reddit subscribers | `/reddit/subscribers/r/{subreddit}` | `/reddit/subscribers/r/reactjs` |
+| Bluesky followers | `/bluesky/followers/{handle}` | `/bluesky/followers/bsky.app` |
+| YouTube subs | `/youtube/subscribers/{channelId}` | `/youtube/subscribers/UCxxxxxx` |
+| Mastodon followers | `/mastodon/followers/{instance}/{acct}` | `/mastodon/followers/mastodon.social/Gargron` |
+| Hacker News karma | `/hackernews/{userId}` | `/hackernews/pg` |
+
+### Code quality
+
+| Provider | Endpoint | Example |
+|----------|----------|---------|
+| Codecov | `/codecov/{service}/{owner}/{repo}` | `/codecov/gh/vercel/next.js` |
+| VS Code installs | `/vscode/installs/{publisher}/{ext}` | `/vscode/installs/esbenp/prettier-vscode` |
+| WakaTime | `/wakatime/{username}` | `/wakatime/@user` |
+
+### Custom badges
+
+| Type | Endpoint | Example |
+|------|----------|---------|
+| Static | `/badge/{label}-{message}-{color}` | `/badge/build-passing-brightgreen` |
+| Dynamic JSON | `/badge/dynamic/json?url=...&query=...` | Fetch any JSON API |
+| HTTPS endpoint | `/https/{hostname}/{path}` | Proxy any JSON endpoint |
+
+## Query parameters
+
+Append to any badge URL as `?key=value&key2=value2`.
+
+| Param | Values | Default | Notes |
+|-------|--------|---------|-------|
+| `variant` | `default`, `secondary`, `outline`, `ghost`, `destructive`, `branded` | `default` | shadcn Button variant |
+| `size` | `xs`, `sm`, `default`, `lg` | `sm` | Badge size |
+| `mode` | `dark`, `light` | `dark` | Color mode |
+| `split` | `true`, `false` | `false` | Two-tone label/value split |
+| `logo` | SimpleIcons slug, `lucide:name`, `ri:Name`, `false` | auto | Icon source |
+| `logoColor` | hex (no `#`) | auto | Icon color |
+| `label` | string | auto | Override label text |
+| `color` | hex (no `#`) | — | Background color |
+| `labelColor` | hex (no `#`) | — | Label side bg (split mode) |
+| `theme` | `zinc`, `slate`, `blue`, `green`, `rose`, `orange`, `violet` | — | Color theme |
+| `font` | `inter`, `geist`, `geist-mono` | `inter` | Font family |
+| `statusDot` | `true`, `false` | auto for CI | Show status indicator dot |
+
+## Common recipes
+
+### Typical README badge row
+
+```md
+<p align="center">
+  <a href="https://www.npmjs.com/package/{pkg}"><img src="https://shieldcn.dev/npm/{pkg}.svg" alt="npm" /></a>
+  <a href="https://github.com/{owner}/{repo}/stargazers"><img src="https://shieldcn.dev/github/stars/{owner}/{repo}.svg" alt="stars" /></a>
+  <a href="https://github.com/{owner}/{repo}"><img src="https://shieldcn.dev/github/license/{owner}/{repo}.svg" alt="license" /></a>
+  <a href="https://github.com/{owner}/{repo}/actions"><img src="https://shieldcn.dev/github/ci/{owner}/{repo}.svg" alt="CI" /></a>
+</p>
+```
+
+### Secondary variant (lighter)
+
+```md
+![badge](https://shieldcn.dev/npm/react.svg?variant=secondary)
+```
+
+### Branded variant (brand-colored bg)
+
+```md
+![badge](https://shieldcn.dev/npm/react.svg?variant=branded)
+```
+
+### Split badge (two-tone)
+
+```md
+![badge](https://shieldcn.dev/npm/react.svg?split=true)
+```
+
+### Light mode
+
+```md
+![badge](https://shieldcn.dev/npm/react.svg?mode=light)
+```
+
+### Custom icon
+
+```md
+![badge](https://shieldcn.dev/npm/react.svg?logo=typescript)
+![badge](https://shieldcn.dev/github/stars/owner/repo.svg?logo=lucide:star)
+```
+
+### No icon
+
+```md
+![badge](https://shieldcn.dev/npm/react.svg?logo=false)
+```
+
+## Rules
+
+1. Always use `.svg` for markdown images (best quality, smallest size)
+2. Use `<a>` wrapper to make badges clickable links
+3. Use `<p align="center">` to center badge rows in GitHub READMEs
+4. Replace `{owner}`, `{repo}`, `{package}` with actual values — never leave placeholders
+5. Default variant (`default`) works on both light and dark GitHub themes
+6. Icons are auto-resolved per provider — only set `?logo=` to override
+7. For npm scoped packages, use the full scope: `/npm/v/@scope/package`
+8. Prefer `variant=secondary` for subtle badge rows
+9. Keep badge rows to 3–6 badges for readability
+10. Link each badge to its relevant page (npm registry, GitHub stars page, etc.)
+
+## Docs
+
+Full documentation: https://shieldcn.dev/docs
+API reference: https://shieldcn.dev/docs/api-reference
+Badge builder: https://shieldcn.dev (interactive UI)


### PR DESCRIPTION
## Summary

Adds a [skills.sh](https://skills.sh)-compatible agent skill that teaches AI coding agents how to add shieldcn badges to projects. Installable via:

```bash
npx skills add jal-co/shieldcn
```

Works with Claude Code, Cursor, Codex, Windsurf, and 40+ more agents.

## Changes

- **`skills/shieldcn-badges/SKILL.md`** — The skill itself. Covers all providers, endpoints, query params, markdown patterns, and best practices.
- **`content/docs/skill.mdx`** — Docs page at `/docs/skill` with install commands (using `<CodeLine>`), usage examples, and links.
- **`components/sidebar.tsx`** — Added "Agent Skill" under Getting Started.
- **`components/footer.tsx`** — Added "Agent Skill" to footer Product column.
- **`content/docs/meta.json`** — Added `skill` to Getting Started section.
- **`README.md`** — Added "Agent skill" section.
- **`public/llms.txt`** / **`public/llms-full.txt`** — Added skill info and docs link.

Closes #12