### PR TITLE
fix: correct generator source link

### DIFF
--- a/app/gen/page.tsx
+++ b/app/gen/page.tsx
@@ -48,7 +48,7 @@ export default function GeneratorPage() {
                   </a>
                   {" · "}
                   <a
-                    href="https://github.com/k33bs/shieldcngen"
+                    href="https://github.com/jal-co/shieldcn"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="underline underline-offset-2 hover:text-foreground"


### PR DESCRIPTION
## What

Correct the generator page GitHub source link so it points to `jal-co/shieldcn`.

## Why

The generator page was linking to the wrong GitHub repository.

Closes #

## Type

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `docs` — Documentation
- [ ] `refactor` — Code restructuring
- [ ] `perf` — Performance improvement
- [ ] `style` — Visual / CSS changes
- [ ] `chore` — Maintenance / deps
- [ ] `ci` — CI/CD changes
- [ ] `test` — Tests

## Checklist

- [x] Branch follows conventional naming (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tested locally with `pnpm dev`
- [ ] Badge renders correctly in SVG and PNG (if applicable)
- [ ] Docs updated (if adding/changing a provider or query param)

## Screenshots

N/A