### PR TITLE
fix: showcase submission branch prefix + category insertion

### DIFF
--- a/app/api/showcase/route.ts
+++ b/app/api/showcase/route.ts
@@ -23,7 +23,7 @@ import { SignJWT, importPKCS8 } from "jose"
 const OWNER = "jal-co"
 const REPO = "shieldcn"
 const FILE_PATH = "lib/showcase-data.ts"
-const BRANCH_PREFIX = "community-badge"
+const BRANCH_PREFIX = "feat/community-badge"
 
 // ---------------------------------------------------------------------------
 // GitHub App auth — generate an installation token

--- a/app/api/showcase/route.ts
+++ b/app/api/showcase/route.ts
@@ -163,8 +163,10 @@ export async function POST(req: NextRequest) {
       const needsComma = before.trimEnd().endsWith(")") || before.trimEnd().endsWith(",")
       updatedContent = before + (needsComma && !before.trimEnd().endsWith(",") ? "," : "") + "\n    " + newEntry + "\n    " + after
     } else {
-      // Add a new Community category at the end of the categories array
-      const closingBracket = content.lastIndexOf("]")
+      // Add a new Community category at the end of the categories array.
+      // Find the closing `]` of `export const categories` — it's the `]` before `allBadgePaths`.
+      const allBadgePathsIdx = content.indexOf("allBadgePaths")
+      const closingBracket = content.lastIndexOf("]", allBadgePathsIdx)
       const communityCategory = `  {
     name: "Community",
     description: "Badges submitted by the community. Submit yours with the button on the showcase page!",


### PR DESCRIPTION
<!--begin:badgetizr-shieldcn--> 
![Ready](https://shieldcn.dev/badge/Ready-22C55E.svg?variant=default&mode=dark&size=sm&logo=ri:RiCheckFill&color=22C55E)  [![CI 25025129385](https://shieldcn.dev/badge/Build-25025129385-7C3AED.svg?variant=default&mode=dark&size=sm&logo=github&color=7C3AED)](https://github.com/jal-co/shieldcn/actions/runs/25025129385)
<!--end:badgetizr-shieldcn-->
Two fixes for the showcase submission flow:

1. **Branch prefix** — changed from `community-badge/` to `feat/community-badge/` so commit-check passes conventional branch validation
2. **Category insertion** — was targeting the last `]` in the file (the `allBadgePaths` array) instead of the `categories` array, causing a type error on build