### PR TITLE
ci: add badgetizr-shieldcn PR badges workflow

### DIFF
--- a/.github/.badgetizr-scn.yml
+++ b/.github/.badgetizr-scn.yml
@@ -1,5 +1,5 @@
 # badgetizr-shieldcn — shadcn-styled PR badges
-# Powered by shieldcn (https://shieldcn.com)
+# Powered by shieldcn (https://shieldcn.dev)
 
 shieldcn:
   variant: "default"
@@ -11,14 +11,14 @@ badge_wip:
   settings:
     color: "EAB308"
     label: "WIP"
-    logo: "lucide:construction"
+    logo: "ri:RiAlertFill"
 
 badge_hotfix:
   enabled: "true"
   settings:
     color: "EF4444"
     label: "HOTFIX"
-    logo: "lucide:flame"
+    logo: "ri:RiFireFill"
     variant: "destructive"
     production_branch: "main"
 
@@ -28,7 +28,7 @@ badge_base_branch:
     base_branch: "main"
     color: "F97316"
     label: "Target"
-    logo: "lucide:git-branch"
+    logo: "ri:RiGitBranchFill"
 
 badge_ci:
   enabled: "true"
@@ -42,7 +42,7 @@ badge_ready_for_approval:
   settings:
     color: "22C55E"
     label: "Ready"
-    logo: "lucide:check-circle"
+    logo: "ri:RiCheckFill"
 
 badge_ticket:
   enabled: "false"

--- a/.github/workflows/pr-badges.yml
+++ b/.github/workflows/pr-badges.yml
@@ -17,6 +17,6 @@ jobs:
           pr_destination_branch: ${{ github.event.pull_request.base.ref }}
           pr_build_number: ${{ github.run_id }}
           pr_build_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          configuration: .badgetizr.yml
+          configuration: .github/.badgetizr-scn.yml
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--begin:badgetizr-shieldcn--> 
![Ready](https://shieldcn.dev/badge/Ready-22C55E.svg?variant=default&mode=dark&size=sm&logo=ri:RiCheckFill&color=22C55E)  [![CI 24978292190](https://shieldcn.dev/badge/Build-24978292190-7C3AED.svg?variant=default&mode=dark&size=sm&logo=github&color=7C3AED)](https://github.com/jal-co/shieldcn/actions/runs/24978292190)
<!--end:badgetizr-shieldcn-->
Add automatic shadcn-styled badges to pull requests via [badgetizr-shieldcn](https://github.com/jal-co/badgetizr-shieldcn).

Config lives at `.github/.badgetizr-scn.yml`.

### Badges enabled

- **WIP** — detects "WIP" in PR title
- **Hotfix** — detects hotfix PRs targeting main
- **Branch** — shows target branch when not main
- **CI** — build status with clickable link
- **Ready** — all checkboxes completed