### PR TITLE
feat(gen): Profile README Badge Generator

### DIFF
--- a/app/[...slug]/route.ts
+++ b/app/[...slug]/route.ts
@@ -62,6 +62,8 @@ import {
   getGitHubDownloadsAssetAllReleases,
   getGitHubDownloadsAssetLatest,
   getGitHubDownloadsAssetTag,
+  getGitHubFollowers,
+  getGitHubUserStars,
 } from "@/lib/providers/github"
 import { getDiscordOnline, getDiscordByInvite } from "@/lib/providers/discord"
 import { parseStaticBadgeContent, getDynamicJsonBadge } from "@/lib/providers/badge"
@@ -245,6 +247,18 @@ async function fetchBadgeData(
     // Support both: /github/stars/owner/repo AND /github/owner/repo/stars
     case "github": {
       const rest = segments.slice(1)
+
+      // User-level endpoints (2 segments: topic + username)
+      const userTopics = new Set(["followers", "user-stars"])
+      if (rest.length >= 2 && userTopics.has(rest[0])) {
+        const username = rest[1]
+        switch (rest[0]) {
+          case "followers":  return getGitHubFollowers(username)
+          case "user-stars": return getGitHubUserStars(username)
+          default: return null
+        }
+      }
+
       if (rest.length < 3) return null
 
       // Detect format: is rest[0] a known topic or an owner?

--- a/app/api/gen-count/route.ts
+++ b/app/api/gen-count/route.ts
@@ -1,0 +1,31 @@
+/**
+ * shieldcn
+ * app/api/gen-count/route.ts
+ *
+ * POST: increment the badge generation counter
+ * GET:  return the current count
+ */
+
+import { NextResponse } from "next/server"
+import { incrementGenCounter, getGenCount } from "@/lib/gen-counter"
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json()
+    const count = typeof body?.count === "number" ? Math.max(0, Math.floor(body.count)) : 0
+    if (count > 0) {
+      await incrementGenCounter(count)
+    }
+    return NextResponse.json({ ok: true })
+  } catch {
+    return NextResponse.json({ ok: true }) // fail silently
+  }
+}
+
+export async function GET() {
+  const count = await getGenCount()
+  return NextResponse.json(
+    { count: count ?? 0 },
+    { headers: { "Cache-Control": "public, s-maxage=60, stale-while-revalidate=120" } },
+  )
+}

--- a/app/gen/generator-client.tsx
+++ b/app/gen/generator-client.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from "react"
 import { useQueryStates } from "nuqs"
+import { useOpenPanel } from "@openpanel/nextjs"
 import { Copy, Download, FileUp, RefreshCw, Trash2, X } from "lucide-react"
 import {
   badgeHtml,
@@ -79,7 +80,7 @@ const THEMES: Theme[] = [
   "emerald",
 ]
 
-const GROUP_TITLES: Record<BadgeGroup, string> = {
+const GROUP_TITLES: Partial<Record<BadgeGroup, string>> = {
   github: "GitHub",
   package: "Package",
   tooling: "Tooling",
@@ -98,6 +99,7 @@ const GROUP_ORDER: BadgeGroup[] = [
 ]
 
 export default function GeneratorApp() {
+  const { track } = useOpenPanel()
   const [qs, setQs] = useQueryStates(genSearchParams, {
     history: "replace",
   })
@@ -237,7 +239,18 @@ export default function GeneratorApp() {
     })
     setNotes(result.notes)
     setShieldsIoUrls(result.existingShieldsIoUrls)
-  }, [inputUrl, runInspect, setQs, qs.variant, qs.size, qs.mode, qs.theme])
+    const enabledCount = result.badges.filter((b) => b.enabled).length
+    track("generator_generate", {
+      type: "repo",
+      target: `${result.source.owner}/${result.source.repo}`,
+      badge_count: enabledCount,
+    })
+    fetch("/api/gen-count", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ count: enabledCount }),
+    }).catch(() => {})
+  }, [inputUrl, runInspect, setQs, qs.variant, qs.size, qs.mode, qs.theme, track])
 
   const handleConfigUpload = useCallback(async (file: File) => {
     setError(null)
@@ -523,7 +536,10 @@ function ResultsPanel({
   }, [config.badges])
 
   const downloadConfig = useCallback(() => {
-    const safeName = `${config.source.owner}-${config.source.repo}.shieldcngen.json`
+    const src = config.source
+    const safeName = src.type === "profile"
+      ? `${src.username}.shieldcngen.json`
+      : `${src.owner}-${src.repo}.shieldcngen.json`
     onDownload(serialize(config), safeName, "application/json")
   }, [config, onDownload])
 
@@ -538,7 +554,9 @@ function ResultsPanel({
         Detected <strong className="text-foreground">{enabledBadges.length}</strong> badge
         {enabledBadges.length === 1 ? "" : "s"} for{" "}
         <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
-          {config.source.owner}/{config.source.repo}
+          {config.source.type === "profile"
+            ? config.source.username
+            : `${config.source.owner}/${config.source.repo}`}
         </code>
         {refreshDiff && (
           <>

--- a/app/gen/page.tsx
+++ b/app/gen/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next"
+import Link from "next/link"
 import { Suspense } from "react"
+import { ArrowRight, User } from "lucide-react"
 import { SiteShell } from "@/components/site-shell"
 import GeneratorClient from "./generator-client"
 import { GeneratorTourProvider, TourReplayButton } from "./generator-tour"
@@ -58,6 +60,21 @@ export default function GeneratorPage() {
                 </span>
               </div>
             </header>
+
+            {/* Cross-link to profile generator */}
+            <Link
+              href="/gen/profile"
+              className="mb-8 flex items-center gap-3 rounded-lg border border-dashed border-border/60 bg-muted/30 px-4 py-3 text-sm transition-colors hover:border-border hover:bg-muted/50"
+            >
+              <User className="size-4 shrink-0 text-muted-foreground" />
+              <div className="flex-1">
+                <span className="font-medium">Looking for profile README badges?</span>
+                <span className="ml-1.5 text-muted-foreground">
+                  Generate badges from a GitHub username instead.
+                </span>
+              </div>
+              <ArrowRight className="size-4 shrink-0 text-muted-foreground" />
+            </Link>
 
             <Suspense>
               <GeneratorClient />

--- a/app/gen/profile/page.tsx
+++ b/app/gen/profile/page.tsx
@@ -1,0 +1,73 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { Suspense } from "react"
+import { ArrowLeft } from "lucide-react"
+import { SiteShell } from "@/components/site-shell"
+import ProfileGeneratorClient from "./profile-client"
+import {
+  ProfileTourProvider,
+  ProfileTourReplayButton,
+} from "./profile-tour"
+import { pageMetadata } from "@/lib/metadata"
+import { profileReadmeJsonLd } from "@/lib/json-ld"
+
+export const metadata: Metadata = pageMetadata({
+  title: "GitHub Profile README Badge Generator",
+  description:
+    "Generate beautiful badges for your GitHub profile README. Auto-detects your skills, languages, social links, and top repos. Styled as shadcn/ui buttons with 6 variants, 16 themes, and 40,000+ icons.",
+  path: "/gen/profile",
+  ogTitle:
+    "GitHub Profile README Badge Generator — shieldcn",
+})
+
+export default function ProfileGeneratorPage() {
+  return (
+    <SiteShell>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(profileReadmeJsonLd()),
+        }}
+      />
+      <main className="min-w-0 flex-1">
+        <div className="mx-auto max-w-4xl px-6 py-12 md:px-10">
+          <ProfileTourProvider>
+            <header className="mb-10 flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+              <div>
+                <div className="mb-2">
+                  <Link
+                    href="/gen"
+                    className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    <ArrowLeft className="size-3" />
+                    Repository Generator
+                  </Link>
+                </div>
+                <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+                  Profile README Generator
+                </h1>
+                <p className="text-sm text-muted-foreground">
+                  Auto-generate{" "}
+                  <a
+                    href="https://shieldcn.dev"
+                    className="underline underline-offset-2 hover:text-foreground"
+                  >
+                    shieldcn
+                  </a>{" "}
+                  badges for your GitHub profile README.
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <ProfileTourReplayButton />
+              </div>
+            </header>
+
+            <Suspense>
+              <ProfileGeneratorClient />
+            </Suspense>
+          </ProfileTourProvider>
+        </div>
+      </main>
+    </SiteShell>
+  )
+}

--- a/app/gen/profile/profile-client.tsx
+++ b/app/gen/profile/profile-client.tsx
@@ -1,0 +1,1012 @@
+"use client"
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+import { useQueryStates } from "nuqs"
+import { useOpenPanel } from "@openpanel/nextjs"
+import { Copy, Download, FileUp, RefreshCw, Trash2, X } from "lucide-react"
+import {
+  badgeHtml,
+  badgeMarkdown,
+  badgeUrl,
+  DEFAULT_GLOBAL,
+  type Badge,
+  type BadgeGroup,
+  type GlobalSettings,
+  type Mode,
+  type Overrides,
+  type Size,
+  type Theme,
+  type Variant,
+} from "@/lib/gen/shieldcn"
+import { profileSearchParams } from "@/lib/gen/profile-search-params"
+import { inspectProfile, type ProfileInspectResult, type GitHubUserProfile } from "@/lib/gen/detect-profile"
+import type { Config } from "@/lib/gen/config"
+import { mergeRefresh, serialize, deserialize } from "@/lib/gen/config"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Label } from "@/components/ui/label"
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
+import { Card, CardContent } from "@/components/ui/card"
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover"
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select"
+import { Separator } from "@/components/ui/separator"
+import { Switch } from "@/components/ui/switch"
+import { ColorInput } from "@/components/color-input"
+import { SvgIconUpload } from "@/components/svg-icon-upload"
+import { cn } from "@/lib/utils"
+import { PROFILE_TOUR_STEP_IDS } from "@/lib/tour-constants"
+
+const VARIANTS: Variant[] = [
+  "default",
+  "secondary",
+  "outline",
+  "ghost",
+  "destructive",
+  "branded",
+]
+const SIZES: Size[] = ["xs", "sm", "default", "lg"]
+const MODES: Mode[] = ["dark", "light"]
+const THEMES: Theme[] = [
+  "none",
+  "zinc",
+  "slate",
+  "stone",
+  "neutral",
+  "gray",
+  "blue",
+  "green",
+  "rose",
+  "orange",
+  "amber",
+  "violet",
+  "purple",
+  "red",
+  "cyan",
+  "emerald",
+]
+
+const GROUP_TITLES: Record<string, string> = {
+  profile: "Profile",
+  social: "Social",
+  skills: "Skills & Languages",
+  repos: "Top Repositories",
+}
+
+const GROUP_ORDER: BadgeGroup[] = ["profile", "social", "skills", "repos"]
+
+export default function ProfileGeneratorClient() {
+  const { track } = useOpenPanel()
+  const [qs, setQs] = useQueryStates(profileSearchParams, {
+    history: "replace",
+  })
+  const [inputUser, setInputUser] = useState(qs.user)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [config, setConfig] = useState<Config | null>(null)
+  const [notes, setNotes] = useState<string[]>([])
+  const [profile, setProfile] = useState<GitHubUserProfile | null>(null)
+  const [useTemplate, setUseTemplate] = useState(true)
+  const [refreshDiff, setRefreshDiff] = useState<
+    { added: string[]; refreshed: string[]; missing: string[] } | null
+  >(null)
+
+  // Auto-generate on mount if user param is present
+  const didAutoGenerate = useRef(false)
+  useEffect(() => {
+    if (qs.user && !didAutoGenerate.current && !config) {
+      didAutoGenerate.current = true
+      void handleGenerate(qs.user)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Sync global settings from URL params to config
+  useEffect(() => {
+    if (!config) return
+    const urlGlobal: GlobalSettings = {
+      variant: qs.variant,
+      size: qs.size,
+      mode: qs.mode,
+      theme: qs.theme,
+    }
+    const configGlobal = config.global
+    if (
+      urlGlobal.variant !== configGlobal.variant ||
+      urlGlobal.size !== configGlobal.size ||
+      urlGlobal.mode !== configGlobal.mode ||
+      urlGlobal.theme !== configGlobal.theme
+    ) {
+      setConfig((c) => (c ? { ...c, global: urlGlobal } : c))
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [qs.variant, qs.size, qs.mode, qs.theme])
+
+  const updateGlobal = useCallback(
+    (patch: Partial<GlobalSettings>) => {
+      setConfig((c) => (c ? { ...c, global: { ...c.global, ...patch } } : c))
+      void setQs(patch)
+    },
+    [setQs],
+  )
+
+  const updateBadge = useCallback((id: string, patch: Partial<Badge>) => {
+    setConfig((c) => {
+      if (!c) return c
+      return {
+        ...c,
+        badges: c.badges.map((b) => (b.id === id ? { ...b, ...patch } : b)),
+      }
+    })
+  }, [])
+
+  const updateOverrides = useCallback((id: string, patch: Overrides) => {
+    setConfig((c) => {
+      if (!c) return c
+      return {
+        ...c,
+        badges: c.badges.map((b) =>
+          b.id === id ? { ...b, overrides: { ...b.overrides, ...patch } } : b,
+        ),
+      }
+    })
+  }, [])
+
+  const removeBadge = useCallback((id: string) => {
+    setConfig((c) => {
+      if (!c) return c
+      return {
+        ...c,
+        badges: c.badges.map((b) =>
+          b.id === id ? { ...b, enabled: false } : b,
+        ),
+      }
+    })
+  }, [])
+
+  const inspectAbortRef = useRef<AbortController | null>(null)
+
+  const runInspect = useCallback(
+    async (
+      user: string,
+    ): Promise<ProfileInspectResult | null> => {
+      inspectAbortRef.current?.abort()
+      const controller = new AbortController()
+      inspectAbortRef.current = controller
+
+      setLoading(true)
+      setError(null)
+      setRefreshDiff(null)
+      try {
+        const result = await inspectProfile(user, controller.signal)
+        if (controller.signal.aborted) return null
+        if ("error" in result) {
+          setError(result.error)
+          return null
+        }
+        return result
+      } catch (e) {
+        if (controller.signal.aborted) return null
+        setError((e as Error).message)
+        return null
+      } finally {
+        if (inspectAbortRef.current === controller) {
+          setLoading(false)
+          inspectAbortRef.current = null
+        }
+      }
+    },
+    [],
+  )
+
+  useEffect(() => {
+    return () => {
+      inspectAbortRef.current?.abort()
+    }
+  }, [])
+
+  const handleGenerate = useCallback(
+    async (userOverride?: string) => {
+      const user = userOverride ?? inputUser.trim()
+      if (!user) return
+      if (user !== inputUser) setInputUser(user)
+      void setQs({ user })
+      const result = await runInspect(user)
+      if (!result) return
+      setProfile(result.profile)
+      setConfig({
+        version: 1,
+        source: { type: "profile", ...result.source },
+        global: {
+          variant: qs.variant,
+          size: qs.size,
+          mode: qs.mode,
+          theme: qs.theme,
+        },
+        badges: result.badges,
+        generatedAt: new Date().toISOString(),
+      })
+      setNotes(result.notes)
+      const enabledCount = result.badges.filter((b) => b.enabled).length
+      track("generator_generate", {
+        type: "profile",
+        target: result.source.username,
+        badge_count: enabledCount,
+      })
+      fetch("/api/gen-count", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ count: enabledCount }),
+      }).catch(() => {})
+    },
+    [inputUser, runInspect, setQs, qs.variant, qs.size, qs.mode, qs.theme, track],
+  )
+
+  const configRef = useRef<Config | null>(null)
+  useEffect(() => {
+    configRef.current = config
+  }, [config])
+
+  const handleRefresh = useCallback(async () => {
+    const source = configRef.current?.source
+    if (!source || source.type !== "profile") return
+    const result = await runInspect(source.username)
+    if (!result) return
+    const latest = configRef.current
+    if (!latest) return
+    const merged = mergeRefresh(latest, {
+      badges: result.badges,
+      source: { type: "profile", ...result.source },
+    })
+    setConfig(merged.config)
+    setNotes(result.notes)
+    setProfile(result.profile)
+    setRefreshDiff(merged.diff)
+  }, [runInspect])
+
+  const enabledBadges = useMemo(
+    () => (config ? config.badges.filter((b) => b.enabled) : []),
+    [config],
+  )
+
+  const badgesByGroup = useMemo(() => {
+    const map = new Map<BadgeGroup, Badge[]>()
+    for (const b of enabledBadges) {
+      const arr = map.get(b.group) ?? []
+      arr.push(b)
+      map.set(b.group, arr)
+    }
+    return map
+  }, [enabledBadges])
+
+  const markdown = useMemo(() => {
+    if (!config) return ""
+    if (!useTemplate) {
+      return enabledBadges.map((b) => badgeMarkdown(b, config.global)).join("\n")
+    }
+    return buildProfileTemplate(config, enabledBadges, profile)
+  }, [config, enabledBadges, useTemplate, profile])
+
+  const copy = useCallback(async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text)
+    } catch {
+      /* ignore */
+    }
+  }, [])
+
+  const downloadText = useCallback(
+    (text: string, filename: string, type: string) => {
+      const blob = new Blob([text], { type })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement("a")
+      a.href = url
+      a.download = filename
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      URL.revokeObjectURL(url)
+    },
+    [],
+  )
+
+  return (
+    <div className="space-y-6">
+      {/* Input */}
+      <Card>
+        <CardContent>
+          <div id={PROFILE_TOUR_STEP_IDS.USER_INPUT} className="space-y-2">
+            <Label
+              htmlFor="user-input"
+              className="text-xs text-muted-foreground"
+            >
+              GitHub username
+            </Label>
+            <div className="flex gap-2">
+              <Input
+                id="user-input"
+                type="text"
+                placeholder="jal-co"
+                value={inputUser}
+                onChange={(e) => setInputUser(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") void handleGenerate()
+                }}
+                className="flex-1"
+              />
+              <Button
+                onClick={() => void handleGenerate()}
+                disabled={loading || !inputUser.trim()}
+              >
+                {loading ? "Generating…" : "Generate"}
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {error && (
+        <div className="rounded-md border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-red-400">
+          {error}
+        </div>
+      )}
+
+      {config && (
+        <>
+          {/* Profile header */}
+          {profile && (
+            <div className="flex items-center gap-4">
+              <img
+                src={profile.avatar_url}
+                alt={profile.login}
+                className="size-12 rounded-full border"
+              />
+              <div>
+                <div className="font-semibold">
+                  {profile.name ?? profile.login}
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  @{profile.login}
+                  {profile.bio && ` · ${profile.bio}`}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Status */}
+          <div className="text-sm text-muted-foreground">
+            Detected{" "}
+            <strong className="text-foreground">
+              {enabledBadges.length}
+            </strong>{" "}
+            badge{enabledBadges.length === 1 ? "" : "s"} for{" "}
+            <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+              {config.source.type === "profile"
+                ? config.source.username
+                : ""}
+            </code>
+            {refreshDiff && (
+              <>
+                {" · "}
+                <span className="text-emerald-400">
+                  +{refreshDiff.added.length} new
+                </span>
+                {refreshDiff.missing.length > 0 && (
+                  <>
+                    {" · "}
+                    <span className="text-red-400">
+                      {refreshDiff.missing.length} no longer detected
+                    </span>
+                  </>
+                )}
+              </>
+            )}
+          </div>
+
+          {notes.length > 0 && (
+            <div className="space-y-1 text-xs text-muted-foreground">
+              {notes.map((n) => (
+                <div key={n}>· {n}</div>
+              ))}
+            </div>
+          )}
+
+          {/* Global defaults */}
+          <div
+            id={PROFILE_TOUR_STEP_IDS.GLOBAL_DEFAULTS}
+            className="space-y-3"
+          >
+            <h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Global defaults
+            </h3>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <GlobalSelect
+                label="Variant"
+                value={config.global.variant}
+                options={VARIANTS}
+                onChange={(v) => updateGlobal({ variant: v as Variant })}
+              />
+              <GlobalSelect
+                label="Size"
+                value={config.global.size}
+                options={SIZES}
+                onChange={(v) => updateGlobal({ size: v as Size })}
+              />
+              <GlobalSelect
+                label="Theme"
+                value={config.global.theme}
+                options={THEMES}
+                onChange={(v) => updateGlobal({ theme: v as Theme })}
+              />
+              <GlobalSelect
+                label="Mode"
+                value={config.global.mode}
+                options={MODES}
+                onChange={(v) => updateGlobal({ mode: v as Mode })}
+              />
+            </div>
+          </div>
+
+          {/* Badge groups */}
+          {GROUP_ORDER.map((group) => {
+            const items = badgesByGroup.get(group)
+            if (!items || items.length === 0) return null
+            const isFirst =
+              GROUP_ORDER.indexOf(group) ===
+              GROUP_ORDER.findIndex((g) => {
+                const items2 = badgesByGroup.get(g)
+                return items2 && items2.length > 0
+              })
+            return (
+              <div
+                key={group}
+                id={
+                  isFirst ? PROFILE_TOUR_STEP_IDS.BADGE_GROUP : undefined
+                }
+                className="space-y-3"
+              >
+                <div className="flex items-baseline gap-2">
+                  <h3 className="text-sm font-semibold">
+                    {GROUP_TITLES[group] ?? group}
+                  </h3>
+                  <span className="text-xs text-muted-foreground">
+                    {items.length}
+                  </span>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {items.map((badge, badgeIdx) => (
+                    <BadgeItem
+                      key={badge.id}
+                      badge={badge}
+                      global={config.global}
+                      onUpdate={(patch) => updateBadge(badge.id, patch)}
+                      onUpdateOverrides={(patch) =>
+                        updateOverrides(badge.id, patch)
+                      }
+                      onRemove={() => removeBadge(badge.id)}
+                      onCopy={copy}
+                      tourId={
+                        isFirst && badgeIdx === 0
+                          ? PROFILE_TOUR_STEP_IDS.BADGE_POPOVER
+                          : undefined
+                      }
+                    />
+                  ))}
+                </div>
+              </div>
+            )
+          })}
+
+          <Separator />
+
+          {/* Output */}
+          <div className="space-y-3">
+            <div
+              id={PROFILE_TOUR_STEP_IDS.TEMPLATE_OUTPUT}
+              className="flex items-center justify-between"
+            >
+              <h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Output
+              </h3>
+              <div className="flex items-center gap-2">
+                <Label
+                  htmlFor="template-toggle"
+                  className="text-xs text-muted-foreground"
+                >
+                  Full README template
+                </Label>
+                <Switch
+                  id="template-toggle"
+                  checked={useTemplate}
+                  onCheckedChange={setUseTemplate}
+                />
+              </div>
+            </div>
+            <Textarea
+              readOnly
+              value={markdown}
+              rows={Math.min(
+                Math.max(
+                  useTemplate ? 20 : enabledBadges.length,
+                  6,
+                ),
+                30,
+              )}
+              className="font-mono text-xs"
+            />
+            <div
+              id={PROFILE_TOUR_STEP_IDS.COPY_ACTIONS}
+              className="flex flex-wrap gap-2"
+            >
+              <Button size="sm" onClick={() => copy(markdown)}>
+                <Copy className="size-3.5" />
+                Copy {useTemplate ? "README" : "markdown"}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  downloadText(
+                    markdown + "\n",
+                    "README.md",
+                    "text/markdown",
+                  )
+                }
+              >
+                <Download className="size-3.5" />
+                Download README.md
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  const safeName = `${config.source.type === "profile" ? config.source.username : "profile"}.shieldcngen.json`
+                  downloadText(
+                    serialize(config),
+                    safeName,
+                    "application/json",
+                  )
+                }}
+              >
+                <Download className="size-3.5" />
+                Download config
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => void handleRefresh()}
+                disabled={loading}
+              >
+                <RefreshCw
+                  className={cn("size-3.5", loading && "animate-spin")}
+                />
+                {loading ? "Refreshing…" : "Refresh"}
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+// ── Profile template builder ─────────────────────────
+
+function buildProfileTemplate(
+  config: Config,
+  badges: Badge[],
+  profile: GitHubUserProfile | null,
+): string {
+  const g = config.global
+  const lines: string[] = []
+  const byGroup = new Map<BadgeGroup, Badge[]>()
+  for (const b of badges) {
+    const arr = byGroup.get(b.group) ?? []
+    arr.push(b)
+    byGroup.set(b.group, arr)
+  }
+
+  const name = profile?.name ?? (config.source.type === "profile" ? config.source.username : "")
+  const bio = profile?.bio ?? ""
+
+  lines.push(`<div align="center">`)
+  lines.push(``)
+  if (name) lines.push(`# Hi, I'm ${name} 👋`)
+  if (bio) {
+    lines.push(``)
+    lines.push(`**${bio}**`)
+  }
+  lines.push(``)
+
+  // Social badges
+  const socialBadges = byGroup.get("social")
+  if (socialBadges && socialBadges.length > 0) {
+    lines.push(socialBadges.map((b) => badgeMarkdown(b, g)).join(" "))
+    lines.push(``)
+  }
+
+  // Profile badges
+  const profileBadges = byGroup.get("profile")
+  if (profileBadges && profileBadges.length > 0) {
+    lines.push(profileBadges.map((b) => badgeMarkdown(b, g)).join(" "))
+    lines.push(``)
+  }
+
+  lines.push(`</div>`)
+  lines.push(``)
+
+  // Skills
+  const skillsBadges = byGroup.get("skills")
+  if (skillsBadges && skillsBadges.length > 0) {
+    lines.push(`## 🛠️ Skills & Technologies`)
+    lines.push(``)
+    lines.push(skillsBadges.map((b) => badgeMarkdown(b, g)).join(" "))
+    lines.push(``)
+  }
+
+  // Top repos
+  const repoBadges = byGroup.get("repos")
+  if (repoBadges && repoBadges.length > 0) {
+    lines.push(`## 📦 Top Repositories`)
+    lines.push(``)
+    lines.push(repoBadges.map((b) => badgeMarkdown(b, g)).join(" "))
+    lines.push(``)
+  }
+
+  lines.push(`---`)
+  lines.push(``)
+  lines.push(
+    `<sub>Badges generated with [shieldcn](https://shieldcn.dev/gen/profile)</sub>`,
+  )
+
+  return lines.join("\n")
+}
+
+// ── Shared subcomponents ─────────────────────────────
+
+function GlobalSelect({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string
+  value: string
+  options: readonly string[]
+  onChange: (v: string) => void
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label className="text-xs uppercase tracking-wider text-muted-foreground">
+        {label}
+      </Label>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger className="w-full">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((opt) => (
+            <SelectItem key={opt} value={opt}>
+              {opt}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
+function BadgeItem({
+  badge,
+  global,
+  onUpdate,
+  onUpdateOverrides,
+  onRemove,
+  onCopy,
+  tourId,
+}: {
+  badge: Badge
+  global: GlobalSettings
+  onUpdate: (patch: Partial<Badge>) => void
+  onUpdateOverrides: (patch: Overrides) => void
+  onRemove: () => void
+  onCopy: (text: string) => void
+  tourId?: string
+}) {
+  const [open, setOpen] = useState(false)
+  const url = badgeUrl(badge, global)
+  const md = badgeMarkdown(badge, global)
+  const html = badgeHtml(badge, global)
+
+  const setOverride = (
+    key: keyof Overrides,
+    value: string | number | boolean | undefined,
+  ) => {
+    if (value === "" || value === undefined) {
+      const next = { ...badge.overrides }
+      delete next[key]
+      onUpdate({ overrides: next })
+    } else {
+      onUpdateOverrides({ [key]: value } as Overrides)
+    }
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          id={tourId}
+          className={cn(
+            "inline-flex items-center rounded-md border border-transparent p-0.5 transition-colors hover:border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+            open && "border-primary",
+            !badge.enabled && "opacity-30 grayscale-[60%]",
+          )}
+        >
+          <img
+            src={url}
+            alt={badge.label}
+            loading="lazy"
+            className="block max-h-10"
+          />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80 space-y-3" align="start">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium">{badge.label}</span>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            onClick={() => setOpen(false)}
+          >
+            <X className="size-3" />
+          </Button>
+        </div>
+
+        {/* Override selects */}
+        <div className="grid grid-cols-2 gap-2">
+          <OverrideSelect
+            label="Variant"
+            value={badge.overrides.variant ?? ""}
+            options={VARIANTS}
+            onChange={(v) => setOverride("variant", v)}
+          />
+          <OverrideSelect
+            label="Size"
+            value={badge.overrides.size ?? ""}
+            options={SIZES}
+            onChange={(v) => setOverride("size", v)}
+          />
+          <OverrideSelect
+            label="Theme"
+            value={badge.overrides.theme ?? ""}
+            options={THEMES}
+            onChange={(v) => setOverride("theme", v)}
+          />
+          <OverrideSelect
+            label="Mode"
+            value={badge.overrides.mode ?? ""}
+            options={MODES}
+            onChange={(v) => setOverride("mode", v)}
+          />
+        </div>
+
+        {/* Colors */}
+        <div className="grid grid-cols-2 gap-2">
+          <ColorField
+            label="Value color"
+            value={badge.overrides.color ?? ""}
+            onChange={(v) => setOverride("color", v)}
+          />
+          <ColorField
+            label="Label color"
+            value={badge.overrides.labelColor ?? ""}
+            onChange={(v) => setOverride("labelColor", v)}
+          />
+        </div>
+
+        {/* Advanced */}
+        <details className="group">
+          <summary className="cursor-pointer text-xs text-muted-foreground">
+            Advanced
+          </summary>
+          <div className="mt-2 space-y-2">
+            <div className="grid grid-cols-2 gap-2">
+              <ColorField
+                label="Value text"
+                value={badge.overrides.valueColor ?? ""}
+                onChange={(v) => setOverride("valueColor", v)}
+              />
+              <ColorField
+                label="Label text"
+                value={badge.overrides.labelTextColor ?? ""}
+                onChange={(v) => setOverride("labelTextColor", v)}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label className="text-[11px] uppercase tracking-wider text-muted-foreground">
+                Custom label
+              </Label>
+              <Input
+                placeholder="(default)"
+                value={badge.overrides.label ?? ""}
+                onChange={(e) => setOverride("label", e.target.value)}
+                className="h-7 text-xs"
+              />
+            </div>
+            <div className="space-y-2">
+              <div className="grid grid-cols-2 gap-2">
+                <div className="space-y-1">
+                  <Label className="text-[11px] uppercase tracking-wider text-muted-foreground">
+                    Logo
+                  </Label>
+                  <Input
+                    placeholder="slug or ri:Name"
+                    value={
+                      typeof badge.overrides.logo === "string" &&
+                      !String(badge.overrides.logo).startsWith("data:")
+                        ? badge.overrides.logo
+                        : badge.overrides.logo === false
+                          ? "false"
+                          : ""
+                    }
+                    onChange={(e) => {
+                      const raw = e.target.value.trim()
+                      if (raw === "false") setOverride("logo", false)
+                      else setOverride("logo", raw)
+                    }}
+                    className="h-7 text-xs"
+                  />
+                </div>
+                <ColorField
+                  label="Logo color"
+                  value={badge.overrides.logoColor ?? ""}
+                  onChange={(v) => setOverride("logoColor", v)}
+                />
+              </div>
+              <SvgIconUpload
+                value={
+                  typeof badge.overrides.logo === "string"
+                    ? badge.overrides.logo
+                    : ""
+                }
+                onChange={(v) => setOverride("logo", v || undefined)}
+                className="w-full"
+              />
+            </div>
+          </div>
+        </details>
+
+        <Separator />
+
+        {/* Embed */}
+        <div className="space-y-1.5">
+          <Label className="text-[11px] uppercase tracking-wider text-muted-foreground">
+            Embed
+          </Label>
+          <EmbedField label="Markdown" value={md} onCopy={onCopy} />
+          <EmbedField label="HTML" value={html} onCopy={onCopy} />
+          <EmbedField label="URL" value={url} onCopy={onCopy} />
+        </div>
+
+        <Separator />
+
+        {/* Remove */}
+        <Button
+          variant="destructive"
+          size="sm"
+          className="w-full"
+          onClick={() => {
+            onRemove()
+            setOpen(false)
+          }}
+        >
+          <Trash2 className="size-3.5" />
+          Remove this badge
+        </Button>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+function OverrideSelect({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string
+  value: string
+  options: readonly string[]
+  onChange: (v: string) => void
+}) {
+  return (
+    <div className="space-y-1">
+      <Label className="text-[11px] uppercase tracking-wider text-muted-foreground">
+        {label}
+      </Label>
+      <Select
+        value={value || "__global__"}
+        onValueChange={(v) => onChange(v === "__global__" ? "" : v)}
+      >
+        <SelectTrigger className="h-7 w-full text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="__global__">(global)</SelectItem>
+          {options.map((opt) => (
+            <SelectItem key={opt} value={opt}>
+              {opt}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
+function EmbedField({
+  label,
+  value,
+  onCopy,
+}: {
+  label: string
+  value: string
+  onCopy: (text: string) => void
+}) {
+  return (
+    <div className="flex gap-1.5">
+      <Textarea
+        readOnly
+        value={value}
+        rows={1}
+        aria-label={label}
+        className="h-7 min-h-0 flex-1 resize-none py-1 font-mono text-[11px]"
+      />
+      <Button
+        variant="outline"
+        size="icon-xs"
+        onClick={() => onCopy(value)}
+        title={`Copy ${label}`}
+      >
+        <Copy className="size-3" />
+      </Button>
+    </div>
+  )
+}
+
+function ColorField({
+  label,
+  value,
+  onChange,
+}: {
+  label: string
+  value: string
+  onChange: (v: string) => void
+}) {
+  return (
+    <div className="space-y-1">
+      <Label className="text-[11px] uppercase tracking-wider text-muted-foreground">
+        {label}
+      </Label>
+      <ColorInput value={value} onChange={onChange} placeholder="(none)" />
+    </div>
+  )
+}

--- a/app/gen/profile/profile-tour.tsx
+++ b/app/gen/profile/profile-tour.tsx
@@ -1,0 +1,270 @@
+// shieldcn — app/gen/profile/profile-tour.tsx
+// Tour overlay + provider for the profile badge generator page
+
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { useOpenPanel } from "@openpanel/nextjs"
+import {
+  TourProvider,
+  useTour,
+  TourAlertDialog,
+  type TourStep,
+} from "@/components/tour"
+import { PROFILE_TOUR_STEP_IDS } from "@/lib/tour-constants"
+import type React from "react"
+import { CircleHelp } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+const STORAGE_KEY = "shieldcn-profile-tour-completed"
+
+const steps: TourStep[] = [
+  {
+    selectorId: PROFILE_TOUR_STEP_IDS.USER_INPUT,
+    position: "bottom",
+    content: (
+      <div className="space-y-2">
+        <p className="text-sm font-semibold">Enter a GitHub username</p>
+        <p className="text-xs text-muted-foreground">
+          Type any GitHub username and hit Generate. We&apos;ll scan their
+          profile, repos, and social links to create profile README badges.
+        </p>
+      </div>
+    ),
+  },
+  {
+    selectorId: PROFILE_TOUR_STEP_IDS.GLOBAL_DEFAULTS,
+    position: "top",
+    content: (
+      <div className="space-y-2">
+        <p className="text-sm font-semibold">Customize the look</p>
+        <p className="text-xs text-muted-foreground">
+          Change variant, size, theme, and mode. These apply to all badges at
+          once.
+        </p>
+      </div>
+    ),
+  },
+  {
+    selectorId: PROFILE_TOUR_STEP_IDS.BADGE_GROUP,
+    position: "top",
+    content: (
+      <div className="space-y-2">
+        <p className="text-sm font-semibold">Your profile badges</p>
+        <p className="text-xs text-muted-foreground">
+          Badges are grouped by type — profile stats, social links, skills, and
+          top repos. Click any badge to customize it.
+        </p>
+      </div>
+    ),
+  },
+  {
+    selectorId: PROFILE_TOUR_STEP_IDS.BADGE_POPOVER,
+    position: "bottom",
+    content: (
+      <div className="space-y-2">
+        <p className="text-sm font-semibold">Per-badge overrides</p>
+        <p className="text-xs text-muted-foreground">
+          Override variant, colors, icon, or label for any specific badge. Hit
+          the red button to remove it.
+        </p>
+      </div>
+    ),
+  },
+  {
+    selectorId: PROFILE_TOUR_STEP_IDS.TEMPLATE_OUTPUT,
+    position: "top",
+    content: (
+      <div className="space-y-2">
+        <p className="text-sm font-semibold">README template</p>
+        <p className="text-xs text-muted-foreground">
+          Toggle between a full profile README template with sections and
+          headings, or just the raw badge markdown.
+        </p>
+      </div>
+    ),
+  },
+  {
+    selectorId: PROFILE_TOUR_STEP_IDS.COPY_ACTIONS,
+    position: "top",
+    content: (
+      <div className="space-y-2">
+        <p className="text-sm font-semibold">Copy &amp; deploy</p>
+        <p className="text-xs text-muted-foreground">
+          Copy the README, download it, or save the config. Paste it into your{" "}
+          <code className="rounded bg-muted px-1 text-[11px]">
+            username/username
+          </code>{" "}
+          repo to go live.
+        </p>
+        <p className="text-[11px] text-muted-foreground/60">
+          Press{" "}
+          <kbd className="rounded border border-border bg-muted px-1 py-0.5 font-mono text-[10px]">
+            →
+          </kbd>{" "}
+          or <span className="font-medium text-primary">Finish</span> to close
+          the tour.
+        </p>
+      </div>
+    ),
+  },
+]
+
+export function ProfileTourProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const { track } = useOpenPanel()
+  return (
+    <TourProvider
+      onComplete={() => {
+        localStorage.setItem(STORAGE_KEY, "true")
+        track("tour_completed", { tour: "profile-generator" })
+      }}
+      className="rounded-lg"
+    >
+      {children}
+      <ProfileTourTrigger />
+    </TourProvider>
+  )
+}
+
+export function ProfileTourReplayButton() {
+  const { setIsTourCompleted, startTour, setSteps } = useTour()
+  const hasReset = useRef(false)
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className="gap-1.5 text-xs text-muted-foreground"
+      onClick={() => {
+        localStorage.removeItem(STORAGE_KEY)
+        setIsTourCompleted(false)
+        if (!hasReset.current) {
+          hasReset.current = true
+          setSteps(steps)
+        }
+        setTimeout(() => startTour(), 100)
+      }}
+    >
+      <CircleHelp className="size-3.5" />
+      How to use
+    </Button>
+  )
+}
+
+function ProfileTourTrigger() {
+  const op = useOpenPanel()
+  const {
+    setSteps,
+    isTourCompleted,
+    setIsTourCompleted,
+    currentStep,
+    isActive,
+  } = useTour()
+  const [showDialog, setShowDialog] = useState(false)
+  const hasFilledInput = useRef(false)
+
+  useEffect(() => {
+    const completed = localStorage.getItem(STORAGE_KEY) === "true"
+    if (completed) {
+      setIsTourCompleted(true)
+      return
+    }
+
+    setSteps(steps)
+
+    const timer = setTimeout(() => {
+      setShowDialog(true)
+    }, 500)
+
+    return () => clearTimeout(timer)
+  }, [setSteps, setIsTourCompleted])
+
+  // When entering the badge popover step, click the first badge to open it
+  useEffect(() => {
+    if (!isActive || currentStep !== 3) return
+    const badge = document.getElementById(
+      PROFILE_TOUR_STEP_IDS.BADGE_POPOVER,
+    )
+    if (badge) {
+      badge.click()
+    }
+  }, [isActive, currentStep])
+
+  // When leaving the badge popover step, close the popover
+  useEffect(() => {
+    if (!isActive || currentStep !== 4) return
+
+    requestAnimationFrame(() => {
+      const badge = document.getElementById(
+        PROFILE_TOUR_STEP_IDS.BADGE_POPOVER,
+      )
+      if (badge) badge.click()
+    })
+
+    setTimeout(() => {
+      const el = document.getElementById(
+        PROFILE_TOUR_STEP_IDS.TEMPLATE_OUTPUT,
+      )
+      if (el) {
+        el.scrollIntoView({ behavior: "smooth", block: "center" })
+      }
+    }, 150)
+  }, [isActive, currentStep])
+
+  // When tour starts (step 0), fill the input and trigger generate
+  useEffect(() => {
+    if (!isActive || currentStep !== 0 || hasFilledInput.current) return
+    hasFilledInput.current = true
+
+    const input = document.querySelector<HTMLInputElement>("#user-input")
+    if (!input) return
+
+    const demo = "jal-co"
+    let i = 0
+    input.focus()
+
+    const nativeSetter = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      "value",
+    )?.set
+    const typeChar = () => {
+      if (i < demo.length) {
+        i++
+        nativeSetter?.call(input, demo.slice(0, i))
+        input.dispatchEvent(new Event("input", { bubbles: true }))
+        setTimeout(typeChar, 40 + Math.random() * 30)
+      } else {
+        setTimeout(() => {
+          input.dispatchEvent(
+            new KeyboardEvent("keydown", {
+              key: "Enter",
+              bubbles: true,
+            }),
+          )
+        }, 300)
+      }
+    }
+    setTimeout(typeChar, 400)
+  }, [isActive, currentStep])
+
+  useEffect(() => {
+    if (isTourCompleted) {
+      localStorage.setItem(STORAGE_KEY, "true")
+    }
+  }, [isTourCompleted])
+
+  const handleOpenChange = (open: boolean) => {
+    setShowDialog(open)
+    if (!open) {
+      localStorage.setItem(STORAGE_KEY, "true")
+      setIsTourCompleted(true)
+      op.track("tour_skipped", { tour: "profile-generator" })
+    }
+  }
+
+  return <TourAlertDialog isOpen={showDialog} setIsOpen={handleOpenChange} />
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,7 @@ import { GenHeroInput } from "@/components/gen-hero-input"
 import { SiteShell } from "@/components/site-shell"
 import { pageMetadata } from "@/lib/metadata"
 import { websiteJsonLd, softwareAppJsonLd } from "@/lib/json-ld"
-import { pickToken } from "@/lib/token-pool"
+import { getGenCount } from "@/lib/gen-counter"
 
 export const metadata: Metadata = pageMetadata({
   title: "shieldcn — Beautiful README Badges",
@@ -19,30 +19,8 @@ export const metadata: Metadata = pageMetadata({
   ogTitle: "shieldcn — Beautiful README Badges",
 })
 
-async function getAdoptionCount(): Promise<number | null> {
-  try {
-    const token = await pickToken()
-    if (!token) return null
-    const res = await fetch(
-      "https://api.github.com/search/code?q=%22shieldcn.dev%22+language%3AMarkdown&per_page=1",
-      {
-        headers: {
-          Accept: "application/vnd.github.v3+json",
-          Authorization: `Bearer ${token}`,
-        },
-        next: { revalidate: 3600 },
-      }
-    )
-    if (!res.ok) return null
-    const data = await res.json()
-    return typeof data.total_count === "number" ? data.total_count : null
-  } catch {
-    return null
-  }
-}
-
 export default async function Home() {
-  const adoptionCount = await getAdoptionCount()
+  const genCount = await getGenCount()
   return (
     <SiteShell>
       <script
@@ -67,18 +45,13 @@ export default async function Home() {
                 6 variants, 16 themes, 30,000+ built-in icons, and custom SVG upload — unlimited combinations.
               </p>
 
-              {adoptionCount !== null && adoptionCount > 0 && (
+              {genCount !== null && genCount > 0 && (
                 <p className="text-sm text-muted-foreground/70">
-                  Used in{" "}
-                  <a
-                    href="https://github.com/search?q=%22shieldcn.dev%22+language%3AMarkdown&type=code&l=Markdown"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="font-medium text-foreground underline underline-offset-4 decoration-border hover:decoration-foreground transition-colors"
-                  >
-                    {adoptionCount} {adoptionCount === 1 ? "repo" : "repos"}
-                  </a>{" "}
-                  and counting.
+                  Over{" "}
+                  <span className="font-medium text-foreground">
+                    {genCount.toLocaleString()}
+                  </span>{" "}
+                  badges generated and counting.
                 </p>
               )}
 

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -5,7 +5,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: [
       {
         userAgent: "*",
-        allow: ["/", "/docs/", "/showcase", "/gallery", "/gen", "/sponsor"],
+        allow: ["/", "/docs/", "/showcase", "/gallery", "/gen", "/gen/profile", "/sponsor"],
         disallow: ["/api/", "/dev/"],
       },
     ],

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -31,6 +31,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: BASE_URL, lastModified: now, changeFrequency: "weekly", priority: 1 },
     { url: `${BASE_URL}/showcase`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
     { url: `${BASE_URL}/gen`, lastModified: now, changeFrequency: "weekly", priority: 0.8 },
+    { url: `${BASE_URL}/gen/profile`, lastModified: now, changeFrequency: "weekly", priority: 0.85 },
     { url: `${BASE_URL}/sponsor`, lastModified: now, changeFrequency: "monthly", priority: 0.5 },
     { url: `${BASE_URL}/token-pool`, lastModified: now, changeFrequency: "monthly", priority: 0.4 },
   ]

--- a/components/gen-hero-input.tsx
+++ b/components/gen-hero-input.tsx
@@ -18,7 +18,16 @@ export function GenHeroInput() {
   const handleSubmit = () => {
     const trimmed = value.trim()
     if (!trimmed) return
-    router.push(`/gen?url=${encodeURIComponent(trimmed)}`)
+
+    // Smart routing: if it looks like a username (no slash, no URL), go to profile
+    // If it contains a slash (owner/repo) or is a full URL, go to repo generator
+    const isRepo =
+      trimmed.includes("/") || trimmed.startsWith("http")
+    if (isRepo) {
+      router.push(`/gen?url=${encodeURIComponent(trimmed)}`)
+    } else {
+      router.push(`/gen/profile?user=${encodeURIComponent(trimmed)}`)
+    }
   }
 
   // Dismiss on Escape
@@ -46,7 +55,7 @@ export function GenHeroInput() {
         )}
       >
         <span className="rounded-full border border-border/60 bg-white px-3 py-1 text-xs font-semibold text-zinc-600 shadow-sm group-hover:text-zinc-900 group-hover:border-border transition-colors dark:bg-white dark:text-zinc-600 dark:group-hover:text-zinc-900">
-          Try it yourself — paste a GitHub repo
+          Try it — username for profile, owner/repo for badges
         </span>
         {/* Tail */}
         <svg
@@ -70,7 +79,7 @@ export function GenHeroInput() {
         <Input
           ref={inputRef}
           type="text"
-          placeholder="vercel/next.js"
+          placeholder="sindresorhus or vercel/next.js"
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onFocus={() => setFocused(true)}

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import * as React from "react"
+import { Switch as SwitchPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground"
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -41,5 +41,11 @@ export async function initDB() {
     );
     CREATE INDEX IF NOT EXISTS idx_github_tokens_valid
       ON github_tokens (is_valid) WHERE is_valid = TRUE;
+
+    CREATE TABLE IF NOT EXISTS gen_counter (
+      id TEXT PRIMARY KEY DEFAULT 'badges',
+      count BIGINT NOT NULL DEFAULT 0
+    );
+    INSERT INTO gen_counter (id, count) VALUES ('badges', 0) ON CONFLICT DO NOTHING;
   `)
 }

--- a/lib/gen-counter.ts
+++ b/lib/gen-counter.ts
@@ -1,0 +1,44 @@
+/**
+ * shieldcn
+ * lib/gen-counter
+ *
+ * Tracks total badges generated across both generators (repo + profile).
+ * Uses a single row in Postgres for fast reads on the homepage.
+ */
+
+import { getPool } from "@/lib/db"
+
+/**
+ * Increment the badge counter by a given amount.
+ * Called after each successful generation.
+ */
+export async function incrementGenCounter(badgeCount: number): Promise<void> {
+  if (badgeCount <= 0) return
+  try {
+    const db = getPool()
+    await db.query(
+      `INSERT INTO gen_counter (id, count) VALUES ('badges', $1)
+       ON CONFLICT (id) DO UPDATE SET count = gen_counter.count + $1`,
+      [badgeCount],
+    )
+  } catch {
+    // Silently fail — don't block the response for a counter
+  }
+}
+
+/**
+ * Get the current badge generation count.
+ * Returns null if the DB is unavailable.
+ */
+export async function getGenCount(): Promise<number | null> {
+  try {
+    const db = getPool()
+    const result = await db.query(
+      `SELECT count FROM gen_counter WHERE id = 'badges'`,
+    )
+    if (result.rows.length === 0) return 0
+    return Number(result.rows[0].count)
+  } catch {
+    return null
+  }
+}

--- a/lib/gen/config.ts
+++ b/lib/gen/config.ts
@@ -1,9 +1,13 @@
 import type { Badge, BadgeGroup, GlobalSettings } from './shieldcn';
 import { DEFAULT_GLOBAL } from './shieldcn';
 
+export type RepoSource = { type: 'github'; url: string; owner: string; repo: string };
+export type ProfileSource = { type: 'profile'; url: string; username: string };
+export type ConfigSource = RepoSource | ProfileSource;
+
 export type Config = {
   version: 1;
-  source: { type: 'github'; url: string; owner: string; repo: string };
+  source: ConfigSource;
   global: GlobalSettings;
   badges: Badge[];
   generatedAt: string;
@@ -16,6 +20,10 @@ const VALID_GROUPS: BadgeGroup[] = [
   'stack',
   'modern',
   'community',
+  'profile',
+  'social',
+  'skills',
+  'repos',
 ];
 
 export function serialize(config: Config): string {
@@ -76,9 +84,19 @@ export function deserialize(raw: string):
   if (parsed.version !== 1) {
     return { ok: false, error: `Unsupported config version: ${parsed.version ?? 'missing'}` };
   }
-  const source = parsed.source as Partial<Config['source']> | undefined;
-  if (!isPlainObject(source) || typeof source.owner !== 'string' || typeof source.repo !== 'string') {
-    return { ok: false, error: 'Missing source.owner / source.repo' };
+  const source = parsed.source as Record<string, unknown> | undefined;
+  if (!isPlainObject(source)) {
+    return { ok: false, error: 'Missing source object' };
+  }
+  // Profile sources need username, repo sources need owner/repo
+  if (source.type === 'profile') {
+    if (typeof source.username !== 'string') {
+      return { ok: false, error: 'Missing source.username for profile config' };
+    }
+  } else {
+    if (typeof source.owner !== 'string' || typeof source.repo !== 'string') {
+      return { ok: false, error: 'Missing source.owner / source.repo' };
+    }
   }
   if (!Array.isArray(parsed.badges)) {
     return { ok: false, error: 'badges must be an array' };
@@ -92,13 +110,21 @@ export function deserialize(raw: string):
     else droppedCount++;
   }
 
+  const sourceType = source.type === 'profile' ? 'profile' : 'github';
+  const sOwner = typeof source.owner === 'string' ? source.owner : '';
+  const sRepo = typeof source.repo === 'string' ? source.repo : '';
+  const sUsername = typeof source.username === 'string' ? source.username : sOwner;
   const safeUrl = typeof source.url === 'string'
-    ? safeLinkUrl(source.url) ?? `https://github.com/${source.owner}/${source.repo}`
-    : `https://github.com/${source.owner}/${source.repo}`;
+    ? safeLinkUrl(source.url) ?? `https://github.com/${sOwner || sUsername}`
+    : `https://github.com/${sOwner || sUsername}`;
+
+  const resolvedSource: Config['source'] = sourceType === 'profile'
+    ? { type: 'profile', username: sUsername, url: safeUrl }
+    : { type: 'github', owner: sOwner, repo: sRepo, url: safeUrl };
 
   const config: Config = {
     version: 1,
-    source: { type: 'github', owner: source.owner, repo: source.repo, url: safeUrl },
+    source: resolvedSource,
     global: { ...DEFAULT_GLOBAL, ...(isPlainObject(parsed.global) ? parsed.global : {}) },
     badges,
     generatedAt:
@@ -122,7 +148,7 @@ export function deserialize(raw: string):
  */
 export function mergeRefresh(
   saved: Config,
-  fresh: { badges: Badge[]; source: Config['source'] },
+  fresh: { badges: Badge[]; source: ConfigSource },
 ): { config: Config; diff: { added: string[]; refreshed: string[]; missing: string[] } } {
   const freshMap = new Map(fresh.badges.map((b) => [b.id, b]));
   const savedMap = new Map(saved.badges.map((b) => [b.id, b]));

--- a/lib/gen/detect-profile.ts
+++ b/lib/gen/detect-profile.ts
@@ -1,0 +1,651 @@
+// shieldcn — lib/gen/detect-profile.ts
+// Profile README badge detection — inspects a GitHub user profile and their
+// top repos to generate profile-oriented badge sets.
+
+import type { Badge } from "./shieldcn"
+import { staticBadgePath } from "./shieldcn"
+import { matchBrand } from "./brands"
+
+export type ProfileInspectResult = {
+  source: { username: string; url: string }
+  badges: Badge[]
+  notes: string[]
+  profile: GitHubUserProfile | null
+}
+
+export type GitHubUserProfile = {
+  login: string
+  name: string | null
+  bio: string | null
+  location: string | null
+  company: string | null
+  blog: string | null
+  twitter_username: string | null
+  public_repos: number
+  public_gists: number
+  followers: number
+  following: number
+  created_at: string
+  avatar_url: string
+}
+
+type GitHubRepo = {
+  name: string
+  full_name: string
+  description: string | null
+  html_url: string
+  stargazers_count: number
+  forks_count: number
+  language: string | null
+  fork: boolean
+  archived: boolean
+  topics: string[]
+}
+
+type PackageJson = {
+  name?: string
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+}
+
+const API = "https://api.github.com"
+const RAW = "https://raw.githubusercontent.com"
+
+// ── Helpers ──────────────────────────────────────────
+
+function isAbort(e: unknown): boolean {
+  return (
+    e instanceof Error &&
+    (e.name === "AbortError" ||
+      (typeof DOMException !== "undefined" &&
+        e instanceof DOMException &&
+        e.name === "AbortError"))
+  )
+}
+
+async function fetchJson<T = unknown>(
+  url: string,
+  signal?: AbortSignal,
+): Promise<T | null> {
+  try {
+    const res = await fetch(url, { signal })
+    if (!res.ok) return null
+    return (await res.json()) as T
+  } catch (e) {
+    if (isAbort(e)) throw e
+    return null
+  }
+}
+
+async function fetchText(
+  url: string,
+  signal?: AbortSignal,
+): Promise<string | null> {
+  try {
+    const res = await fetch(url, { signal })
+    if (!res.ok) return null
+    return await res.text()
+  } catch (e) {
+    if (isAbort(e)) throw e
+    return null
+  }
+}
+
+function parseUsername(input: string): string | null {
+  const trimmed = input.trim()
+  if (!trimmed) return null
+
+  // Pure username: letters, numbers, hyphens
+  if (/^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/.test(trimmed)) {
+    return trimmed
+  }
+
+  // GitHub URL: https://github.com/{username}
+  try {
+    const url = new URL(
+      trimmed.startsWith("http") ? trimmed : `https://${trimmed}`,
+    )
+    if (!/^github\.com$/i.test(url.hostname)) return null
+    const parts = url.pathname.replace(/^\/+|\/+$/g, "").split("/")
+    // Must be exactly one segment (user profile, not a repo)
+    if (parts.length === 1 && parts[0]) return parts[0]
+    return null
+  } catch {
+    return null
+  }
+}
+
+// ── Social link extraction from README ───────────────
+
+interface SocialLink {
+  platform: string
+  url: string
+  slug: string
+  color: string
+  username?: string
+}
+
+function extractSocialLinks(readme: string): SocialLink[] {
+  const links: SocialLink[] = []
+  const seen = new Set<string>()
+
+  const patterns: Array<{
+    platform: string
+    re: RegExp
+    slug: string
+    color: string
+    extractUsername?: (match: RegExpMatchArray) => string | undefined
+  }> = [
+    {
+      platform: "Twitter / X",
+      re: /https?:\/\/(?:twitter\.com|x\.com)\/([\w]+)/gi,
+      slug: "x",
+      color: "000000",
+      extractUsername: (m) => m[1],
+    },
+    {
+      platform: "LinkedIn",
+      re: /https?:\/\/(?:www\.)?linkedin\.com\/in\/([\w-]+)/gi,
+      slug: "linkedin",
+      color: "0A66C2",
+      extractUsername: (m) => m[1],
+    },
+    {
+      platform: "YouTube",
+      re: /https?:\/\/(?:www\.)?youtube\.com\/(?:@|c\/|channel\/)([\w-]+)/gi,
+      slug: "youtube",
+      color: "FF0000",
+      extractUsername: (m) => m[1],
+    },
+    {
+      platform: "Twitch",
+      re: /https?:\/\/(?:www\.)?twitch\.tv\/([\w]+)/gi,
+      slug: "twitch",
+      color: "9146FF",
+    },
+    {
+      platform: "Discord",
+      re: /https?:\/\/discord\.(?:gg|com\/invite)\/([\w-]+)/gi,
+      slug: "discord",
+      color: "5865F2",
+    },
+    {
+      platform: "Dev.to",
+      re: /https?:\/\/dev\.to\/([\w-]+)/gi,
+      slug: "devdotto",
+      color: "0A0A0A",
+    },
+    {
+      platform: "Hashnode",
+      re: /https?:\/\/([\w-]+)\.hashnode\.dev/gi,
+      slug: "hashnode",
+      color: "2962FF",
+    },
+    {
+      platform: "Medium",
+      re: /https?:\/\/(?:medium\.com|[\w]+\.medium\.com)\/@?([\w-]+)/gi,
+      slug: "medium",
+      color: "000000",
+    },
+    {
+      platform: "Stack Overflow",
+      re: /https?:\/\/stackoverflow\.com\/users\/(\d+)/gi,
+      slug: "stackoverflow",
+      color: "F58025",
+    },
+    {
+      platform: "Mastodon",
+      re: /https?:\/\/([\w.-]+)\/@([\w]+)/gi,
+      slug: "mastodon",
+      color: "6364FF",
+    },
+    {
+      platform: "Bluesky",
+      re: /https?:\/\/bsky\.app\/profile\/([\w.-]+)/gi,
+      slug: "bluesky",
+      color: "0085FF",
+    },
+    {
+      platform: "Instagram",
+      re: /https?:\/\/(?:www\.)?instagram\.com\/([\w.]+)/gi,
+      slug: "instagram",
+      color: "E4405F",
+    },
+    {
+      platform: "Reddit",
+      re: /https?:\/\/(?:www\.)?reddit\.com\/u(?:ser)?\/([\w-]+)/gi,
+      slug: "reddit",
+      color: "FF4500",
+    },
+  ]
+
+  for (const { platform, re, slug, color, extractUsername } of patterns) {
+    const matches = [...readme.matchAll(re)]
+    if (matches.length === 0) continue
+    if (seen.has(slug)) continue
+    seen.add(slug)
+    const match = matches[0]!
+    const url = match[0]
+    links.push({
+      platform,
+      url,
+      slug,
+      color,
+      username: extractUsername?.(match),
+    })
+  }
+
+  return links
+}
+
+// ── Language → brand mapping ─────────────────────────
+
+const LANGUAGE_BRANDS: Record<
+  string,
+  { slug: string; color: string; label: string }
+> = {
+  TypeScript: { slug: "typescript", color: "3178C6", label: "TypeScript" },
+  JavaScript: { slug: "javascript", color: "F7DF1E", label: "JavaScript" },
+  Python: { slug: "python", color: "3776AB", label: "Python" },
+  Rust: { slug: "rust", color: "000000", label: "Rust" },
+  Go: { slug: "go", color: "00ADD8", label: "Go" },
+  Java: { slug: "openjdk", color: "ED8B00", label: "Java" },
+  Kotlin: { slug: "kotlin", color: "7F52FF", label: "Kotlin" },
+  Swift: { slug: "swift", color: "F05138", label: "Swift" },
+  Ruby: { slug: "ruby", color: "CC342D", label: "Ruby" },
+  PHP: { slug: "php", color: "777BB4", label: "PHP" },
+  "C#": { slug: "csharp", color: "512BD4", label: "C#" },
+  "C++": { slug: "cplusplus", color: "00599C", label: "C++" },
+  C: { slug: "c", color: "A8B9CC", label: "C" },
+  Dart: { slug: "dart", color: "0175C2", label: "Dart" },
+  Elixir: { slug: "elixir", color: "4B275F", label: "Elixir" },
+  Haskell: { slug: "haskell", color: "5D4F85", label: "Haskell" },
+  Lua: { slug: "lua", color: "2C2D72", label: "Lua" },
+  Scala: { slug: "scala", color: "DC322F", label: "Scala" },
+  Shell: { slug: "gnubash", color: "4EAA25", label: "Bash" },
+  Vue: { slug: "vuedotjs", color: "4FC08D", label: "Vue" },
+  Svelte: { slug: "svelte", color: "FF3E00", label: "Svelte" },
+  Zig: { slug: "zig", color: "F7A41D", label: "Zig" },
+  Nim: { slug: "nim", color: "FFE953", label: "Nim" },
+  Nix: { slug: "nixos", color: "5277C3", label: "Nix" },
+  OCaml: { slug: "ocaml", color: "EC6813", label: "OCaml" },
+  Clojure: { slug: "clojure", color: "5881D8", label: "Clojure" },
+  R: { slug: "r", color: "276DC3", label: "R" },
+  MATLAB: { slug: "matlab", color: "0076A8", label: "MATLAB" },
+  Jupyter: { slug: "jupyter", color: "F37626", label: "Jupyter" },
+}
+
+const SKILLS_CAP = 12
+
+// ── Badge builders ───────────────────────────────────
+
+function profileBadges(
+  user: GitHubUserProfile,
+  username: string,
+): Badge[] {
+  const badges: Badge[] = []
+
+  const mk = (
+    id: string,
+    label: string,
+    path: string,
+    query: Record<string, string> = {},
+    linkUrl?: string,
+  ): Badge => ({
+    id,
+    group: "profile",
+    label,
+    path,
+    query,
+    overrides: {},
+    enabled: true,
+    linkUrl,
+  })
+
+  badges.push(
+    mk(
+      "profile.followers",
+      "GitHub Followers",
+      `/github/followers/${username}.svg`,
+      { variant: "outline" },
+      `https://github.com/${username}?tab=followers`,
+    ),
+  )
+  badges.push(
+    mk(
+      "profile.stars",
+      "GitHub Stars",
+      `/github/user-stars/${username}.svg`,
+      { variant: "secondary" },
+      `https://github.com/${username}?tab=repositories`,
+    ),
+  )
+  badges.push(
+    mk(
+      "profile.repos",
+      "Public Repos",
+      staticBadgePath("Repos", String(user.public_repos), "2563eb"),
+      { logo: "github", variant: "outline" },
+      `https://github.com/${username}?tab=repositories`,
+    ),
+  )
+
+  if (user.location) {
+    badges.push(
+      mk(
+        "profile.location",
+        "Location",
+        staticBadgePath("Location", user.location, "6366f1"),
+        { logo: "googlemaps", variant: "ghost" },
+      ),
+    )
+  }
+
+  if (user.company) {
+    const company = user.company.replace(/^@/, "")
+    badges.push(
+      mk(
+        "profile.company",
+        "Company",
+        staticBadgePath("Company", company, "1f2937"),
+        { logo: "building", variant: "ghost" },
+      ),
+    )
+  }
+
+  return badges
+}
+
+function socialBadges(
+  user: GitHubUserProfile,
+  username: string,
+  readme: string | null,
+): Badge[] {
+  const badges: Badge[] = []
+  const seen = new Set<string>()
+
+  const mk = (
+    id: string,
+    label: string,
+    path: string,
+    query: Record<string, string> = {},
+    linkUrl?: string,
+  ): Badge => ({
+    id,
+    group: "social",
+    label,
+    path,
+    query,
+    overrides: {},
+    enabled: true,
+    linkUrl,
+  })
+
+  // GitHub profile
+  badges.push(
+    mk(
+      "social.github",
+      "GitHub",
+      staticBadgePath("GitHub", `@${username}`, "181717"),
+      { logo: "github", variant: "branded" },
+      `https://github.com/${username}`,
+    ),
+  )
+  seen.add("github")
+
+  // Twitter from API
+  if (user.twitter_username) {
+    badges.push(
+      mk(
+        "social.twitter",
+        "Twitter / X",
+        staticBadgePath("Follow", `@${user.twitter_username}`, "000000"),
+        { logo: "x", variant: "branded" },
+        `https://x.com/${user.twitter_username}`,
+      ),
+    )
+    seen.add("x")
+  }
+
+  // Website from API
+  if (user.blog) {
+    const blog = user.blog.startsWith("http")
+      ? user.blog
+      : `https://${user.blog}`
+    const displayUrl = blog
+      .replace(/^https?:\/\//, "")
+      .replace(/\/$/, "")
+    badges.push(
+      mk(
+        "social.website",
+        "Website",
+        staticBadgePath("Website", displayUrl, "4f46e5"),
+        { logo: "safari", variant: "outline" },
+        blog,
+      ),
+    )
+  }
+
+  // Extract additional social links from README
+  if (readme) {
+    const socialLinks = extractSocialLinks(readme)
+    for (const link of socialLinks) {
+      if (seen.has(link.slug)) continue
+      seen.add(link.slug)
+      const display = link.username
+        ? `@${link.username}`
+        : link.platform
+      badges.push(
+        mk(
+          `social.${link.slug}`,
+          link.platform,
+          staticBadgePath(link.platform, display, link.color),
+          { logo: link.slug, variant: "branded" },
+          link.url,
+        ),
+      )
+    }
+  }
+
+  return badges
+}
+
+function skillsBadges(
+  repos: GitHubRepo[],
+  packageJsons: (PackageJson | null)[],
+): Badge[] {
+  const badges: Badge[] = []
+  const seen = new Set<string>()
+
+  // 1. Languages from repos (weighted by stars)
+  const langWeight = new Map<string, number>()
+  for (const repo of repos) {
+    if (!repo.language || repo.fork || repo.archived) continue
+    const w = langWeight.get(repo.language) ?? 0
+    langWeight.set(repo.language, w + Math.max(repo.stargazers_count, 1))
+  }
+  const sortedLangs = [...langWeight.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 8)
+
+  for (const [lang] of sortedLangs) {
+    const brand = LANGUAGE_BRANDS[lang]
+    if (!brand || seen.has(brand.slug)) continue
+    seen.add(brand.slug)
+    badges.push({
+      id: `skills.lang.${brand.slug}`,
+      group: "skills",
+      label: brand.label,
+      path: staticBadgePath("", brand.label, brand.color),
+      query: { logo: brand.slug, variant: "branded" },
+      overrides: {},
+      enabled: true,
+    })
+  }
+
+  // 2. Frameworks & tools from package.json dependencies
+  const allDeps: Record<string, string> = {}
+  for (const pkg of packageJsons) {
+    if (!pkg) continue
+    Object.assign(allDeps, pkg.dependencies, pkg.devDependencies, pkg.peerDependencies)
+  }
+
+  const depBrands: Array<{ slug: string; label: string; color: string }> = []
+  for (const name of Object.keys(allDeps)) {
+    const brand = matchBrand(name)
+    if (!brand || seen.has(brand.slug)) continue
+    seen.add(brand.slug)
+    depBrands.push(brand)
+    if (depBrands.length >= SKILLS_CAP - badges.length) break
+  }
+
+  for (const brand of depBrands) {
+    badges.push({
+      id: `skills.dep.${brand.slug}`,
+      group: "skills",
+      label: brand.label,
+      path: staticBadgePath("", brand.label, brand.color),
+      query: { logo: brand.slug, variant: "branded" },
+      overrides: {},
+      enabled: true,
+    })
+  }
+
+  return badges.slice(0, SKILLS_CAP)
+}
+
+function repoBadges(repos: GitHubRepo[]): Badge[] {
+  // Pick top repos by stars (non-fork, non-archived)
+  const top = repos
+    .filter((r) => !r.fork && !r.archived && r.stargazers_count > 0)
+    .sort((a, b) => b.stargazers_count - a.stargazers_count)
+    .slice(0, 6)
+
+  return top.map((repo) => ({
+    id: `repos.${repo.full_name.replace("/", ".")}`,
+    group: "repos" as const,
+    label: `${repo.name} ⭐ ${repo.stargazers_count}`,
+    path: `/github/stars/${repo.full_name}.svg`,
+    query: { variant: "outline" },
+    overrides: {},
+    enabled: true,
+    linkUrl: repo.html_url,
+  }))
+}
+
+// ── Main inspect function ────────────────────────────
+
+export async function inspectProfile(
+  input: string,
+  externalSignal?: AbortSignal,
+): Promise<ProfileInspectResult | { error: string }> {
+  const username = parseUsername(input)
+  if (!username) {
+    return { error: "Enter a GitHub username (e.g. jal-co)" }
+  }
+
+  const controller = new AbortController()
+  const timer = setTimeout(
+    () => controller.abort(new DOMException("Timeout", "AbortError")),
+    20_000,
+  )
+  if (externalSignal) {
+    if (externalSignal.aborted) controller.abort(externalSignal.reason)
+    else
+      externalSignal.addEventListener("abort", () =>
+        controller.abort(externalSignal.reason),
+      )
+  }
+  const signal = controller.signal
+
+  try {
+    // 1. Fetch user profile + repos in parallel
+    const [user, repos] = await Promise.all([
+      fetchJson<GitHubUserProfile>(`${API}/users/${username}`, signal),
+      fetchJson<GitHubRepo[]>(
+        `${API}/users/${username}/repos?sort=stars&per_page=30&type=owner`,
+        signal,
+      ),
+    ])
+
+    if (!user) {
+      return { error: `GitHub user "${username}" not found` }
+    }
+
+    const notes: string[] = []
+    const allBadges: Badge[] = []
+
+    // 2. Fetch profile README
+    const readme = await fetchText(
+      `${RAW}/${username}/${username}/HEAD/README.md`,
+      signal,
+    )
+    if (!readme) {
+      notes.push(
+        `No profile README found at ${username}/${username}. Create one to unlock social badge detection.`,
+      )
+    }
+
+    // 3. Profile badges
+    allBadges.push(...profileBadges(user, username))
+
+    // 4. Social badges
+    allBadges.push(...socialBadges(user, username, readme))
+
+    // 5. Skills — scan top repos for package.json
+    const repoList = repos ?? []
+    const topRepos = repoList
+      .filter((r) => !r.fork && !r.archived)
+      .sort((a, b) => b.stargazers_count - a.stargazers_count)
+      .slice(0, 6)
+
+    const packageJsons = await Promise.all(
+      topRepos.map((repo) =>
+        fetchText(
+          `${RAW}/${repo.full_name}/HEAD/package.json`,
+          signal,
+        ).then((text) => {
+          if (!text) return null
+          try {
+            return JSON.parse(text) as PackageJson
+          } catch {
+            return null
+          }
+        }),
+      ),
+    )
+
+    allBadges.push(...skillsBadges(repoList, packageJsons))
+
+    // 6. Top repos
+    allBadges.push(...repoBadges(repoList))
+
+    if (topRepos.length === 0) {
+      notes.push("No public repos with stars found — repo badges skipped.")
+    }
+
+    const pkgsScanned = packageJsons.filter(Boolean).length
+    if (pkgsScanned > 0) {
+      notes.push(
+        `Scanned ${pkgsScanned} package.json file${pkgsScanned === 1 ? "" : "s"} for skill detection.`,
+      )
+    }
+
+    return {
+      source: { username, url: `https://github.com/${username}` },
+      badges: allBadges,
+      notes,
+      profile: user,
+    }
+  } catch (e) {
+    if (isAbort(e)) {
+      return { error: controller.signal.reason?.message ?? "Request was cancelled" }
+    }
+    throw e
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export { parseUsername }

--- a/lib/gen/profile-search-params.ts
+++ b/lib/gen/profile-search-params.ts
@@ -1,0 +1,48 @@
+// shieldcn — lib/gen/profile-search-params.ts
+// nuqs search param parsers for the profile badge generator
+
+import {
+  parseAsString,
+  parseAsStringEnum,
+  createSearchParamsCache,
+} from "nuqs/server"
+import type { Variant, Size, Mode, Theme } from "./shieldcn"
+
+const VARIANTS: Variant[] = [
+  "default",
+  "secondary",
+  "outline",
+  "ghost",
+  "destructive",
+  "branded",
+]
+const SIZES: Size[] = ["xs", "sm", "default", "lg"]
+const MODES: Mode[] = ["dark", "light"]
+const THEMES: Theme[] = [
+  "none",
+  "zinc",
+  "slate",
+  "stone",
+  "neutral",
+  "gray",
+  "blue",
+  "green",
+  "rose",
+  "orange",
+  "amber",
+  "violet",
+  "purple",
+  "red",
+  "cyan",
+  "emerald",
+]
+
+export const profileSearchParams = {
+  user: parseAsString.withDefault(""),
+  variant: parseAsStringEnum(VARIANTS).withDefault("default"),
+  size: parseAsStringEnum(SIZES).withDefault("sm"),
+  mode: parseAsStringEnum(MODES).withDefault("dark"),
+  theme: parseAsStringEnum(THEMES).withDefault("none"),
+}
+
+export const profileSearchParamsCache = createSearchParamsCache(profileSearchParams)

--- a/lib/gen/shieldcn.ts
+++ b/lib/gen/shieldcn.ts
@@ -74,7 +74,11 @@ export type BadgeGroup =
   | 'stack'
   | 'tooling'
   | 'modern'
-  | 'community';
+  | 'community'
+  | 'profile'
+  | 'social'
+  | 'skills'
+  | 'repos';
 
 export type Badge = {
   id: string;

--- a/lib/json-ld.ts
+++ b/lib/json-ld.ts
@@ -56,6 +56,41 @@ export function softwareAppJsonLd() {
   }
 }
 
+/** WebApplication schema for profile README generator — rich SEO signal */
+export function profileReadmeJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    name: "GitHub Profile README Badge Generator",
+    url: `${SITE_URL}/gen/profile`,
+    applicationCategory: "DeveloperApplication",
+    operatingSystem: "Any",
+    description:
+      "Generate beautiful badges for your GitHub profile README. Auto-detects skills, languages, social links, and top repos. Styled as shadcn/ui buttons with 6 variants, 16 themes, and 40,000+ icons.",
+    offers: {
+      "@type": "Offer",
+      price: "0",
+      priceCurrency: "USD",
+    },
+    author: {
+      "@type": "Person",
+      name: "Justin Levine",
+      url: "https://justinlevine.me",
+    },
+    isAccessibleForFree: true,
+    keywords: [
+      "github profile readme",
+      "github profile readme badges",
+      "github profile readme generator",
+      "profile readme badges",
+      "readme badge generator",
+      "github badges",
+      "developer profile",
+      "shadcn badges",
+    ],
+  }
+}
+
 /** TechArticle schema for doc pages */
 export function techArticleJsonLd({
   title,

--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -5,7 +5,8 @@
  * GitHub REST API client. Uses the token pool for distributed rate limiting.
  * Supports: stars, forks, watchers, branches, releases, tags, license,
  *           contributors, checks, issues, PRs, milestones, commits,
- *           last-commit, assets-dl, dependents, dependabot.
+ *           last-commit, assets-dl, dependents, dependabot,
+ *           followers, user-stars.
  */
 
 import type { BadgeData } from "@/lib/badges/types"
@@ -482,4 +483,37 @@ export async function getGitHubDependabot(owner: string, repo: string): Promise<
   if (r2) return { label: "dependabot", value: "enabled", color: "success" }
 
   return { label: "dependabot", value: "not found", color: "cancelled" }
+}
+
+// ---------------------------------------------------------------------------
+// User-level: followers, total stars
+// ---------------------------------------------------------------------------
+
+export async function getGitHubFollowers(username: string): Promise<BadgeData | null> {
+  const data = await githubJson(`https://api.github.com/users/${username}`)
+  if (!data || typeof data.followers !== "number") return null
+  return {
+    label: "followers",
+    value: formatCount(data.followers as number),
+    link: `https://github.com/${username}?tab=followers`,
+  }
+}
+
+export async function getGitHubUserStars(username: string): Promise<BadgeData | null> {
+  // Sum stargazers across all user-owned repos
+  const repos = await githubFetch(
+    `https://api.github.com/users/${username}/repos?per_page=100&sort=stars&type=owner`,
+  )
+  if (!repos) return null
+  const list = await repos.json() as Array<{ stargazers_count: number; fork: boolean }>
+  if (!Array.isArray(list)) return null
+  const total = list.reduce(
+    (sum, r) => sum + (r.fork ? 0 : (r.stargazers_count ?? 0)),
+    0,
+  )
+  return {
+    label: "stars",
+    value: formatCount(total),
+    link: `https://github.com/${username}?tab=repositories`,
+  }
 }

--- a/lib/tour-constants.ts
+++ b/lib/tour-constants.ts
@@ -1,5 +1,5 @@
 // shieldcn — lib/tour-constants.ts
-// Tour step IDs for the badge generator
+// Tour step IDs for the badge generators
 
 export const TOUR_STEP_IDS = {
   URL_INPUT: "tour-url-input",
@@ -7,4 +7,13 @@ export const TOUR_STEP_IDS = {
   BADGE_GROUP: "tour-badge-group",
   BADGE_POPOVER: "tour-badge-popover",
   COPY_ACTIONS: "tour-copy-actions",
+}
+
+export const PROFILE_TOUR_STEP_IDS = {
+  USER_INPUT: "tour-profile-user-input",
+  GLOBAL_DEFAULTS: "tour-profile-global-defaults",
+  BADGE_GROUP: "tour-profile-badge-group",
+  BADGE_POPOVER: "tour-profile-badge-popover",
+  TEMPLATE_OUTPUT: "tour-profile-template-output",
+  COPY_ACTIONS: "tour-profile-copy-actions",
 }


### PR DESCRIPTION
<!--begin:badgetizr-shieldcn--> 
![Ready](https://shieldcn.dev/badge/Ready-22C55E.svg?variant=default&mode=dark&size=sm&logo=ri:RiCheckFill&color=22C55E)  [![CI 25078104099](https://shieldcn.dev/badge/Build-25078104099-7C3AED.svg?variant=default&mode=dark&size=sm&logo=github&color=7C3AED)](https://github.com/jal-co/shieldcn/actions/runs/25078104099)
<!--end:badgetizr-shieldcn-->
## Summary

Adds a new **Profile README Badge Generator** at `/gen/profile` — enter a GitHub username and get a full set of badges for your profile README, auto-detected from your GitHub profile, repos, and social links.

### What it does

- **Profile badges** — followers, total stars, public repos, location, company
- **Social badges** — Twitter/X from API + 13 platforms extracted from profile README (LinkedIn, YouTube, Bluesky, Mastodon, Discord, Dev.to, Medium, Stack Overflow, etc.)
- **Skills badges** — top languages weighted by stars + frameworks/tools from `package.json` across top 6 repos
- **Top repo badges** — star count badges for top non-fork repos with links
- **Full README template** — toggle between raw badges and a centered profile README with sections (`## Skills`, `## Top Repos`, etc.)
- **Guided tour** — 6-step walkthrough with auto-typing demo (`jal-co`)

### Smart homepage input

The homepage input now routes intelligently:
- `sindresorhus` → `/gen/profile?user=sindresorhus`
- `vercel/next.js` → `/gen?url=vercel/next.js`

### Badge generation counter

Replaces the "Used in X repos" hero stat (GitHub code search) with **"Over X badges generated"** — a Postgres counter incremented on every generation. Faster, no token pool usage, measures actual value.

### New badge endpoints

- `/github/followers/{username}.svg`
- `/github/user-stars/{username}.svg`

### SEO

- Dedicated title: "GitHub Profile README Badge Generator"
- OG/Twitter cards, canonical URL, JSON-LD WebApplication schema
- Added to sitemap (0.85 priority) and robots.txt

### Files

- **7 new files** — profile page, client, tour, detection engine, search params, counter, API route
- **13 modified files** — types, config, route handler, homepage, hero input, JSON-LD, sitemap, robots, tour constants, GitHub provider
- **2,364 lines added**, 54 removed