### PR TITLE
fix: font path resolution for Vercel runtime

### DIFF
--- a/packages/core/src/badges/render.tsx
+++ b/packages/core/src/badges/render.tsx
@@ -29,10 +29,28 @@ import {
 } from "./button-tokens"
 
 // Pre-load all font files
-// Use import.meta.url to resolve relative to this file, not process.cwd()
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-const fontsDir = join(__dirname, "..", "fonts")
+// Try multiple paths to find fonts — Vercel, Docker standalone, and local dev
+// all resolve import.meta.url and process.cwd() differently.
+import { existsSync } from "node:fs"
+
+function findFontsDir(): string {
+  const candidates = [
+    // 1. Relative to this file via import.meta.url (works in Docker standalone)
+    join(dirname(fileURLToPath(import.meta.url)), "..", "fonts"),
+    // 2. In packages/core/src/fonts relative to cwd (works in local dev / Vercel)
+    join(process.cwd(), "packages", "core", "src", "fonts"),
+    // 3. Relative to cwd when cwd is packages/web (Vercel with root=packages/web)
+    join(process.cwd(), "..", "core", "src", "fonts"),
+    // 4. Legacy path (pre-monorepo)
+    join(process.cwd(), "lib", "fonts"),
+  ]
+  for (const dir of candidates) {
+    if (existsSync(join(dir, "inter-medium.ttf"))) return dir
+  }
+  throw new Error(`Could not find font files. Searched: ${candidates.join(", ")}`)
+}
+
+const fontsDir = findFontsDir()
 const interData = readFileSync(join(fontsDir, "inter-medium.ttf"))
 const geistData = readFileSync(join(fontsDir, "geist-medium.ttf"))
 const geistMonoData = readFileSync(join(fontsDir, "geist-mono-medium.ttf"))


### PR DESCRIPTION
<!--begin:badgetizr-shieldcn--> 
![Ready](https://shieldcn.dev/badge/Ready-22C55E.svg?variant=default&mode=dark&size=sm&logo=ri:RiCheckFill&color=22C55E)  [![CI 25087647768](https://shieldcn.dev/badge/Build-25087647768-7C3AED.svg?variant=default&mode=dark&size=sm&logo=github&color=7C3AED)](https://github.com/jal-co/shieldcn/actions/runs/25087647768)
<!--end:badgetizr-shieldcn-->
Fixes all badge routes returning 500 after the monorepo migration.

**Problem:** `import.meta.url` in `render.tsx` resolves to the Turbopack-compiled location on Vercel, not the source directory. The fonts at `../fonts` relative to the compiled output don't exist, so `readFileSync` throws and every badge request crashes.

**Fix:** Try multiple candidate paths in order:
1. `import.meta.url` relative — works in Docker standalone
2. `packages/core/src/fonts` from `process.cwd()` — works in local dev
3. `../core/src/fonts` from `process.cwd()` — works on Vercel (root=`packages/web`)
4. `lib/fonts` from `process.cwd()` — legacy fallback

First path that contains `inter-medium.ttf` wins. Throws a descriptive error if none found.