### PR TITLE
feat: gradient backgrounds, PNG/SVG format toggle, showcase examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ shieldcn is a standalone Next.js app that serves styled SVG/PNG badge images for
 | `labelTextColor` | hex without # | — |
 | `label` | string | auto |
 | `labelOpacity` | 0–1 | 0.7 |
+| `gradient` | comma-separated hex colors, optional angle last (e.g. `ff6b6b,4ecdc4,135`) | — |
 | `height`, `fontSize`, `radius`, `padX`, `iconSize`, `gap`, `labelGap` | number (px) | per size preset |
 
 ## Rules

--- a/README.md
+++ b/README.md
@@ -128,10 +128,12 @@ Three icon libraries (40,000+ icons) plus custom SVG upload:
 
 ## Response formats
 
-- **`.svg`** — SVG image (default, for READMEs and docs)
-- **`.png`** — rasterized PNG
+- **`.png`** — PNG image (recommended for GitHub READMEs and maximum compatibility)
+- **`.svg`** — SVG image (scalable, smaller file size)
 - **`.json`** — raw badge data
 - **`/shields.json`** — shields.io-compatible endpoint
+
+Both `.png` and `.svg` work everywhere GitHub renders images. Just swap the extension.
 
 ## Design principles
 

--- a/app/[...slug]/route.ts
+++ b/app/[...slug]/route.ts
@@ -94,6 +94,45 @@ import { getTokscaleTokens, getTokscaleCost, getTokscaleRank, getTokscaleActiveD
 /** Response format. */
 type Format = "svg" | "png" | "json" | "shields"
 
+/**
+ * Parse gradient query param into a CSS linear-gradient value.
+ *
+ * Formats:
+ *   ?gradient=ff6b6b,4ecdc4           → linear-gradient(90deg, #ff6b6b, #4ecdc4)
+ *   ?gradient=ff6b6b,4ecdc4,135       → linear-gradient(135deg, #ff6b6b, #4ecdc4)
+ *   ?gradient=ff6b6b,feca57,4ecdc4    → linear-gradient(90deg, #ff6b6b, #feca57, #4ecdc4)
+ *   ?gradient=ff6b6b,feca57,4ecdc4,45 → linear-gradient(45deg, #ff6b6b, #feca57, #4ecdc4)
+ *
+ * The last segment is treated as an angle (degrees) if it parses as a number
+ * between 0 and 360. Otherwise it's treated as another color stop.
+ */
+function parseGradient(raw: string | null): string | undefined {
+  if (!raw) return undefined
+  const parts = raw.split(",").map(s => s.trim()).filter(Boolean)
+  if (parts.length < 2) return undefined
+
+  // Check if last part is an angle (number 0-360)
+  const lastNum = parseFloat(parts[parts.length - 1])
+  let angle = 90
+  let colorParts: string[]
+
+  if (!isNaN(lastNum) && lastNum >= 0 && lastNum <= 360 && /^\d+(\.\d+)?$/.test(parts[parts.length - 1])) {
+    angle = lastNum
+    colorParts = parts.slice(0, -1)
+  } else {
+    colorParts = parts
+  }
+
+  if (colorParts.length < 2) return undefined
+
+  // Validate each color is a valid hex (3, 4, 6, or 8 hex chars)
+  const hexRegex = /^[0-9a-fA-F]{3,8}$/
+  if (!colorParts.every(c => hexRegex.test(c))) return undefined
+
+  const stops = colorParts.map(c => `#${c}`).join(", ")
+  return `linear-gradient(${angle}deg, ${stops})`
+}
+
 /** Cache headers for responses. */
 const CACHE_HEADERS = {
   "Cache-Control":
@@ -1118,6 +1157,9 @@ export async function GET(
     return isNaN(n) ? undefined : n
   }
 
+  // Parse gradient
+  const gradient = parseGradient(searchParams.get("gradient"))
+
   const svg = await renderBadge({
     label,
     value: data.value,
@@ -1135,6 +1177,7 @@ export async function GET(
     hasThemeOverride,
     brandColor,
     font,
+    gradient,
     valueColor: searchParams.get("valueColor") ?? undefined,
     labelTextColor: searchParams.get("labelTextColor") ?? undefined,
     labelOpacity: num("labelOpacity"),
@@ -1160,6 +1203,7 @@ export async function GET(
       hasLogo: !!iconPath,
       hasThemeOverride,
       hasBrandColor: !!brandColor,
+      hasGradient: !!gradient,
       font: font ?? "inter",
     },
   })

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -114,10 +114,10 @@ export default function PrivacyPage() {
                 </a>{" "}
                 or reach out at{" "}
                 <a
-                  href="mailto:hello@justinlevine.me"
+                  href="mailto:github@fwdtojustin.com"
                   className="underline underline-offset-2 hover:text-foreground"
                 >
-                  hello@justinlevine.me
+                  github@fwdtojustin.com
                 </a>
                 .
               </p>

--- a/components/badge-builder.tsx
+++ b/components/badge-builder.tsx
@@ -69,6 +69,7 @@ const THEMES = [
 interface State {
   provider: string
   input: string
+  format: "png" | "svg"
   variant: string
   size: string
   theme: string
@@ -80,6 +81,7 @@ interface State {
   logoColor: string
   label: string
   color: string
+  gradient: string
   valueColor: string
   labelTextColor: string
   labelOpacity: string
@@ -90,16 +92,17 @@ interface State {
 function buildUrl(s: State, baseUrl: string): string {
   if (!s.input.trim()) return ""
 
+  const ext = s.format === "svg" ? ".svg" : ".png"
   let path = ""
   switch (s.provider) {
-    case "npm":            path = `/npm/${s.input}.svg`; break
-    case "npm-downloads":  path = `/npm/${s.input}/downloads.svg`; break
-    case "github-stars":   path = `/github/${s.input}/stars.svg`; break
-    case "github-release": path = `/github/${s.input}/release.svg`; break
-    case "github-ci":      path = `/github/${s.input}/ci.svg`; break
-    case "github-license": path = `/github/${s.input}/license.svg`; break
-    case "discord":        path = `/discord/${s.input}.svg`; break
-    case "static":         path = `/badge/${s.input}.svg`; break
+    case "npm":            path = `/npm/${s.input}${ext}`; break
+    case "npm-downloads":  path = `/npm/${s.input}/downloads${ext}`; break
+    case "github-stars":   path = `/github/${s.input}/stars${ext}`; break
+    case "github-release": path = `/github/${s.input}/release${ext}`; break
+    case "github-ci":      path = `/github/${s.input}/ci${ext}`; break
+    case "github-license": path = `/github/${s.input}/license${ext}`; break
+    case "discord":        path = `/discord/${s.input}${ext}`; break
+    case "static":         path = `/badge/${s.input}${ext}`; break
   }
 
   const p = new URLSearchParams()
@@ -123,6 +126,7 @@ function buildUrl(s: State, baseUrl: string): string {
   if (s.valueColor) p.set("valueColor", s.valueColor)
   if (s.labelTextColor) p.set("labelTextColor", s.labelTextColor)
   if (s.labelOpacity) p.set("labelOpacity", s.labelOpacity)
+  if (s.gradient) p.set("gradient", s.gradient)
 
   const q = p.toString()
   return `${baseUrl}${path}${q ? `?${q}` : ""}`
@@ -135,6 +139,7 @@ function buildUrl(s: State, baseUrl: string): string {
 const defaults: State = {
   provider: "npm",
   input: "react",
+  format: "png",
   variant: "default",
   size: "sm",
   theme: "_none",
@@ -146,6 +151,7 @@ const defaults: State = {
   logoColor: "",
   label: "",
   color: "",
+  gradient: "",
   valueColor: "",
   labelTextColor: "",
   labelOpacity: "",
@@ -280,6 +286,24 @@ export function BadgeBuilder() {
               <SelectItem value="geist-mono">Geist Mono</SelectItem>
             </SelectContent>
           </Select>
+        </Field>
+      </div>
+
+      {/* ── Row 4: Format + Gradient ── */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <Field label="Format">
+          <Select value={s.format} onValueChange={v => set("format", v as "png" | "svg")}>
+            <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="png">PNG</SelectItem>
+              <SelectItem value="svg">SVG</SelectItem>
+            </SelectContent>
+          </Select>
+        </Field>
+
+        <Field label="Gradient">
+          <Input value={s.gradient} onChange={e => set("gradient", e.target.value)} placeholder="ff6b6b,4ecdc4" />
+          <p className="text-[10px] text-muted-foreground">Comma-separated hex colors, optional angle last (e.g. ff6b6b,4ecdc4,135)</p>
         </Field>
       </div>
 

--- a/components/badge-sandbox.tsx
+++ b/components/badge-sandbox.tsx
@@ -77,6 +77,7 @@ export function BadgeSandbox({
   })
 
   // Standard styling params (same for every badge)
+  const [imageFormat, setImageFormat] = useState<"png" | "svg">("png")
   const [variant, setVariant] = useState("default")
   const [size, setSize] = useState("sm")
   const [mode, setMode] = useState("dark")
@@ -90,6 +91,7 @@ export function BadgeSandbox({
   // Advanced
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [color, setColor] = useState("")
+  const [gradient, setGradient] = useState("")
   const [valueColor, setValueColor] = useState("")
   const [labelTextColor, setLabelTextColor] = useState("")
   const [labelOpacity, setLabelOpacity] = useState("")
@@ -108,7 +110,8 @@ export function BadgeSandbox({
 
   // Build URL
   const builtUrl = useMemo(() => {
-    let path = endpoint
+    // Replace .svg extension with selected format
+    let path = endpoint.replace(/\.svg$/, imageFormat === "svg" ? ".svg" : ".png")
     for (const p of pathParams) {
       const val = values[p.name]
       if (!val) return null
@@ -131,13 +134,14 @@ export function BadgeSandbox({
     if (showStatusDot && !statusDot) qp.set("statusDot", "false")
     if (label) qp.set("label", label)
     if (color) qp.set("color", color)
+    if (gradient) qp.set("gradient", gradient)
     if (valueColor) qp.set("valueColor", valueColor)
     if (labelTextColor) qp.set("labelTextColor", labelTextColor)
     if (labelOpacity) qp.set("labelOpacity", labelOpacity)
 
     const qs = qp.toString()
     return `${baseUrl}${path}${qs ? `?${qs}` : ""}`
-  }, [endpoint, pathParams, extraParams, values, variant, size, mode, theme, logo, logoColor, split, statusDot, showStatusDot, label, color, valueColor, labelTextColor, labelOpacity, baseUrl])
+  }, [endpoint, pathParams, extraParams, values, imageFormat, variant, size, mode, theme, logo, logoColor, split, statusDot, showStatusDot, label, color, gradient, valueColor, labelTextColor, labelOpacity, baseUrl])
 
   const formattedOutput = useMemo(() => {
     if (!builtUrl) return ""
@@ -219,7 +223,17 @@ export function BadgeSandbox({
         <Separator />
 
         {/* Standard styling params */}
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <div className="grid grid-cols-2 sm:grid-cols-5 gap-3">
+          <SField label="format">
+            <Select value={imageFormat} onValueChange={v => setImageFormat(v as "png" | "svg")}>
+              <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="png">PNG</SelectItem>
+                <SelectItem value="svg">SVG</SelectItem>
+              </SelectContent>
+            </Select>
+          </SField>
+
           <SField label="variant">
             <Select value={variant} onValueChange={setVariant}>
               <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
@@ -308,6 +322,9 @@ export function BadgeSandbox({
         {showAdvanced && (
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
             <SField label="color"><ColorInput value={color} onChange={setColor} placeholder="hex" /></SField>
+            <SField label="gradient">
+              <Input value={gradient} onChange={e => setGradient(e.target.value)} placeholder="ff6b6b,4ecdc4" />
+            </SField>
             <SField label="valueColor"><ColorInput value={valueColor} onChange={setValueColor} placeholder="hex" /></SField>
             <SField label="labelTextColor"><ColorInput value={labelTextColor} onChange={setLabelTextColor} placeholder="hex" /></SField>
             <SField label="labelOpacity"><Input value={labelOpacity} onChange={e => setLabelOpacity(e.target.value)} placeholder="0–1" /></SField>

--- a/content/docs/api-reference.mdx
+++ b/content/docs/api-reference.mdx
@@ -5,6 +5,7 @@ description: Complete URL specification, query parameters, and response formats.
 
 ## URL format
 
+<CodeLine language="bash" code="https://shieldcn.dev/{provider}/{...params}.png" />
 <CodeLine language="bash" code="https://shieldcn.dev/{provider}/{...params}.svg" />
 <CodeLine language="bash" code="https://shieldcn.dev/{provider}/{...params}.json" />
 <CodeLine language="bash" code="https://shieldcn.dev/{provider}/{...params}/shields.json" />
@@ -138,6 +139,12 @@ description: Complete URL specification, query parameters, and response formats.
       default: "0.7",
       description: "Label text opacity (0-1). Set to 1 for full visibility.",
     },
+    {
+      name: "gradient",
+      type: "string",
+      default: "\u2014",
+      description: "Comma-separated hex colors for a linear gradient background. Optionally append an angle (0\u2013360) as the last value. Example: ff6b6b,4ecdc4 or ff6b6b,4ecdc4,135.",
+    },
   ]}
 />
 
@@ -220,9 +227,17 @@ description: Complete URL specification, query parameters, and response formats.
 
 ## Response formats
 
-### SVG (default)
+### PNG
+
+<CodeBlock language="http" code={"Content-Type: image/png\nCache-Control: public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400"} />
+
+PNG badges are rasterized at the exact badge dimensions. Recommended for GitHub READMEs and maximum cross-platform compatibility.
+
+### SVG
 
 <CodeBlock language="http" code={"Content-Type: image/svg+xml\nCache-Control: public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400"} />
+
+SVG badges are scalable and have smaller file sizes. Use `.svg` when you need crisp rendering at any scale.
 
 ### JSON
 

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -11,33 +11,35 @@ shieldcn serves SVG badge images that look like **shadcn/ui Button components** 
 
 Add a badge to your README:
 
-<CodeLine language="markdown" code="![npm version](https://shieldcn.dev/npm/react.svg)" />
+<CodeLine language="markdown" code="![npm version](https://shieldcn.dev/npm/react.png)" />
 
-That's it. No configuration, no API keys, no build step.
+That's it. No configuration, no API keys, no build step. Both `.png` and `.svg` extensions are supported — just swap the extension.
 
 ## Badge types
 
 | Badge | URL pattern |
 |-------|------------|
-| npm version | `/npm/{package}.svg` |
-| npm downloads | `/npm/dw/{package}.svg` |
-| npm license | `/npm/license/{package}.svg` |
-| npm types | `/npm/types/{package}.svg` |
-| GitHub stars | `/github/stars/{owner}/{repo}.svg` |
-| GitHub forks | `/github/forks/{owner}/{repo}.svg` |
-| GitHub release | `/github/release/{owner}/{repo}.svg` |
-| GitHub CI | `/github/ci/{owner}/{repo}.svg` |
-| GitHub license | `/github/license/{owner}/{repo}.svg` |
-| GitHub issues | `/github/issues/{owner}/{repo}.svg` |
-| GitHub PRs | `/github/prs/{owner}/{repo}.svg` |
-| GitHub commits | `/github/commits/{owner}/{repo}.svg` |
-| Discord online | `/discord/{serverId}.svg` |
-| Discord members | `/discord/members/{inviteCode}.svg` |
-| Reddit karma | `/reddit/{type}/u/{user}.svg` |
-| Static | `/badge/{label}-{message}-{color}.svg` |
-| Dynamic JSON | `/badge/dynamic/json.svg?url=...&query=...` |
-| HTTPS endpoint | `/https/{hostname}/{path}.svg` |
-| Memo | `/memo/{key}.svg` |
+| npm version | `/npm/{package}` |
+| npm downloads | `/npm/dw/{package}` |
+| npm license | `/npm/license/{package}` |
+| npm types | `/npm/types/{package}` |
+| GitHub stars | `/github/stars/{owner}/{repo}` |
+| GitHub forks | `/github/forks/{owner}/{repo}` |
+| GitHub release | `/github/release/{owner}/{repo}` |
+| GitHub CI | `/github/ci/{owner}/{repo}` |
+| GitHub license | `/github/license/{owner}/{repo}` |
+| GitHub issues | `/github/issues/{owner}/{repo}` |
+| GitHub PRs | `/github/prs/{owner}/{repo}` |
+| GitHub commits | `/github/commits/{owner}/{repo}` |
+| Discord online | `/discord/{serverId}` |
+| Discord members | `/discord/members/{inviteCode}` |
+| Reddit karma | `/reddit/{type}/u/{user}` |
+| Static | `/badge/{label}-{message}-{color}` |
+| Dynamic JSON | `/badge/dynamic/json?url=...&query=...` |
+| HTTPS endpoint | `/https/{hostname}/{path}` |
+| Memo | `/memo/{key}` |
+
+Append `.png` or `.svg` to any endpoint (e.g. `/npm/react.png` or `/npm/react.svg`).
 
 ## Variants
 
@@ -66,9 +68,12 @@ Badges auto-detect icons per provider. Override with any [Simple Icons](https://
 
 ## Response formats
 
-- **`.svg`** — SVG image (default, for `<img>` tags and markdown)
+- **`.png`** — PNG image (recommended for GitHub READMEs and most use cases)
+- **`.svg`** — SVG image (scalable, smaller file size)
 - **`.json`** — raw badge data
 - **`/shields.json`** — shields.io-compatible endpoint
+
+Both `.png` and `.svg` work everywhere GitHub renders images. Use `.png` for maximum compatibility across platforms.
 
 ## Built with
 

--- a/lib/badges/render.tsx
+++ b/lib/badges/render.tsx
@@ -46,6 +46,28 @@ function getFonts(font: BadgeFont = "inter") {
   return [{ name: f.name, data: f.data, weight: 500 as const, style: "normal" as const }]
 }
 
+/** Check if a hex color (with #) is light enough to need dark text. */
+function isLightColor(hex: string): boolean {
+  const h = hex.replace("#", "")
+  const r = parseInt(h.substring(0, 2), 16)
+  const g = parseInt(h.substring(2, 4), 16)
+  const b = parseInt(h.substring(4, 6), 16)
+  if (isNaN(r) || isNaN(g) || isNaN(b)) return false
+  return (0.299 * r + 0.587 * g + 0.114 * b) / 255 > 0.6
+}
+
+/**
+ * Determine the best foreground color for a gradient background.
+ * Extracts hex stops from the CSS linear-gradient value and checks
+ * the average luminance to pick white or dark text.
+ */
+function gradientFg(gradient: string): string {
+  const stops = gradient.match(/#[0-9a-fA-F]{3,8}/g)
+  if (!stops || stops.length === 0) return "#ffffff"
+  const lightCount = stops.filter(isLightColor).length
+  return lightCount > stops.length / 2 ? "#18181b" : "#ffffff"
+}
+
 /** Hex → rgba with baked-in opacity */
 function rgba(hex: string, opacity: number): string {
   if (opacity >= 1) return hex
@@ -95,6 +117,9 @@ interface ResolvedBadge {
   leftBg: string                  // split left background
   rightBg: string                 // split right background
   rightFg: string                 // split right text color
+
+  // Gradient
+  gradient: string | undefined     // CSS linear-gradient value
 
   // Icon data (pass-through)
   icon: string | undefined
@@ -153,6 +178,14 @@ function resolve(config: BadgeConfig): ResolvedBadge {
     labelFgBase = bs.fg
   }
 
+  // When gradient is active, override text colors for contrast
+  // unless the user has explicitly set them
+  if (config.gradient && !config.valueColor && !config.labelTextColor) {
+    const gfg = gradientFg(config.gradient)
+    fg = gfg
+    labelFgBase = gfg
+  }
+
   // Apply overrides
   const finalValueColor = config.valueColor
     ? `#${config.valueColor}`
@@ -173,7 +206,9 @@ function resolve(config: BadgeConfig): ResolvedBadge {
   // Split colors
   const leftBg = hasTheme ? config.colors.labelBg : mode.secondary
   const rightBg = config.statusColor || config.colors.valueBg || mode.primary
-  const rightFg = config.colors.valueFg || mode.primaryForeground
+  const rightFg = config.gradient
+    ? gradientFg(config.gradient)
+    : (config.colors.valueFg || mode.primaryForeground)
 
   return {
     label: config.label,
@@ -197,6 +232,7 @@ function resolve(config: BadgeConfig): ResolvedBadge {
     leftBg,
     rightBg,
     rightFg,
+    gradient: config.gradient,
     icon: config.icon,
     iconViewBox: config.iconViewBox,
     iconFillRule: config.iconFillRule,
@@ -347,6 +383,11 @@ function DotEl({ r }: { r: ResolvedBadge }) {
 // ---------------------------------------------------------------------------
 
 function renderSingle(r: ResolvedBadge): React.ReactElement {
+  // Gradient overrides backgroundColor when present
+  const bgStyles = r.gradient
+    ? { backgroundImage: r.gradient }
+    : r.bg ? { backgroundColor: r.bg } : {}
+
   return (
     <div style={{
       display: "flex",
@@ -358,7 +399,7 @@ function renderSingle(r: ResolvedBadge): React.ReactElement {
       fontFamily: r.fontFamily,
       fontSize: r.fontSize,
       fontWeight: 500,
-      ...(r.bg ? { backgroundColor: r.bg } : {}),
+      ...bgStyles,
       ...(r.border ? { border: `1px solid ${r.border}` } : {}),
     }}>
       <DotEl r={r} />
@@ -382,6 +423,9 @@ function renderSingle(r: ResolvedBadge): React.ReactElement {
 // ---------------------------------------------------------------------------
 
 function renderSplit(r: ResolvedBadge): React.ReactElement {
+  // When gradient is active, it spans the full badge and inner segments are transparent
+  const hasGradient = !!r.gradient
+
   return (
     <div style={{
       display: "flex",
@@ -392,13 +436,14 @@ function renderSplit(r: ResolvedBadge): React.ReactElement {
       fontSize: r.fontSize,
       fontWeight: 500,
       overflow: "hidden",
+      ...(hasGradient ? { backgroundImage: r.gradient } : {}),
     }}>
       {/* Left segment */}
       <div style={{
         display: "flex",
         alignItems: "center",
         height: r.height,
-        backgroundColor: r.leftBg,
+        ...(hasGradient ? {} : { backgroundColor: r.leftBg }),
         paddingLeft: r.paddingX,
         paddingRight: r.paddingX,
       }}>
@@ -412,7 +457,7 @@ function renderSplit(r: ResolvedBadge): React.ReactElement {
         display: "flex",
         alignItems: "center",
         height: r.height,
-        backgroundColor: r.rightBg,
+        ...(hasGradient ? {} : { backgroundColor: r.rightBg }),
         paddingLeft: r.paddingX,
         paddingRight: r.paddingX,
       }}>

--- a/lib/badges/types.ts
+++ b/lib/badges/types.ts
@@ -86,6 +86,8 @@ export interface BadgeConfig {
   brandColor?: string
   /** Font family for badge text. */
   font?: "inter" | "geist" | "geist-mono"
+  /** CSS linear-gradient value for badge background. */
+  gradient?: string
 }
 
 /** Raw badge data returned by data providers. */

--- a/lib/showcase-data.ts
+++ b/lib/showcase-data.ts
@@ -332,6 +332,24 @@ export const categories: Category[] = [
     ],
   },
   {
+    name: "Gradients",
+    description: "Gradient background badges — use ?gradient=color1,color2 or add a third value for the angle.",
+    icons: [
+      dynamicBadge("Sunset", "gradient", "/badge/sunset-vibes-ff6b6b.svg?gradient=ff6b6b,feca57&logoColor=fff&logo=ri:GoSunFill", "Warm sunset gradient with a sun icon."),
+      dynamicBadge("Ocean", "gradient", "/badge/ocean-deep-667eea.svg?gradient=667eea,764ba2&logoColor=fff&logo=ri:GoDropletFill", "Cool purple-to-indigo gradient."),
+      dynamicBadge("Mint", "gradient", "/badge/fresh-mint-00b09b.svg?gradient=00b09b,96c93d&logoColor=fff&logo=ri:GoSparklesFill", "Fresh green gradient for eco or health themes."),
+      dynamicBadge("Aurora", "gradient", "/badge/aurora-borealis-a18cd1.svg?gradient=a18cd1,fbc2eb&logoColor=fff&logo=ri:GoStarFill", "Soft pink-to-lavender aurora gradient."),
+      dynamicBadge("Fire", "gradient", "/badge/on-fire-ff0844.svg?gradient=ff0844,ffb199&logoColor=fff&logo=ri:GoFlame", "Hot red-to-peach fire gradient."),
+      dynamicBadge("Neon", "gradient", "/badge/neon-glow-08AEEA.svg?gradient=08AEEA,2AF598&logoColor=fff&logo=ri:GoZap", "Electric cyan-to-green neon gradient."),
+      dynamicBadge("Gradient + Split", "gradient", "/npm/react.svg?gradient=667eea,764ba2&split=true&logoColor=fff", "Gradient flowing across a split badge."),
+      dynamicBadge("3-Stop Rainbow", "gradient", "/badge/rainbow-vibes-ff6b6b.svg?gradient=ff6b6b,feca57,4ecdc4&logoColor=fff", "Three-color gradient for a playful look."),
+      dynamicBadge("Diagonal", "gradient", "/badge/diagonal-gradient-667eea.svg?gradient=667eea,764ba2,135&logoColor=fff", "135° diagonal gradient."),
+      dynamicBadge("GitHub + Gradient", "gradient", "/github/stars/vercel/next.js.svg?gradient=667eea,764ba2&logoColor=fff", "Real data badge with a gradient background."),
+      dynamicBadge("npm + Gradient", "gradient", "/npm/react.svg?gradient=ff6b6b,feca57&logoColor=fff", "npm version badge with a warm gradient."),
+      dynamicBadge("Outline + Gradient", "gradient", "/badge/outline-gradient-667eea.svg?variant=outline&gradient=667eea,764ba2&logoColor=fff", "Gradient fills the outline variant background."),
+    ],
+  },
+  {
     name: "For Fun",
     description: "Honest badges for honest READMEs. Use responsibly.",
     icons: [


### PR DESCRIPTION
<!--begin:badgetizr-shieldcn--> 
![Ready](https://shieldcn.dev/badge/Ready-22C55E.svg?variant=default&mode=dark&size=sm&logo=ri:RiCheckFill&color=22C55E)  [![CI 24980428597](https://shieldcn.dev/badge/Build-24980428597-7C3AED.svg?variant=default&mode=dark&size=sm&logo=github&color=7C3AED)](https://github.com/jal-co/shieldcn/actions/runs/24980428597)
<!--end:badgetizr-shieldcn-->
## Summary

Adds gradient background support for badges, defaults builders to PNG with a format toggle, and updates docs to highlight both PNG and SVG formats.

### Gradient backgrounds

New `?gradient=` query parameter applies a CSS `linear-gradient` to badge backgrounds.

```
?gradient=ff6b6b,4ecdc4            → left-to-right (90°)
?gradient=ff6b6b,4ecdc4,135        → 135° angle
?gradient=ff6b6b,feca57,4ecdc4     → 3 color stops
?gradient=ff6b6b,feca57,4ecdc4,45  → 3 stops at 45°
```

- Works with all variants (default, secondary, outline, ghost, branded)
- Split mode: gradient spans the full badge across both halves
- Auto-detects text contrast — white text on dark gradients, dark text on light gradients
- User can still override with `?valueColor=` or `?labelTextColor=`
- Invalid input silently ignored (badge renders normally)

### PNG/SVG format toggle

- Badge Builder and Badge Sandbox now default to PNG format
- Added format `<Select>` to both components (PNG / SVG)
- Badge Sandbox replaces `.svg` extension from endpoint props dynamically

### Docs updates

- Getting Started: quick start uses `.png`, badge type table shows extensionless URLs with note to append `.png` or `.svg`
- API Reference: `.png` added to URL format, `gradient` added to Colors params table, PNG listed first in response formats
- README: PNG listed first as recommended format

### Other changes

- 12 gradient examples added to showcase (Sunset, Ocean, Mint, Aurora, Fire, Neon, etc.)
- Contact email updated to `github@fwdtojustin.com`
- `gradient` added to AGENTS.md query parameter table

## Files changed

| File | Change |
|------|--------|
| `lib/badges/types.ts` | Added `gradient?: string` to `BadgeConfig` |
| `lib/badges/render.tsx` | Gradient rendering, contrast-aware text colors |
| `app/[...slug]/route.ts` | `parseGradient()` + wiring + analytics |
| `components/badge-builder.tsx` | Format select, gradient input |
| `components/badge-sandbox.tsx` | Format select, gradient in advanced |
| `lib/showcase-data.ts` | Gradients showcase category |
| `content/docs/index.mdx` | PNG-first docs |
| `content/docs/api-reference.mdx` | Gradient param, PNG format |
| `README.md` | PNG recommended |
| `AGENTS.md` | Gradient in params table |
| `app/privacy/page.tsx` | Email update |