### PR TITLE
fix(gen): default generated badges to secondary instead of outline

### DIFF
--- a/packages/web/lib/gen/detect-profile.ts
+++ b/packages/web/lib/gen/detect-profile.ts
@@ -309,7 +309,7 @@ function profileBadges(
       "profile.followers",
       "GitHub Followers",
       `/github/followers/${username}.svg`,
-      { variant: "outline" },
+      { variant: "secondary" },
       `https://github.com/${username}?tab=followers`,
     ),
   )
@@ -528,7 +528,7 @@ function repoBadges(repos: GitHubRepo[]): Badge[] {
     group: "repos" as const,
     label: `${repo.name} ⭐ ${repo.stargazers_count}`,
     path: `/github/stars/${repo.full_name}.svg`,
-    query: { variant: "outline" },
+    query: { variant: "secondary" },
     overrides: {},
     enabled: true,
     linkUrl: repo.html_url,

--- a/packages/web/lib/gen/detect.ts
+++ b/packages/web/lib/gen/detect.ts
@@ -251,9 +251,9 @@ function githubMetricBadges(owner: string, repo: string): Badge[] {
   });
   const p = (m: string) => `/github/${m}/${owner}/${repo}.svg`;
   return [
-    mk('github.stars', 'GitHub Stars', p('stars'), { variant: 'outline' }),
-    mk('github.forks', 'GitHub Forks', p('forks'), { variant: 'outline' }),
-    mk('github.watchers', 'Watchers', p('watchers'), { variant: 'outline' }),
+    mk('github.stars', 'GitHub Stars', p('stars'), { variant: 'secondary' }),
+    mk('github.forks', 'GitHub Forks', p('forks'), { variant: 'secondary' }),
+    mk('github.watchers', 'Watchers', p('watchers'), { variant: 'secondary' }),
     mk('github.branches', 'Branches', p('branches'), { variant: 'ghost' }),
     mk('github.contributors', 'Contributors', p('contributors'), {
       theme: 'emerald',
@@ -299,13 +299,13 @@ function npmBadges(pkg: string): Badge[] {
       variant: 'ghost',
     }),
     mk('npm.dt', 'npm Total Downloads', `/npm/dt/${pkg}.svg`, {
-      variant: 'outline',
+      variant: 'secondary',
     }),
     mk('npm.dependents', 'npm Dependents', `/npm/dependents/${pkg}.svg`, {
-      variant: 'outline',
+      variant: 'secondary',
     }),
     mk('npm.types', 'npm Types', `/npm/types/${pkg}.svg`, { theme: 'blue' }),
-    mk('npm.node', 'npm Node', `/npm/node/${pkg}.svg`, { variant: 'outline' }),
+    mk('npm.node', 'npm Node', `/npm/node/${pkg}.svg`, { variant: 'secondary' }),
     mk('npm.license', 'npm License', `/npm/license/${pkg}.svg`, {
       variant: 'ghost',
     }),
@@ -318,7 +318,7 @@ function privatePackageBadge(): Badge {
     group: 'package',
     label: 'Private package',
     path: staticBadgePath('Private', 'package', 'red'),
-    query: { variant: 'outline' },
+    query: { variant: 'secondary' },
     overrides: {},
     enabled: true,
   };
@@ -427,7 +427,7 @@ function modernBadges(pkg: PackageJson, probes: ProbeResult): Badge[] {
     label: string,
     message: string,
     color: string,
-    variant = 'outline',
+    variant = 'secondary',
   ) =>
     out.push({
       id,
@@ -479,7 +479,7 @@ async function communityBadges(
         group: 'community',
         label: 'Discord Members',
         path: `/discord/members/${code}.svg`,
-        query: { variant: 'outline' },
+        query: { variant: 'secondary' },
         overrides: {},
         enabled: true,
       });
@@ -511,7 +511,7 @@ async function communityBadges(
           group: 'community',
           label: 'GitHub Sponsors',
           path: staticBadgePath('Sponsor', 'GitHub', 'ea4aaa'),
-          query: { logo: 'githubsponsors', variant: 'outline' },
+          query: { logo: 'githubsponsors', variant: 'secondary' },
           overrides: {},
           enabled: true,
         });
@@ -522,7 +522,7 @@ async function communityBadges(
           group: 'community',
           label: 'Open Collective',
           path: staticBadgePath('Open Collective', 'sponsor', '7FADF2'),
-          query: { logo: 'opencollective', variant: 'outline' },
+          query: { logo: 'opencollective', variant: 'secondary' },
           overrides: {},
           enabled: true,
         });
@@ -533,7 +533,7 @@ async function communityBadges(
           group: 'community',
           label: 'Patreon',
           path: staticBadgePath('Patreon', 'sponsor', 'FF424D'),
-          query: { logo: 'patreon', variant: 'outline' },
+          query: { logo: 'patreon', variant: 'secondary' },
           overrides: {},
           enabled: true,
         });
@@ -544,7 +544,7 @@ async function communityBadges(
           group: 'community',
           label: 'Ko-fi',
           path: staticBadgePath('Ko-fi', 'sponsor', 'FF5E5B'),
-          query: { logo: 'kofi', variant: 'outline' },
+          query: { logo: 'kofi', variant: 'secondary' },
           overrides: {},
           enabled: true,
         });


### PR DESCRIPTION
<!--begin:badgetizr-shieldcn--> 
![Ready](https://shieldcn.dev/badge/Ready-22C55E.svg?variant=default&mode=dark&size=sm&logo=ri:RiCheckFill&color=22C55E)  [![CI 25140514588](https://shieldcn.dev/badge/Build-25140514588-7C3AED.svg?variant=default&mode=dark&size=sm&logo=github&color=7C3AED)](https://github.com/jal-co/shieldcn/actions/runs/25140514588)
<!--end:badgetizr-shieldcn-->
Outline badges have a transparent background — they only look good on dark surfaces. When someone generates badges and pastes them into a README viewed on GitHub (white bg) or any other light context, outlined badges break visually.

Switch all 17 hardcoded `variant: "outline"` defaults to `variant: "secondary"` in both the repo detector and profile detector. Secondary has a solid muted background that works everywhere.

Users can still manually switch to outline in the generator UI if they want it.