### PR TITLE
feat(showcase): add OpenPanel badges to Friends of shieldcn

### DIFF
--- a/packages/web/app/api/showcase/route.ts
+++ b/packages/web/app/api/showcase/route.ts
@@ -192,18 +192,23 @@ export async function POST(req: NextRequest) {
 
     // 7. Open a PR
     const prBody = [
-      `## Community Badge Submission`,
+      `## Summary`,
       ``,
-      `**Badge:** \`${badgePath}\``,
-      `**Title:** ${safeTitle}`,
-      description ? `**Description:** ${safeDesc}` : "",
-      safeUser ? `**Submitted by:** @${safeUser}` : "**Submitted by:** anonymous",
+      description ? `${safeDesc}` : `Community badge submitted by ${safeUser ? `@${safeUser}` : "anonymous"}.`,
       ``,
-      `### Preview`,
+      `## Badges added`,
+      ``,
+      `| Variant | Path |`,
+      `|---------|------|`,
+      `| ${safeTitle} | \`${badgePath}\` |`,
+      ``,
+      `## Preview`,
       ``,
       `![${safeTitle}](https://shieldcn.dev${badgePath})`,
       ``,
       `---`,
+      ``,
+      safeUser ? `**Submitted by:** @${safeUser}` : "**Submitted by:** anonymous",
       `*Submitted via the [shieldcn showcase](https://shieldcn.dev/showcase) badge builder.*`,
     ].filter(Boolean).join("\n")
 

--- a/packages/web/lib/showcase-data.ts
+++ b/packages/web/lib/showcase-data.ts
@@ -381,6 +381,9 @@ export const categories: Category[] = [
       dynamicBadge("IndieDevs", "profile badge", "/indiedevs/jalco.svg?variant=branded", "Link your IndieDevs developer profile.", "/docs/badges/indiedevs"),
       dynamicBadge("IndieDevs (outline)", "profile badge", "/indiedevs/jalco.svg?variant=outline", "Subtle IndieDevs profile badge for README rows."),
       dynamicBadge("IndieDevs (secondary)", "profile badge", "/indiedevs/jalco.svg?variant=secondary", "IndieDevs profile badge in secondary style."),
+      dynamicBadge("Analytics by OpenPanel", "analytics", "/badge/analytics%20by-OpenPanel-2564EB.svg?logo=openpanel&logoColor=fff&variant=branded", "Branded OpenPanel badge — shieldcn's analytics provider."),
+      dynamicBadge("Analytics by OpenPanel (outline)", "analytics", "/badge/analytics%20by-OpenPanel-2564EB.svg?logo=openpanel&variant=outline", "Subtle OpenPanel analytics badge for README rows."),
+      dynamicBadge("Analytics by OpenPanel (secondary)", "analytics", "/badge/analytics%20by-OpenPanel-2564EB.svg?logo=openpanel&logoColor=fff&variant=secondary", "OpenPanel analytics badge in secondary style."),
     ],
   },
   {


### PR DESCRIPTION
<!--begin:badgetizr-shieldcn--> 
![Ready](https://shieldcn.dev/badge/Ready-22C55E.svg?variant=default&mode=dark&size=sm&logo=ri:RiCheckFill&color=22C55E)  [![CI 25151230432](https://shieldcn.dev/badge/Build-25151230432-7C3AED.svg?variant=default&mode=dark&size=sm&logo=github&color=7C3AED)](https://github.com/jal-co/shieldcn/actions/runs/25151230432)
<!--end:badgetizr-shieldcn-->
## Summary

Adds three "analytics by OpenPanel" branded badge variants to the **Friends of shieldcn** showcase category.

OpenPanel is shieldcn's analytics provider, so it belongs in the friends section.

## Badges added

| Variant | Path |
|---------|------|
| Branded | `/badge/analytics%20by-OpenPanel-2564EB.svg?logo=openpanel&logoColor=fff&variant=branded` |
| Outline | `/badge/analytics%20by-OpenPanel-2564EB.svg?logo=openpanel&variant=outline` |
| Secondary | `/badge/analytics%20by-OpenPanel-2564EB.svg?logo=openpanel&logoColor=fff&variant=secondary` |

## Preview

![Branded](https://shieldcn.dev/badge/analytics%20by-OpenPanel-2564EB.svg?logo=openpanel&logoColor=fff&variant=branded)
![Outline](https://shieldcn.dev/badge/analytics%20by-OpenPanel-2564EB.svg?logo=openpanel&variant=outline)
![Secondary](https://shieldcn.dev/badge/analytics%20by-OpenPanel-2564EB.svg?logo=openpanel&logoColor=fff&variant=secondary)