### PR TITLE
fix(engine): health route matching without trailing slash

### DIFF
--- a/packages/engine/next.config.ts
+++ b/packages/engine/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from "next"
 const nextConfig: NextConfig = {
   output: "standalone",
   transpilePackages: ["@shieldcn/core"],
+  skipTrailingSlashRedirect: true,
 }
 
 export default nextConfig


### PR DESCRIPTION
<!--begin:badgetizr-shieldcn--> 
![Ready](https://shieldcn.dev/badge/Ready-22C55E.svg?variant=default&mode=dark&size=sm&logo=ri:RiCheckFill&color=22C55E)  [![CI 25140695006](https://shieldcn.dev/badge/Build-25140695006-7C3AED.svg?variant=default&mode=dark&size=sm&logo=github&color=7C3AED)](https://github.com/jal-co/shieldcn/actions/runs/25140695006)
<!--end:badgetizr-shieldcn-->
Without `skipTrailingSlashRedirect`, Next.js standalone redirects `/api/health` to `/api/health/` before matching the API route, causing the `[...slug]` catch-all to handle it first and return a 404 badge error.

Verified: Docker build works, all badge endpoints render (SVG, PNG, JSON), health check responds correctly.