### PR TITLE
ci: add badgetizr-shieldcn PR badges

### DIFF
--- a/.badgetizr.yml
+++ b/.badgetizr.yml
@@ -1,0 +1,51 @@
+# badgetizr-shieldcn — shadcn-styled PR badges
+# Powered by shieldcn (https://shieldcn.com)
+
+shieldcn:
+  variant: "default"
+  mode: "dark"
+  size: "sm"
+
+badge_wip:
+  enabled: "true"
+  settings:
+    color: "EAB308"
+    label: "WIP"
+    logo: "lucide:construction"
+
+badge_hotfix:
+  enabled: "true"
+  settings:
+    color: "EF4444"
+    label: "HOTFIX"
+    logo: "lucide:flame"
+    variant: "destructive"
+    production_branch: "main"
+
+badge_base_branch:
+  enabled: "true"
+  settings:
+    base_branch: "main"
+    color: "F97316"
+    label: "Target"
+    logo: "lucide:git-branch"
+
+badge_ci:
+  enabled: "true"
+  settings:
+    label: "Build"
+    logo: "github"
+    color: "7C3AED"
+
+badge_ready_for_approval:
+  enabled: "true"
+  settings:
+    color: "22C55E"
+    label: "Ready"
+    logo: "lucide:check-circle"
+
+badge_ticket:
+  enabled: "false"
+
+badge_dynamic:
+  enabled: "false"

--- a/.github/workflows/pr-badges.yml
+++ b/.github/workflows/pr-badges.yml
@@ -1,0 +1,22 @@
+name: PR Badges
+on:
+  pull_request:
+    types: [opened, synchronize, edited]
+
+jobs:
+  badges:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jal-co/badgetizr-shieldcn@feat/shieldcn-badges
+        with:
+          pr_id: ${{ github.event.pull_request.number }}
+          pr_destination_branch: ${{ github.event.pull_request.base.ref }}
+          pr_build_number: ${{ github.run_id }}
+          pr_build_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          configuration: .badgetizr.yml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--begin:badgetizr-shieldcn--> 
![Ready](https://shieldcn.dev/badge/Ready-22C55E.svg?variant=default&mode=dark&size=sm&logo=lucide:check-circle&color=22C55E)  [![CI 24976763040](https://shieldcn.dev/badge/Build-24976763040-7C3AED.svg?variant=default&mode=dark&size=sm&logo=github&color=7C3AED)](https://github.com/jal-co/shieldcn/actions/runs/24976763040)
<!--end:badgetizr-shieldcn-->
## What

Adds automatic shadcn-styled badges to pull requests via [badgetizr-shieldcn](https://github.com/jal-co/badgetizr-shieldcn).

## Badges enabled

- [x] **WIP** — detects "WIP" in PR title
- [x] **Hotfix** — detects hotfix PRs targeting main
- [x] **Branch** — shows target branch when not main
- [x] **CI** — build status with clickable link
- [x] **Ready** — all checkboxes completed

## Test

This PR itself should trigger the workflow and inject badges into this description.