### PR TITLE
chore: add Ko-fi and Open Collective to funding

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,3 @@
 github: jal-co
+ko_fi: jalco
+open_collective: shieldcn


### PR DESCRIPTION
<!--begin:badgetizr-shieldcn--> 
![Ready](https://shieldcn.dev/badge/Ready-22C55E.svg?variant=default&mode=dark&size=sm&logo=lucide:check-circle&color=22C55E)  [![CI 24976811180](https://shieldcn.dev/badge/Build-24976811180-7C3AED.svg?variant=default&mode=dark&size=sm&logo=github&color=7C3AED)](https://github.com/jal-co/shieldcn/actions/runs/24976811180)
<!--end:badgetizr-shieldcn-->
Adds Ko-fi (jalco) and Open Collective (shieldcn) as funding sources alongside GitHub Sponsors.