### PR TITLE
ci: use engine@ tag prefix for Docker releases

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,8 @@
-name: Publish Docker Image
+name: Publish Engine Docker Image
 
 on:
   push:
-    tags: ["v*"]
+    tags: ["engine@*"]
   workflow_dispatch:
 
 jobs:
@@ -22,6 +22,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#engine@}" >> "$GITHUB_OUTPUT"
+
       - uses: docker/build-push-action@v6
         with:
           context: .
@@ -29,6 +33,6 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository }}/engine:latest
-            ghcr.io/${{ github.repository }}/engine:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}/engine:${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
<!--begin:badgetizr-shieldcn--> 
![Ready](https://shieldcn.dev/badge/Ready-22C55E.svg?variant=default&mode=dark&size=sm&logo=ri:RiCheckFill&color=22C55E)  [![CI 25140757706](https://shieldcn.dev/badge/Build-25140757706-7C3AED.svg?variant=default&mode=dark&size=sm&logo=github&color=7C3AED)](https://github.com/jal-co/shieldcn/actions/runs/25140757706)
<!--end:badgetizr-shieldcn-->
Change Docker publish trigger from `v*` tags to `engine@*` tags.

**Before:** `git tag v0.1.0` → publishes Docker image (confusing — implies whole repo version)
**After:** `git tag engine@0.1.0` → publishes Docker image (engine-specific)

Usage:
```bash
git tag -a engine@0.1.0 -m "engine 0.1.0"
git push origin engine@0.1.0
```

Produces:
- `ghcr.io/jal-co/shieldcn/engine:0.1.0`
- `ghcr.io/jal-co/shieldcn/engine:latest`

`workflow_dispatch` still available for manual triggers.