### PR TITLE
docs: move self-hosting to Getting Started section

### DIFF
--- a/packages/web/components/sidebar.tsx
+++ b/packages/web/components/sidebar.tsx
@@ -23,6 +23,7 @@ const docsNav: NavGroup[] = [
     items: [
       { title: "Introduction", href: "/docs" },
       { title: "Agent Skill", href: "/docs/skill" },
+      { title: "Self-Hosting", href: "/docs/self-hosting" },
       { title: "API Reference", href: "/docs/api-reference" },
       { title: "Token Pool", href: "/token-pool" },
       { title: "Sponsor", href: "/sponsor" },

--- a/packages/web/content/docs/meta.json
+++ b/packages/web/content/docs/meta.json
@@ -4,6 +4,7 @@
     "---Getting Started---",
     "index",
     "skill",
+    "self-hosting",
     "---Badges---",
     "...badges",
     "---Customization---",
@@ -11,8 +12,6 @@
     "---Registry---",
     "...registry",
     "---Reference---",
-    "api-reference",
-    "---Self-Hosting---",
-    "self-hosting"
+    "api-reference"
   ]
 }

--- a/packages/web/lib/highlight-code.ts
+++ b/packages/web/lib/highlight-code.ts
@@ -1,7 +1,7 @@
 import { codeToHtml } from "shiki"
 
-const lightTheme = "github-light"
-const darkTheme = "github-dark"
+const lightTheme = "min-light"
+const darkTheme = "vesper"
 
 /**
  * Highlight code with shiki.

--- a/packages/web/source.config.ts
+++ b/packages/web/source.config.ts
@@ -8,5 +8,12 @@ export const docs = defineDocs({
 })
 
 export default defineConfig({
-  mdxOptions: {},
+  mdxOptions: {
+    rehypeCodeOptions: {
+      themes: {
+        light: "min-light",
+        dark: "vesper",
+      },
+    },
+  },
 })


### PR DESCRIPTION
<!--begin:badgetizr-shieldcn--> 
![Ready](https://shieldcn.dev/badge/Ready-22C55E.svg?variant=default&mode=dark&size=sm&logo=ri:RiCheckFill&color=22C55E)  [![CI 25140267053](https://shieldcn.dev/badge/Build-25140267053-7C3AED.svg?variant=default&mode=dark&size=sm&logo=github&color=7C3AED)](https://github.com/jal-co/shieldcn/actions/runs/25140267053)
<!--end:badgetizr-shieldcn-->
Move the self-hosting docs page from its own sidebar section into Getting Started, right after the skill page.