### PR TITLE
feat(indiedevs): add IndieDevs provider with custom icons + rotation

### DIFF
--- a/app/[...slug]/route.ts
+++ b/app/[...slug]/route.ts
@@ -1045,6 +1045,7 @@ export async function GET(
   let iconStrokeWidth: number | undefined
   let iconStrokeLinecap: string | undefined
   let iconStrokeLinejoin: string | undefined
+  let iconRotation: number | undefined
   let brandColor: string | undefined
 
   // For branded variant, get provider brand color as fallback
@@ -1070,6 +1071,7 @@ export async function GET(
         iconStrokeWidth = parsed.icon.strokeWidth
         iconStrokeLinecap = parsed.icon.strokeLinecap
         iconStrokeLinejoin = parsed.icon.strokeLinejoin
+        iconRotation = parsed.icon.rotation
 
         if (providerBrand) brandColor = providerBrand
 
@@ -1093,6 +1095,7 @@ export async function GET(
       iconStrokeWidth = si.icon.strokeWidth
       iconStrokeLinecap = si.icon.strokeLinecap
       iconStrokeLinejoin = si.icon.strokeLinejoin
+      iconRotation = si.icon.rotation
 
       // Track brand color: icon's color > provider's color
       if (si.defaultColor && si.defaultColor !== "currentColor") {
@@ -1133,6 +1136,7 @@ export async function GET(
           iconStrokeWidth = si.icon.strokeWidth
           iconStrokeLinecap = si.icon.strokeLinecap
           iconStrokeLinejoin = si.icon.strokeLinejoin
+          iconRotation = si.icon.rotation
 
           // Track brand color: icon's color > provider's color
           if (si.defaultColor && si.defaultColor !== "currentColor") {
@@ -1202,6 +1206,7 @@ export async function GET(
     iconStrokeWidth,
     iconStrokeLinecap,
     iconStrokeLinejoin,
+    iconRotation,
     style,
     size,
     mode,

--- a/app/[...slug]/route.ts
+++ b/app/[...slug]/route.ts
@@ -90,6 +90,7 @@ import { getCocoaPodsVersion } from "@/lib/providers/cocoapods"
 import { getCodecovCoverage } from "@/lib/providers/codecov"
 import { getWakaTimeCodingTime } from "@/lib/providers/wakatime"
 import { getTokscaleTokens, getTokscaleCost, getTokscaleRank, getTokscaleActiveDays, getTokscaleStats } from "@/lib/providers/tokscale"
+import { getIndieDevsUser } from "@/lib/providers/indiedevs"
 
 /** Response format. */
 type Format = "svg" | "png" | "json" | "shields"
@@ -841,6 +842,14 @@ async function fetchBadgeData(
       return getTokscaleTokens(rest[0])
     }
 
+    // /indiedevs/{username}
+    // e.g. /indiedevs/jalco
+    case "indiedevs": {
+      const rest = segments.slice(1)
+      if (rest.length === 0) return null
+      return getIndieDevsUser(rest[0])
+    }
+
     // /https/{hostname}/{pathname...}
     // Proxy an HTTPS endpoint that returns { label/subject, value/status, color }
     case "https": {
@@ -913,6 +922,7 @@ function getDefaultLogoSlug(segments: string[]): { simpleIcon?: string; reactIco
   if (provider === "wakatime") return { simpleIcon: "wakatime" }
   if (provider === "reddit") return { simpleIcon: "reddit" }
   if (provider === "tokscale") return { reactIcon: "GoRocket" }
+  if (provider === "indiedevs") return { simpleIcon: "indiedevs" }
 
   if (provider === "github") {
     // Find the topic from either /github/{topic}/owner/repo or /github/owner/repo/{topic}

--- a/lib/badges/brand-colors.ts
+++ b/lib/badges/brand-colors.ts
@@ -38,6 +38,7 @@ export const providerBrandColors: Record<string, string> = {
   codecov: "F01F7A",
   wakatime: "000000",
   tokscale: "0073FF",
+  indiedevs: "818CF8",
 }
 
 /**

--- a/lib/badges/custom-icons.ts
+++ b/lib/badges/custom-icons.ts
@@ -1,0 +1,59 @@
+/**
+ * shieldcn
+ * lib/badges/custom-icons
+ *
+ * Custom SVG icons shipped with shieldcn for providers/brands
+ * not available in SimpleIcons or React Icons.
+ *
+ * Each entry uses the same IconData format as the rest of the icon pipeline.
+ */
+
+import type { IconData } from "./icons"
+
+interface CustomIcon {
+  icon: IconData
+  /** Default brand color (hex without #) */
+  color: string
+}
+
+const customIcons: Record<string, CustomIcon> = {
+  indiedevs: {
+    icon: {
+      viewBox: "0 0 24 24",
+      paths: [
+        "m18 16 4-4-4-4",
+        "m6 8-4 4 4 4",
+        "m14.5 4-5 16",
+      ],
+      path: "m18 16 4-4-4-4 m6 8-4 4 4 4 m14.5 4-5 16",
+      isStroke: true,
+      strokeWidth: 2,
+      strokeLinecap: "round",
+      strokeLinejoin: "round",
+    },
+    color: "818CF8", // indigo-400
+  },
+}
+
+/**
+ * Look up a custom icon by slug.
+ * Returns null if not found.
+ */
+export function getCustomIcon(
+  slug: string
+): { icon: IconData; defaultColor: string } | null {
+  const entry = customIcons[slug.toLowerCase()]
+  if (!entry) return null
+
+  return {
+    icon: entry.icon,
+    defaultColor: entry.color,
+  }
+}
+
+/**
+ * Check if a slug matches a custom icon.
+ */
+export function hasCustomIcon(slug: string): boolean {
+  return slug.toLowerCase() in customIcons
+}

--- a/lib/badges/custom-icons.ts
+++ b/lib/badges/custom-icons.ts
@@ -30,6 +30,7 @@ const customIcons: Record<string, CustomIcon> = {
       strokeWidth: 2,
       strokeLinecap: "round",
       strokeLinejoin: "round",
+      rotation: 45,
     },
     color: "818CF8", // indigo-400
   },

--- a/lib/badges/icons.ts
+++ b/lib/badges/icons.ts
@@ -27,6 +27,8 @@ export interface IconData {
   strokeLinecap?: string
   /** Stroke linejoin for stroke-based icons. */
   strokeLinejoin?: string
+  /** Rotation in degrees (applied around viewBox center). */
+  rotation?: number
 }
 
 export const icons: Record<string, IconData> = {

--- a/lib/badges/render.tsx
+++ b/lib/badges/render.tsx
@@ -135,6 +135,9 @@ interface ResolvedBadge {
   iconStrokeWidth: number
   iconStrokeLinecap: string | undefined
   iconStrokeLinejoin: string | undefined
+
+  // Icon rotation (degrees, applied around center)
+  iconRotation: number | undefined
 }
 
 // ---------------------------------------------------------------------------
@@ -253,6 +256,7 @@ function resolve(config: BadgeConfig): ResolvedBadge {
     iconStrokeWidth: config.iconStrokeWidth ?? 2,
     iconStrokeLinecap: config.iconStrokeLinecap,
     iconStrokeLinejoin: config.iconStrokeLinejoin,
+    iconRotation: config.iconRotation,
   }
 }
 
@@ -289,6 +293,9 @@ function optimizeSvg(svg: string): string {
               // (Lucide, Feather) need each path separate to preserve
               // relative coordinate spaces (m commands).
               mergePaths: false,
+              // Don't collapse <g> elements — rotation transforms on icon
+              // groups must be preserved.
+              collapseGroups: false,
             },
           },
         },
@@ -339,6 +346,10 @@ function inlineDataUriImages(svg: string): string {
     const viewBox = vbMatch ? vbMatch[1].split(/\s+/).map(Number) : [0, 0, 24, 24]
     const [, , vbWidth, vbHeight] = viewBox
 
+    // Extract any <g transform="..."> wrapper from inner SVG (e.g. rotation)
+    const gTransformMatch = innerSvg.match(/<g\s+transform="([^"]+)">/)
+    const innerTransform = gTransformMatch ? gTransformMatch[1] : null
+
     // Extract path(s) from inner SVG
     const paths: string[] = []
     const pathRegex = /<path\s+([^>]+)>/g
@@ -355,7 +366,11 @@ function inlineDataUriImages(svg: string): string {
     const scale = Math.min(scaleX, scaleY)
 
     // Create a group with transform to position and scale the paths
-    return `<g transform="translate(${x},${y}) scale(${scale})">${paths.join("")}</g>`
+    // If inner SVG had a transform (e.g. rotation), nest it inside
+    const pathContent = innerTransform
+      ? `<g transform="${innerTransform}">${paths.join("")}</g>`
+      : paths.join("")
+    return `<g transform="translate(${x},${y}) scale(${scale})">${pathContent}</g>`
   })
 }
 
@@ -377,25 +392,34 @@ function IconEl({ r }: { r: ResolvedBadge }) {
   const vb = r.iconViewBox || "0 0 16 16"
   const color = r.iconFill || r.iconColor
 
+  // Compute rotation transform string if needed
+  const rotTransform = r.iconRotation
+    ? (() => {
+        const [, , w, h] = vb.split(" ").map(Number)
+        return `rotate(${r.iconRotation}, ${w / 2}, ${h / 2})`
+      })()
+    : undefined
+
   if (r.iconIsStroke) {
     // Stroke-based icons (Lucide, Feather, etc.) — render with stroke, not fill.
     // Each original SVG element becomes its own <path> to preserve relative
     // coordinate spaces. Joining them into one `d` would break `m` (relative
     // move-to) commands that are relative to the previous element's end point.
     const paths = r.iconPaths && r.iconPaths.length > 0 ? r.iconPaths : [r.icon]
+    const pathEls = paths.map((d, i) => (
+      <path
+        key={i}
+        d={d}
+        fill="none"
+        stroke={color}
+        strokeWidth={r.iconStrokeWidth}
+        strokeLinecap={r.iconStrokeLinecap as "round" | "butt" | "square" | undefined}
+        strokeLinejoin={r.iconStrokeLinejoin as "round" | "miter" | "bevel" | undefined}
+      />
+    ))
     return (
       <svg viewBox={vb} width={r.iconSize} height={r.iconSize} style={{ flexShrink: 0 }}>
-        {paths.map((d, i) => (
-          <path
-            key={i}
-            d={d}
-            fill="none"
-            stroke={color}
-            strokeWidth={r.iconStrokeWidth}
-            strokeLinecap={r.iconStrokeLinecap as "round" | "butt" | "square" | undefined}
-            strokeLinejoin={r.iconStrokeLinejoin as "round" | "miter" | "bevel" | undefined}
-          />
-        ))}
+        {rotTransform ? <g transform={rotTransform}>{pathEls}</g> : pathEls}
       </svg>
     )
   }
@@ -403,7 +427,10 @@ function IconEl({ r }: { r: ResolvedBadge }) {
   const fr = r.iconFillRule as "nonzero" | "evenodd" | undefined
   return (
     <svg viewBox={vb} width={r.iconSize} height={r.iconSize} style={{ flexShrink: 0 }}>
-      <path fill={color} d={r.icon} fillRule={fr} />
+      {rotTransform
+        ? <g transform={rotTransform}><path fill={color} d={r.icon} fillRule={fr} /></g>
+        : <path fill={color} d={r.icon} fillRule={fr} />
+      }
     </svg>
   )
 }

--- a/lib/badges/simple-icons.ts
+++ b/lib/badges/simple-icons.ts
@@ -10,9 +10,11 @@
  */
 
 import type { IconData } from "./icons"
+import { getCustomIcon } from "./custom-icons"
 
 /**
- * Look up an icon by slug. Supports SimpleIcons, React Icons, and Lucide shorthand.
+ * Look up an icon by slug. Supports SimpleIcons, React Icons, Lucide shorthand,
+ * and custom icons shipped with shieldcn.
  *
  * @param slug - "react" (SimpleIcons) or "ri:FaReact" (React Icons) or "lu:Check" (Lucide)
  * @param logoColor - optional override color
@@ -35,6 +37,10 @@ export async function getSimpleIcon(
   if (slug.startsWith("ri:")) {
     return getReactIcon(slug.slice(3))
   }
+
+  // Custom icons shipped with shieldcn (checked before SimpleIcons)
+  const custom = getCustomIcon(slug)
+  if (custom) return custom
 
   // SimpleIcons
   return getSimpleIconBySlug(slug)

--- a/lib/badges/types.ts
+++ b/lib/badges/types.ts
@@ -49,6 +49,8 @@ export interface BadgeConfig {
   iconStrokeLinecap?: string
   /** Stroke linejoin for stroke-based icons. */
   iconStrokeLinejoin?: string
+  /** Icon rotation in degrees (applied around center). */
+  iconRotation?: number
   /** Visual style (shadcn Button variant). */
   style: BadgeStyle
   /** Size preset (shadcn Button size). Overrides individual dimension params. */

--- a/lib/providers/indiedevs.ts
+++ b/lib/providers/indiedevs.ts
@@ -1,0 +1,23 @@
+/**
+ * shieldcn
+ * lib/providers/indiedevs
+ *
+ * IndieDevs profile badge.
+ * Supports: user profile link.
+ */
+
+import type { BadgeData } from "@/lib/badges/types"
+
+// ---------------------------------------------------------------------------
+// User profile
+// ---------------------------------------------------------------------------
+
+export async function getIndieDevsUser(username: string): Promise<BadgeData | null> {
+  if (!username) return null
+
+  return {
+    label: "indiedevs",
+    value: username,
+    link: `https://www.indiedevs.me/${username}`,
+  }
+}

--- a/lib/showcase-data.ts
+++ b/lib/showcase-data.ts
@@ -375,6 +375,15 @@ export const categories: Category[] = [
     ],
   },
   {
+    name: "Friends of shieldcn",
+    description: "Projects and people in the shieldcn orbit. If you use shieldcn, you're a friend.",
+    icons: [
+      dynamicBadge("IndieDevs", "profile badge", "/indiedevs/jalco.svg?variant=branded", "Link your IndieDevs developer profile.", "/docs/badges/indiedevs"),
+      dynamicBadge("IndieDevs (outline)", "profile badge", "/indiedevs/jalco.svg?variant=outline", "Subtle IndieDevs profile badge for README rows."),
+      dynamicBadge("IndieDevs (secondary)", "profile badge", "/indiedevs/jalco.svg?variant=secondary", "IndieDevs profile badge in secondary style."),
+    ],
+  },
+  {
     name: "Community",
     description: "Badges submitted by the community. Submit yours with the button on the showcase page!",
     icons: [


### PR DESCRIPTION
<!--begin:badgetizr-shieldcn--> 
![Ready](https://shieldcn.dev/badge/Ready-22C55E.svg?variant=default&mode=dark&size=sm&logo=ri:RiCheckFill&color=22C55E)  [![CI 25067889850](https://shieldcn.dev/badge/Build-25067889850-7C3AED.svg?variant=default&mode=dark&size=sm&logo=github&color=7C3AED)](https://github.com/jal-co/shieldcn/actions/runs/25067889850)
<!--end:badgetizr-shieldcn-->