### PR TITLE
fix: remove Lucide icon support due to Satori stroke rendering bug

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ shieldcn is a standalone Next.js app that serves styled SVG/PNG badge images for
 
 - **Badge renderer** (`lib/badges/render.tsx`) — React components → SVG via Satori. Uses Inter Medium font. Every badge goes through one `resolve()` function then one `renderSingle()` or `renderSplit()` function. No variant-specific render paths.
 - **Button tokens** (`lib/badges/button-tokens.ts`) — Exact shadcn Button design tokens (bg, fg, border per variant) resolved to hex values for both dark and light mode.
-- **Icon resolution** (`lib/badges/simple-icons.ts`) — Three sources: SimpleIcons (2400+), Lucide (1900+), React Icons (40,000+). Prefix convention: bare slug = SimpleIcons, `lucide:name` = Lucide, `ri:ComponentName` = React Icons.
+- **Icon resolution** (`lib/badges/simple-icons.ts`) — Two sources: SimpleIcons (2400+) and React Icons (40,000+). Prefix convention: bare slug = SimpleIcons, `ri:ComponentName` = React Icons.
 - **Data providers** (`lib/providers/`) — npm, GitHub, Discord, Reddit, static badges, dynamic JSON, HTTPS endpoint, memo badges. Each returns `{ label, value, color?, link? }`.
 - **Token pool** (`lib/token-pool.ts`) — GitHub OAuth token pool stored in Postgres. Distributes API requests across many user-donated tokens to stay under rate limits. Inspired by shields.io.
 - **Route handler** (`app/[...slug]/route.ts`) — Single catch-all that parses URLs, fetches data, resolves icons/colors/variants, renders SVG/PNG/JSON.
@@ -67,7 +67,7 @@ shieldcn is a standalone Next.js app that serves styled SVG/PNG badge images for
 | `theme` | `zinc`, `slate`, `blue`, `green`, `rose`, `orange`, `violet`, `purple`, `cyan`, `emerald` | — |
 | `split` | `true`, `false` | `false` |
 | `statusDot` | `true`, `false` | auto for CI |
-| `logo` | SimpleIcons slug, `lucide:name`, `ri:Name`, `data:image/svg+xml;base64,...`, `false` | auto |
+| `logo` | SimpleIcons slug, `ri:Name`, `data:image/svg+xml;base64,...`, `false` | auto |
 | `logoColor` | hex without # | auto |
 | `color` | hex without # | — |
 | `labelColor` | hex without # | — |

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Every badge supports shadcn Button variants and sizes:
 Three icon libraries (40,000+ icons) plus custom SVG upload:
 
 - **[Simple Icons](https://simpleicons.org)** — `?logo=react`
-- **[Lucide](https://lucide.dev/icons)** — `?logo=lucide:star`
+- **[React Icons](https://react-icons.github.io/react-icons/)** — `?logo=ri:GoStarFill`
 - **[React Icons](https://react-icons.github.io/react-icons/)** — `?logo=ri:FaReact`
 - **Custom SVG** — `?logo=data:image/svg+xml;base64,...` — upload any SVG icon via the Badge Builder or encode it yourself
 

--- a/app/[...slug]/route.ts
+++ b/app/[...slug]/route.ts
@@ -774,12 +774,12 @@ async function fetchBadgeData(
 
 /**
  * Map a provider/badge combination to a SimpleIcons slug and optional
- * Lucide icon name for the default icon.
+ * React Icons name for the default icon.
  *
- * Returns { simpleIcon, lucide } — one or both may be set.
- * simpleIcon is tried first, lucide is fallback.
+ * Returns { simpleIcon, reactIcon } — one or both may be set.
+ * simpleIcon is tried first, reactIcon is fallback.
  */
-function getDefaultLogoSlug(segments: string[]): { simpleIcon?: string; lucide?: string; reactIcon?: string } | null {
+function getDefaultLogoSlug(segments: string[]): { simpleIcon?: string; reactIcon?: string } | null {
   const provider = segments[0]
 
   // Static / dynamic badges have no default icon
@@ -792,7 +792,7 @@ function getDefaultLogoSlug(segments: string[]): { simpleIcon?: string; lucide?:
   if (provider === "docker") return { simpleIcon: "docker" }
   if (provider === "bluesky") return { simpleIcon: "bluesky" }
   if (provider === "jsr") return { simpleIcon: "jsr" }
-  if (provider === "bundlephobia") return { lucide: "package" }
+  if (provider === "bundlephobia") return { reactIcon: "GoPackage" }
   if (provider === "youtube") return { simpleIcon: "youtube" }
   if (provider === "vscode") return { simpleIcon: "visualstudiocode" }
   if (provider === "opencollective") return { simpleIcon: "opencollective" }
@@ -820,16 +820,16 @@ function getDefaultLogoSlug(segments: string[]): { simpleIcon?: string; lucide?:
       "last-commit","assets-dl","dt","dependents-repo","dependents-pkg","dependabot"])
     const topic = knownTopics.has(rest[0]) ? rest[0] : rest[2]
 
-    if (topic === "stars") return { lucide: "star" }
-    if (topic === "forks") return { lucide: "git-fork" }
-    if (topic === "release" || topic === "tag") return { lucide: "tag" }
+    if (topic === "stars") return { reactIcon: "GoStarFill" }
+    if (topic === "forks") return { reactIcon: "GoRepoForked" }
+    if (topic === "release" || topic === "tag") return { reactIcon: "GoTag" }
     if (topic === "ci" || topic === "checks") return null // uses status dot
     if (topic === "license") return { reactIcon: "FaBalanceScale" }
-    if (topic === "contributors") return { lucide: "users" }
-    if (topic === "issues" || topic === "open-issues" || topic === "closed-issues" || topic === "label-issues") return { lucide: "circle-dot" }
-    if (topic === "prs" || topic === "open-prs" || topic === "closed-prs" || topic === "merged-prs") return { lucide: "git-pull-request" }
-    if (topic === "commits" || topic === "last-commit") return { lucide: "git-commit-horizontal" }
-    if (topic === "assets-dl" || topic === "dt") return { lucide: "download" }
+    if (topic === "contributors") return { reactIcon: "GoPeople" }
+    if (topic === "issues" || topic === "open-issues" || topic === "closed-issues" || topic === "label-issues") return { reactIcon: "GoIssueDraft" }
+    if (topic === "prs" || topic === "open-prs" || topic === "closed-prs" || topic === "merged-prs") return { reactIcon: "GoGitPullRequest" }
+    if (topic === "commits" || topic === "last-commit") return { reactIcon: "GoGitCommit" }
+    if (topic === "assets-dl" || topic === "dt") return { reactIcon: "GoDownload" }
     return { simpleIcon: "github" }
   }
 
@@ -958,7 +958,7 @@ export async function GET(
       }
     }
   } else if (logoParam && logoParam !== "true") {
-    // Custom icon: SimpleIcons slug or lucide:name
+    // Custom icon: SimpleIcons slug or ri:Name
     const si = await getSimpleIcon(logoParam, logoColor)
     if (si) {
       iconPath = si.icon.path
@@ -987,10 +987,9 @@ export async function GET(
     // Default provider icon
     const defaultLogo = getDefaultLogoSlug(cleanSegments)
     if (defaultLogo) {
-      // Try sources in order: SimpleIcons > Lucide > React Icons
+      // Try sources in order: SimpleIcons > React Icons
       const sources = [
         defaultLogo.simpleIcon,
-        defaultLogo.lucide ? `lucide:${defaultLogo.lucide}` : null,
         defaultLogo.reactIcon ? `ri:${defaultLogo.reactIcon}` : null,
       ].filter(Boolean) as string[]
 

--- a/app/gen/generator-client.tsx
+++ b/app/gen/generator-client.tsx
@@ -825,7 +825,7 @@ function BadgeItem({
                     Logo
                   </Label>
                   <Input
-                    placeholder="slug or lucide:name"
+                    placeholder="slug or ri:Name"
                     value={
                       typeof badge.overrides.logo === "string" && !String(badge.overrides.logo).startsWith("data:")
                         ? badge.overrides.logo

--- a/components/badge-modal.tsx
+++ b/components/badge-modal.tsx
@@ -206,7 +206,7 @@ export function BadgeModal({
                 <Input
                   value={logo.startsWith("data:") ? "" : logo}
                   onChange={(e) => setLogo(e.target.value)}
-                  placeholder="slug or lucide:name"
+                  placeholder="slug or ri:Name"
                   className="h-8 text-xs"
                 />
                 <SvgIconUpload value={logo} onChange={setLogo} className="w-full" />

--- a/components/logo-picker.tsx
+++ b/components/logo-picker.tsx
@@ -44,13 +44,13 @@ const POPULAR_ICONS = [
   { value: "vercel", label: "Vercel", group: "Popular" },
   { value: "nextdotjs", label: "Next.js", group: "Popular" },
   { value: "tailwindcss", label: "Tailwind CSS", group: "Popular" },
-  // Popular Lucide
-  { value: "lucide:star", label: "Star", group: "Lucide" },
-  { value: "lucide:heart", label: "Heart", group: "Lucide" },
-  { value: "lucide:check", label: "Check", group: "Lucide" },
-  { value: "lucide:download", label: "Download", group: "Lucide" },
-  { value: "lucide:rocket", label: "Rocket", group: "Lucide" },
-  { value: "lucide:zap", label: "Zap", group: "Lucide" },
+  // Popular React Icons
+  { value: "ri:GoStarFill", label: "Star", group: "React Icons" },
+  { value: "ri:GoHeartFill", label: "Heart", group: "React Icons" },
+  { value: "ri:GoCheckFill", label: "Check", group: "React Icons" },
+  { value: "ri:GoDownload", label: "Download", group: "React Icons" },
+  { value: "ri:GoRocket", label: "Rocket", group: "React Icons" },
+  { value: "ri:GoZap", label: "Zap", group: "React Icons" },
 ]
 
 interface LogoPickerProps {
@@ -164,7 +164,7 @@ export function LogoPicker({ value, onChange }: LogoPickerProps) {
               // Popular icons mode
               <>
                 <div className="px-3 py-2 text-[10px] text-muted-foreground">
-                  Type to search 5,000+ icons from SimpleIcons & Lucide
+                  Type to search 40,000+ icons from SimpleIcons & React Icons
                 </div>
                 <CommandSeparator />
                 {Array.from(popularGroups.entries()).map(([group, opts]) => (

--- a/content/docs/api-reference.mdx
+++ b/content/docs/api-reference.mdx
@@ -118,7 +118,7 @@ description: Complete URL specification, query parameters, and response formats.
       name: "logo",
       type: "string | false",
       default: "auto",
-      description: "SimpleIcons slug (e.g. react, typescript), Lucide icon (e.g. lucide:star), React Icons (e.g. ri:FaReact), a base64 SVG data URI (data:image/svg+xml;base64,...) for custom icons, or false to hide.",
+      description: "SimpleIcons slug (e.g. react, typescript), React Icons (e.g. ri:FaReact, ri:GoStarFill), a base64 SVG data URI (data:image/svg+xml;base64,...) for custom icons, or false to hide.",
     },
     {
       name: "logoColor",

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -58,10 +58,10 @@ Every badge supports shadcn Button variants:
 
 ## Icons
 
-Badges auto-detect icons per provider. Override with any [Simple Icons](https://simpleicons.org) slug or [Lucide](https://lucide.dev/icons) icon:
+Badges auto-detect icons per provider. Override with any [Simple Icons](https://simpleicons.org) slug or [React Icons](https://react-icons.github.io/react-icons/) component name:
 
 <CodeLine language="markdown" code="![react](https://shieldcn.dev/npm/react.svg?logo=react)" />
-<CodeLine language="markdown" code="![star](https://shieldcn.dev/badge/stars-42-blue.svg?logo=lucide:star)" />
+<CodeLine language="markdown" code="![star](https://shieldcn.dev/badge/stars-42-blue.svg?logo=ri:GoStarFill)" />
 <CodeLine language="markdown" code="![no icon](https://shieldcn.dev/npm/react.svg?logo=false)" />
 
 ## Response formats

--- a/lib/badges/render.tsx
+++ b/lib/badges/render.tsx
@@ -312,17 +312,6 @@ function IconEl({ r }: { r: ResolvedBadge }) {
   const vb = r.iconViewBox || "0 0 16 16"
   const color = r.iconFill || r.iconColor
 
-  if (r.iconFillRule === "__lucide__") {
-    return (
-      <svg viewBox={vb} width={r.iconSize} height={r.iconSize}
-        fill="none"
-        style={{ flexShrink: 0 }}>
-        <path d={r.icon} fill="none" stroke={color} strokeWidth="2"
-          strokeLinecap="round" strokeLinejoin="round" />
-      </svg>
-    )
-  }
-
   const fr = r.iconFillRule as "nonzero" | "evenodd" | undefined
   return (
     <svg viewBox={vb} width={r.iconSize} height={r.iconSize} style={{ flexShrink: 0 }}>

--- a/lib/badges/simple-icons.ts
+++ b/lib/badges/simple-icons.ts
@@ -4,7 +4,7 @@
  *
  * Icon resolution for badges. Supports:
  * - SimpleIcons slugs: ?logo=react, ?logo=typescript
- * - Lucide icons: ?logo=lucide:star, ?logo=lucide:github
+ * - React Icons: ?logo=ri:FaReact, ?logo=ri:MdHome
  *
  * Returns SVG path data for inline rendering in badge SVGs.
  */
@@ -12,20 +12,15 @@
 import type { IconData } from "./icons"
 
 /**
- * Look up an icon by slug. Supports SimpleIcons and Lucide.
+ * Look up an icon by slug. Supports SimpleIcons and React Icons.
  *
- * @param slug - "react" (SimpleIcons) or "lucide:star" (Lucide)
+ * @param slug - "react" (SimpleIcons) or "ri:FaReact" (React Icons)
  * @param logoColor - optional override color
  */
 export async function getSimpleIcon(
   slug: string,
   logoColor?: string
 ): Promise<{ icon: IconData; defaultColor: string } | null> {
-  // Lucide icons: ?logo=lucide:icon-name
-  if (slug.startsWith("lucide:")) {
-    return getLucideIcon(slug.slice(7))
-  }
-
   // React Icons: ?logo=ri:FaReact or ?logo=ri:AiFillAccountBook
   if (slug.startsWith("ri:")) {
     return getReactIcon(slug.slice(3))
@@ -58,81 +53,6 @@ async function getSimpleIconBySlug(
         path: icon.path,
       },
       defaultColor: icon.hex,
-    }
-  } catch {
-    return null
-  }
-}
-
-/**
- * Look up a Lucide icon by name.
- *
- * Lucide icons are stroke-based SVGs. We extract all `d` attributes from
- * path/circle/line/polyline/rect elements and combine them into a single
- * compound path string that Satori can render as a single <path> element.
- *
- * Since Lucide icons are stroke-based (not filled), we mark them with
- * fillRule="__lucide__" so the renderer can apply stroke instead of fill.
- */
-async function getLucideIcon(
-  name: string
-): Promise<{ icon: IconData; defaultColor: string } | null> {
-  try {
-    const pascalName = name
-      .split("-")
-      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-      .join("")
-
-    const lucide = await import("lucide-static")
-    const svgString = (lucide as unknown as Record<string, string>)[pascalName]
-
-    if (!svgString) return null
-
-    // Extract all d="..." attributes from path elements
-    const pathDs: string[] = []
-    const pathRegex = /d="([^"]+)"/g
-    let match: RegExpExecArray | null
-    while ((match = pathRegex.exec(svgString)) !== null) {
-      pathDs.push(match[1])
-    }
-
-    // Also handle <circle cx="X" cy="Y" r="R" /> → convert to path
-    const circleRegex = /<circle\s+cx="([^"]+)"\s+cy="([^"]+)"\s+r="([^"]+)"/g
-    while ((match = circleRegex.exec(svgString)) !== null) {
-      const cx = parseFloat(match[1])
-      const cy = parseFloat(match[2])
-      const r = parseFloat(match[3])
-      // Circle as two arcs
-      pathDs.push(`M${cx - r},${cy}a${r},${r} 0 1,0 ${r * 2},0a${r},${r} 0 1,0 -${r * 2},0`)
-    }
-
-    // Also handle <line x1 y1 x2 y2 />
-    const lineRegex = /<line\s+x1="([^"]+)"\s+y1="([^"]+)"\s+x2="([^"]+)"\s+y2="([^"]+)"/g
-    while ((match = lineRegex.exec(svgString)) !== null) {
-      pathDs.push(`M${match[1]},${match[2]}L${match[3]},${match[4]}`)
-    }
-
-    // Also handle <polyline points="..." />
-    const polylineRegex = /points="([^"]+)"/g
-    while ((match = polylineRegex.exec(svgString)) !== null) {
-      const pts = match[1].trim().split(/\s+/)
-      if (pts.length >= 2) {
-        pathDs.push("M" + pts.join("L"))
-      }
-    }
-
-    if (pathDs.length === 0) return null
-
-    // Combine all paths into one compound path
-    const combinedPath = pathDs.join(" ")
-
-    return {
-      icon: {
-        viewBox: "0 0 24 24",
-        path: combinedPath,
-        fillRule: "__lucide__",
-      },
-      defaultColor: "currentColor",
     }
   } catch {
     return null
@@ -251,8 +171,7 @@ async function getReactIcon(
       icon: {
         viewBox,
         path: pathDs.join(" "),
-        // Stroke-based icons (Feather/fi) use __lucide__ marker for stroke rendering
-        fillRule: isStroke ? "__lucide__" : undefined,
+        fillRule: undefined,
       },
       defaultColor: "currentColor",
     }

--- a/lib/badges/svg-parser.ts
+++ b/lib/badges/svg-parser.ts
@@ -29,7 +29,7 @@ export function parseSvg(svg: string): ParsedSvg | null {
   const vbMatch = svg.match(/viewBox="([^"]+)"/)
   const viewBox = vbMatch ? vbMatch[1] : inferViewBox(svg)
 
-  // Detect stroke-based SVGs (like Feather/Lucide icons)
+  // Detect stroke-based SVGs
   const isStroke =
     (svg.includes('fill="none"') || svg.includes("fill='none'")) &&
     (svg.includes('stroke="currentColor"') || svg.includes("stroke="))
@@ -138,7 +138,7 @@ export function parseSvg(svg: string): ParsedSvg | null {
     icon: {
       viewBox,
       path: pathDs.join(" "),
-      fillRule: isStroke ? "__lucide__" : undefined,
+      fillRule: undefined,
     },
     isStroke,
   }

--- a/lib/gen/brands.ts
+++ b/lib/gen/brands.ts
@@ -90,7 +90,7 @@ export const BRANDS: Record<string, Brand> = {
   firebase: { slug: 'firebase', color: 'DD2C00', label: 'Firebase' },
   '@firebase/app': { slug: 'firebase', color: 'DD2C00', label: 'Firebase' },
   convex: { slug: 'convex', color: 'EE342F', label: 'Convex' },
-  'better-auth': { slug: 'lucide:lock-keyhole', color: '000000', label: 'Better Auth' },
+  'better-auth': { slug: 'ri:RiShieldKeyholeFill', color: '000000', label: 'Better Auth' },
 
   // Payment
   stripe: { slug: 'stripe', color: '635BFF', label: 'Stripe' },

--- a/lib/showcase-data.ts
+++ b/lib/showcase-data.ts
@@ -241,7 +241,7 @@ export const categories: Category[] = [
       dynamicBadge("Deprecated", "lifecycle", "/badge/status-deprecated-red.svg?variant=destructive", "Deprecated badge — this project is no longer maintained."),
       dynamicBadge("Experimental", "lifecycle", "/badge/status-experimental-7C3AED.svg?variant=secondary", "Experimental badge — exploring new ideas, not production-ready."),
       dynamicBadge("Actively Maintained", "maintenance", "/badge/maintained-yes-brightgreen.svg?variant=secondary", "Signal that the project is actively maintained."),
-      dynamicBadge("Contributions Welcome", "community", "/badge/contributions-welcome-brightgreen.svg?variant=secondary&logo=lucide:heart-handshake", "Invite contributors with a friendly badge."),
+      dynamicBadge("Contributions Welcome", "community", "/badge/contributions-welcome-brightgreen.svg?variant=secondary&logo=ri:GoHeartFill", "Invite contributors with a friendly badge."),
       dynamicBadge("Semantic Versioning", "standards", "/badge/semver-2.0.0-blue.svg?variant=outline", "Indicate that the project follows semantic versioning."),
       dynamicBadge("Conventional Commits", "standards", "/badge/Conventional%20Commits-FE5196.svg?logo=conventionalcommits&logoColor=fff&variant=branded", "Show that your project follows the Conventional Commits spec."),
     ],
@@ -263,7 +263,7 @@ export const categories: Category[] = [
       dynamicBadge("Sponsor This Project", "funding", "/badge/%E2%9D%A4%EF%B8%8F%20Sponsor-this%20project-FF69B4.svg?variant=secondary", "Sponsorship call-to-action badge."),
       dynamicBadge("Made with Love", "meta", "/badge/made%20with-%E2%9D%A4-red.svg", "The classic 'made with love' badge."),
       dynamicBadge("Ask Me Anything", "community", "/badge/Ask%20me-anything-blue.svg?variant=secondary", "Open Q&A signal for personal repos and profiles."),
-      dynamicBadge("Cross Platform", "compatibility", "/badge/cross-platform-brightgreen.svg?variant=outline&logo=lucide:monitor-smartphone", "Cross-platform support badge with a device icon."),
+      dynamicBadge("Cross Platform", "compatibility", "/badge/cross-platform-brightgreen.svg?variant=outline&logo=ri:GoDeviceDesktop", "Cross-platform support badge with a device icon."),
     ],
   },
   {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "*.{ts,tsx}": "eslint --no-warn-ignored --max-warnings 0"
   },
   "dependencies": {
+    "@davestewart/outliner": "^1.2.0",
     "@openpanel/nextjs": "^1.5.0",
     "@resvg/resvg-wasm": "^2.6.2",
     "@types/mdx": "^2.0.13",
@@ -26,7 +27,6 @@
     "jsonpath-plus": "^10.4.0",
     "lru-cache": "^11.3.5",
     "lucide-react": "^1.8.0",
-    "lucide-static": "^1.8.0",
     "motion": "^12.38.0",
     "next": "16.2.4",
     "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@davestewart/outliner':
+        specifier: ^1.2.0
+        version: 1.2.0
       '@openpanel/nextjs':
         specifier: ^1.5.0
         version: 1.5.0(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -47,9 +50,6 @@ importers:
       lucide-react:
         specifier: ^1.8.0
         version: 1.8.0(react@19.2.4)
-      lucide-static:
-        specifier: ^1.8.0
-        version: 1.8.0
       motion:
         specifier: ^12.38.0
         version: 12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -242,6 +242,17 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@colors/colors@1.5.0':
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
+
+  '@danmarshall/jscad-typings@1.0.0':
+    resolution: {integrity: sha512-MGGIGDItK2UQSsz7yTrXErQXDAFXR3UPxyQ7WZ5RHOwnv60CBXjmkJlXYMYPkSvo+7fUuQL2/ODcvECtc/fi9g==}
+
+  '@davestewart/outliner@1.2.0':
+    resolution: {integrity: sha512-x9cz5u1629DQTf6TC2my9ArCB/9TToZnER9HuaT8QzqHh/2DKsh9VlOsoa6MXqLNXhLItV2ls3x7MKROaLa83A==}
+    hasBin: true
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -1794,6 +1805,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/bezier-js@0.0.6':
+    resolution: {integrity: sha512-kXsAlt8e8N6zt9R6LcMYWB1HkBw3q2g+M9BdI/UE+s4agIONuIscQaRCoInH22+Jas3rw8yLUehL2InaZjyNSA==}
+
   '@types/css-font-loading-module@0.0.7':
     resolution: {integrity: sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==}
 
@@ -1826,6 +1840,15 @@ packages:
 
   '@types/node@20.19.39':
     resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
+
+  '@types/node@7.10.14':
+    resolution: {integrity: sha512-29GS75BE8asnTno3yB6ubOJOO0FboExEqNJy4bpz0GSmW/8wPTNL4h9h63c6s1uTrOopCmJYe/4yJLh5r92ZUA==}
+
+  '@types/opentype.js@0.7.2':
+    resolution: {integrity: sha512-Riz6WyBUBEFs7YqSsJya3SbDHJZ6BmMkY7bzNoue6rtwj+RNilLc+mgOX/eJ0Y0asq16FSU6DatBeOg8ZMy2UQ==}
+
+  '@types/pdfkit@0.7.36':
+    resolution: {integrity: sha512-9eRA6MuW+n78yU3HhoIrDxjyAX2++B5MpLDYqHOnaRTquCw+5sYXT+QN8E1eSaxvNUwlRfU3tOm4UzTeGWmBqg==}
 
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
@@ -2032,6 +2055,10 @@ packages:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
@@ -2043,6 +2070,10 @@ packages:
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
+
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -2133,6 +2164,13 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bezier-js@2.6.1:
+    resolution: {integrity: sha512-jelZM33eNzcZ9snJ/5HqJLw3IzXvA8RFcBjkdOB8SDYyOvW8Y2tTosojAiBTnD1MhbHoWUYNbxUXxBl61TxbRg==}
+
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -2193,6 +2231,17 @@ packages:
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.2.0:
+    resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
+    engines: {node: '>=20.18.1'}
+
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
@@ -2204,12 +2253,24 @@ packages:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
 
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+    engines: {node: 10.* || >= 12.*}
+
   cli-truncate@5.2.0:
     resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
     engines: {node: '>=20'}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  clone@1.0.4:
+    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
+    engines: {node: '>=0.8'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -2233,6 +2294,10 @@ packages:
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  colors@1.4.0:
+    resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
+    engines: {node: '>=0.1.90'}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -2393,8 +2458,14 @@ packages:
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
 
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
@@ -2406,6 +2477,10 @@ packages:
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   environment@1.1.0:
@@ -2800,6 +2875,10 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-east-asian-width@1.5.0:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
     engines: {node: '>=18'}
@@ -2852,6 +2931,9 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  graham_scan@1.0.5:
+    resolution: {integrity: sha512-471KIBS1jOrAHpEStAbOjYI5U7MGBSyqy+wIEnvRYaFDNmpUUhbDZWLRsCSh/OnlY0dCg0NaDyN/2XLoypgIfA==}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -2920,10 +3002,17 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2966,6 +3055,10 @@ packages:
     resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
     engines: {node: '>= 0.4'}
 
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
   is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
@@ -2999,6 +3092,10 @@ packages:
   is-finalizationregistry@1.1.1:
     resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
     engines: {node: '>= 0.4'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-fullwidth-code-point@5.1.0:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
@@ -3128,6 +3225,9 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  kdbush@2.0.1:
+    resolution: {integrity: sha512-9KqSdmWCkBIisFIGclT0FRagKhI7IVbMyUjsxCFG0Ly1Dg6whlxJ7b9lrq8ifk3X/fGeJzok1R75LQfZTfA5zQ==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -3137,6 +3237,10 @@ packages:
   language-tags@1.0.9:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
+
+  left-pad@1.3.0:
+    resolution: {integrity: sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==}
+    deprecated: use String.prototype.padStart()
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -3258,11 +3362,11 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  lucide-static@1.8.0:
-    resolution: {integrity: sha512-eQJCJuDg3tyQrjP0PwD5eIA4ePd5CMdxkrfyqk3iUQA4VOtsJ0v5T6IBJ5UyR3SYHzUn8HOAEL+I+SLVnOJNIA==}
-
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  makerjs@0.17.6:
+    resolution: {integrity: sha512-06rZSAK/Sh4YhP+iX4F21v3WHHZwpXJGJrwdlPfDLSyHQAhnAPudnZHDw+ntWxmehVmHRmFP5/Uxlp+3oowl2g==}
 
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
@@ -3529,6 +3633,10 @@ packages:
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
@@ -3623,6 +3731,12 @@ packages:
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -3795,6 +3909,10 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
@@ -3854,6 +3972,10 @@ packages:
   remark@15.0.1:
     resolution: {integrity: sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
@@ -3903,6 +4025,9 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   satori@0.26.0:
     resolution: {integrity: sha512-tkMFrfIs3l2mQ2JEcyW0ADTy3zGggFRFzi6Ef8YozQSFsFKEqaSO1Y8F9wJg4//PJGQauMalHGTUEkPrFwhVPA==}
@@ -4013,6 +4138,10 @@ packages:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
@@ -4049,6 +4178,10 @@ packages:
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
@@ -4187,6 +4320,10 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
+
   unicode-trie@2.0.0:
     resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
@@ -4266,6 +4403,15 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -4291,6 +4437,10 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
@@ -4299,6 +4449,10 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -4306,6 +4460,14 @@ packages:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -4454,6 +4616,21 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@colors/colors@1.5.0':
+    optional: true
+
+  '@danmarshall/jscad-typings@1.0.0': {}
+
+  '@davestewart/outliner@1.2.0':
+    dependencies:
+      cheerio: 1.2.0
+      chokidar: 3.6.0
+      cli-table3: 0.6.5
+      colors: 1.4.0
+      left-pad: 1.3.0
+      makerjs: 0.17.6
+      yargs: 17.7.2
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -5848,6 +6025,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/bezier-js@0.0.6': {}
+
   '@types/css-font-loading-module@0.0.7': {}
 
   '@types/debug@4.1.13':
@@ -5879,6 +6058,14 @@ snapshots:
   '@types/node@20.19.39':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/node@7.10.14': {}
+
+  '@types/opentype.js@0.7.2': {}
+
+  '@types/pdfkit@0.7.36':
+    dependencies:
+      '@types/node': 20.19.39
 
   '@types/pg@8.20.0':
     dependencies:
@@ -6073,6 +6260,8 @@ snapshots:
     dependencies:
       environment: 1.1.0
 
+  ansi-regex@5.0.1: {}
+
   ansi-regex@6.2.2: {}
 
   ansi-styles@4.3.0:
@@ -6080,6 +6269,11 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@6.2.3: {}
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
 
   argparse@2.0.1: {}
 
@@ -6182,6 +6376,10 @@ snapshots:
 
   baseline-browser-mapping@2.10.21: {}
 
+  bezier-js@2.6.1: {}
+
+  binary-extensions@2.3.0: {}
+
   boolbase@1.0.0: {}
 
   brace-expansion@1.1.14:
@@ -6243,6 +6441,41 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.2.0:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.1.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.25.0
+      whatwg-mimetype: 4.0.0
+
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
@@ -6255,12 +6488,26 @@ snapshots:
     dependencies:
       restore-cursor: 5.1.0
 
+  cli-table3@0.6.5:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
+
   cli-truncate@5.2.0:
     dependencies:
       slice-ansi: 8.0.0
       string-width: 8.2.0
 
   client-only@0.0.1: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  clone@1.0.4: {}
 
   clsx@2.1.1: {}
 
@@ -6285,6 +6532,8 @@ snapshots:
   color-name@1.1.4: {}
 
   colorette@2.0.20: {}
+
+  colors@1.4.0: {}
 
   comma-separated-tokens@2.0.3: {}
 
@@ -6436,7 +6685,14 @@ snapshots:
 
   emoji-regex@10.6.0: {}
 
+  emoji-regex@8.0.0: {}
+
   emoji-regex@9.2.2: {}
+
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
 
   enhanced-resolve@5.20.1:
     dependencies:
@@ -6446,6 +6702,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   environment@1.1.0: {}
 
@@ -7015,6 +7273,8 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-caller-file@2.0.5: {}
+
   get-east-asian-width@1.5.0: {}
 
   get-intrinsic@1.3.0:
@@ -7069,6 +7329,8 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  graham_scan@1.0.5: {}
 
   has-bigints@1.1.0: {}
 
@@ -7210,7 +7472,18 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   husky@9.1.7: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
@@ -7256,6 +7529,10 @@ snapshots:
     dependencies:
       has-bigints: 1.1.0
 
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
+
   is-boolean-object@1.2.2:
     dependencies:
       call-bound: 1.0.4
@@ -7289,6 +7566,8 @@ snapshots:
   is-finalizationregistry@1.1.1:
     dependencies:
       call-bound: 1.0.4
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-fullwidth-code-point@5.1.0:
     dependencies:
@@ -7410,6 +7689,8 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  kdbush@2.0.1: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -7419,6 +7700,8 @@ snapshots:
   language-tags@1.0.9:
     dependencies:
       language-subtag-registry: 0.3.23
+
+  left-pad@1.3.0: {}
 
   levn@0.4.1:
     dependencies:
@@ -7527,11 +7810,21 @@ snapshots:
     dependencies:
       react: 19.2.4
 
-  lucide-static@1.8.0: {}
-
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  makerjs@0.17.6:
+    dependencies:
+      '@danmarshall/jscad-typings': 1.0.0
+      '@types/bezier-js': 0.0.6
+      '@types/node': 7.10.14
+      '@types/opentype.js': 0.7.2
+      '@types/pdfkit': 0.7.36
+      bezier-js: 2.6.1
+      clone: 1.0.4
+      graham_scan: 1.0.5
+      kdbush: 2.0.1
 
   markdown-extensions@2.0.0: {}
 
@@ -8051,6 +8344,8 @@ snapshots:
 
   node-releases@2.0.38: {}
 
+  normalize-path@3.0.0: {}
+
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
@@ -8159,6 +8454,15 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.3.0
 
   parse5@7.3.0:
     dependencies:
@@ -8359,6 +8663,10 @@ snapshots:
 
   react@19.2.4: {}
 
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.2
+
   readdirp@5.0.0: {}
 
   recma-build-jsx@1.0.0:
@@ -8484,6 +8792,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  require-directory@2.1.1: {}
+
   reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
@@ -8549,6 +8859,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  safer-buffer@2.1.2: {}
 
   satori@0.26.0:
     dependencies:
@@ -8706,6 +9018,12 @@ snapshots:
 
   string-argv@0.3.2: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
@@ -8773,6 +9091,10 @@ snapshots:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
 
   strip-ansi@7.2.0:
     dependencies:
@@ -8919,6 +9241,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici@7.25.0: {}
+
   unicode-trie@2.0.0:
     dependencies:
       pako: 0.2.9
@@ -9038,6 +9362,12 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -9085,6 +9415,12 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrap-ansi@9.0.2:
     dependencies:
       ansi-styles: 6.2.3
@@ -9093,9 +9429,23 @@ snapshots:
 
   xtend@4.0.2: {}
 
+  y18n@5.0.8: {}
+
   yallist@3.1.1: {}
 
   yaml@2.8.3: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
 

--- a/skills/shieldcn-badges/SKILL.md
+++ b/skills/shieldcn-badges/SKILL.md
@@ -118,7 +118,7 @@ Append to any badge URL as `?key=value&key2=value2`.
 | `size` | `xs`, `sm`, `default`, `lg` | `sm` | Badge size |
 | `mode` | `dark`, `light` | `dark` | Color mode |
 | `split` | `true`, `false` | `false` | Two-tone label/value split |
-| `logo` | SimpleIcons slug, `lucide:name`, `ri:Name`, `false` | auto | Icon source |
+| `logo` | SimpleIcons slug, `ri:Name`, `false` | auto | Icon source |
 | `logoColor` | hex (no `#`) | auto | Icon color |
 | `label` | string | auto | Override label text |
 | `color` | hex (no `#`) | — | Background color |
@@ -168,7 +168,7 @@ Append to any badge URL as `?key=value&key2=value2`.
 
 ```md
 ![badge](https://shieldcn.dev/npm/react.svg?logo=typescript)
-![badge](https://shieldcn.dev/github/stars/owner/repo.svg?logo=lucide:star)
+![badge](https://shieldcn.dev/github/stars/owner/repo.svg?logo=ri:GoStarFill)
 ```
 
 ### No icon


### PR DESCRIPTION
<!--begin:badgetizr-shieldcn--> 
![Ready](https://shieldcn.dev/badge/Ready-22C55E.svg?variant=default&mode=dark&size=sm&logo=lucide:check-circle&color=22C55E)  [![CI 24978021461](https://shieldcn.dev/badge/Build-24978021461-7C3AED.svg?variant=default&mode=dark&size=sm&logo=github&color=7C3AED)](https://github.com/jal-co/shieldcn/actions/runs/24978021461)
<!--end:badgetizr-shieldcn-->
## Problem

Satori cannot reliably render SVG stroke-based paths. All Lucide icons use strokes (`fill="none" stroke="currentColor"`), which results in broken/garbled icon rendering in badges — both on the site and when embedded in GitHub READMEs.

## Solution

Remove Lucide entirely. Between SimpleIcons (2,400+) and React Icons (40,000+), there's more than enough coverage with fill-based icons that render correctly.

## Changes

- Remove `lucide-static` dependency
- Remove `lucide:` prefix handling from icon resolver
- Remove `__lucide__` stroke rendering path from `render.tsx`
- Replace all default provider icons (stars, forks, issues, PRs, etc.) with React Icons `go/*` pack equivalents
- Update logo picker, badge builder, badge modal placeholders
- Update showcase data, brands list
- Update docs (index, API reference), README, AGENTS.md, skills

## Icon sources (after)

| Source | Syntax | Count |
|--------|--------|-------|
| [SimpleIcons](https://simpleicons.org) | bare slug (`github`, `react`) | 2,400+ |
| [React Icons](https://react-icons.github.io/react-icons/) | `ri:ComponentName` (`ri:GoStarFill`) | 40,000+ |