### PR TITLE
fix: theme-provider next-themes typing for Vercel build

### DIFF
--- a/packages/web/components/theme-provider.tsx
+++ b/packages/web/components/theme-provider.tsx
@@ -1,18 +1,18 @@
 "use client"
 
 import * as React from "react"
-import { ThemeProvider as NextThemesProvider } from "next-themes"
+import { ThemeProvider as NextThemesProvider, type ThemeProviderProps } from "next-themes"
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   return (
-    // @ts-expect-error next-themes v0.4 ThemeProviderProps typing issue
     <NextThemesProvider
-      attribute="class"
-      defaultTheme="system"
-      enableSystem
-      disableTransitionOnChange
-    >
-      {children}
-    </NextThemesProvider>
+      {...{
+        attribute: "class",
+        defaultTheme: "system",
+        enableSystem: true,
+        disableTransitionOnChange: true,
+        children,
+      } as ThemeProviderProps}
+    />
   )
 }


### PR DESCRIPTION
<!--begin:badgetizr-shieldcn--> 
![Ready](https://shieldcn.dev/badge/Ready-22C55E.svg?variant=default&mode=dark&size=sm&logo=ri:RiCheckFill&color=22C55E)  [![CI 25087455897](https://shieldcn.dev/badge/Build-25087455897-7C3AED.svg?variant=default&mode=dark&size=sm&logo=github&color=7C3AED)](https://github.com/jal-co/shieldcn/actions/runs/25087455897)
<!--end:badgetizr-shieldcn-->
Fixes the Vercel build failure from #55.

The `@ts-expect-error` directive was unused on Vercel's TypeScript version (the next-themes types don't actually error there), causing `@ts-expect-error` itself to be the build error.

Fix: cast props to `ThemeProviderProps` instead of using `@ts-expect-error`. This handles the React 19 + next-themes v0.4 `children` typing inconsistency cleanly across all TypeScript versions.