### PR TITLE
feat(gen): track generator users + avatar stack on homepage and gen page

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,7 @@
     "./db": "./src/db.ts",
     "./token-pool": "./src/token-pool.ts",
     "./gen-counter": "./src/gen-counter.ts",
+    "./gen-users": "./src/gen-users.ts",
     "./provider-fetch": "./src/provider-fetch.ts",
     "./normalize-params": "./src/normalize-params.ts",
     "./format": "./src/format.ts",

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -53,5 +53,15 @@ export async function initDB() {
       count BIGINT NOT NULL DEFAULT 0
     );
     INSERT INTO gen_counter (id, count) VALUES ('badges', 16000) ON CONFLICT DO NOTHING;
+
+    CREATE TABLE IF NOT EXISTS gen_users (
+      owner TEXT PRIMARY KEY,
+      avatar_url TEXT NOT NULL,
+      repo TEXT NOT NULL,
+      badge_count INT NOT NULL DEFAULT 0,
+      last_used_at TIMESTAMPTZ DEFAULT NOW()
+    );
+    CREATE INDEX IF NOT EXISTS idx_gen_users_recent
+      ON gen_users (last_used_at DESC);
   `)
 }

--- a/packages/core/src/gen-users.ts
+++ b/packages/core/src/gen-users.ts
@@ -1,0 +1,62 @@
+/**
+ * @shieldcn/core
+ * src/gen-users.ts
+ *
+ * Tracks GitHub users/orgs that have used the badge generator.
+ * Stores owner, avatar URL, repo name, and badge count.
+ */
+
+import { getPool } from "./db"
+
+export interface GenUser {
+  owner: string
+  avatar_url: string
+  repo: string
+  badge_count: number
+}
+
+/**
+ * Record a generator usage. Upserts the owner —
+ * updates repo, badge count, and timestamp on repeat visits.
+ */
+export async function trackGenUser(
+  owner: string,
+  repo: string,
+  badgeCount: number
+): Promise<void> {
+  try {
+    const db = getPool()
+    const avatarUrl = `https://github.com/${owner}.png?size=64`
+    await db.query(
+      `INSERT INTO gen_users (owner, avatar_url, repo, badge_count, last_used_at)
+       VALUES ($1, $2, $3, $4, NOW())
+       ON CONFLICT (owner) DO UPDATE SET
+         repo = $3,
+         badge_count = gen_users.badge_count + $4,
+         last_used_at = NOW()`,
+      [owner, avatarUrl, repo, badgeCount]
+    )
+  } catch {
+    // Silently fail — don't block the response
+  }
+}
+
+/**
+ * Get recent generator users for the avatar stack.
+ * Returns up to `limit` users ordered by most recent usage.
+ */
+export async function getRecentGenUsers(limit = 30): Promise<GenUser[]> {
+  try {
+    const db = getPool()
+    const result = await db.query(
+      `SELECT owner, avatar_url, repo, badge_count
+       FROM gen_users
+       ORDER BY last_used_at DESC
+       LIMIT $1`,
+      [limit]
+    )
+    return result.rows
+  } catch {
+    return []
+  }
+}

--- a/packages/web/app/api/gen-users/route.ts
+++ b/packages/web/app/api/gen-users/route.ts
@@ -1,0 +1,32 @@
+/**
+ * shieldcn
+ * app/api/gen-users/route.ts
+ *
+ * POST: track a generator user (owner/repo)
+ * GET:  return recent generator users for avatar stack
+ */
+
+import { NextResponse } from "next/server"
+import { trackGenUser, getRecentGenUsers } from "@shieldcn/core/gen-users"
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json()
+    const { owner, repo, badgeCount } = body ?? {}
+    if (typeof owner === "string" && typeof repo === "string" && owner && repo) {
+      const count = typeof badgeCount === "number" ? Math.max(0, Math.floor(badgeCount)) : 1
+      await trackGenUser(owner, repo, count)
+    }
+    return NextResponse.json({ ok: true })
+  } catch {
+    return NextResponse.json({ ok: true })
+  }
+}
+
+export async function GET() {
+  const users = await getRecentGenUsers(30)
+  return NextResponse.json(
+    { users },
+    { headers: { "Cache-Control": "public, s-maxage=60, stale-while-revalidate=120" } }
+  )
+}

--- a/packages/web/app/gen/gen-users-stack.tsx
+++ b/packages/web/app/gen/gen-users-stack.tsx
@@ -1,0 +1,9 @@
+import { getRecentGenUsers } from "@shieldcn/core/gen-users"
+import { GenUsersStack } from "@/components/gen-users-stack"
+
+export async function GenUsersSection() {
+  const users = await getRecentGenUsers(30)
+  if (users.length === 0) return null
+
+  return <GenUsersStack users={users} />
+}

--- a/packages/web/app/gen/generator-client.tsx
+++ b/packages/web/app/gen/generator-client.tsx
@@ -252,6 +252,15 @@ export default function GeneratorApp() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ count: enabledCount }),
     }).catch(() => {})
+    fetch("/api/gen-users", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        owner: result.source.owner,
+        repo: result.source.repo,
+        badgeCount: enabledCount,
+      }),
+    }).catch(() => {})
   }, [inputUrl, runInspect, setQs, qs.variant, qs.size, qs.mode, qs.theme, track])
 
   const handleConfigUpload = useCallback(async (file: File) => {

--- a/packages/web/app/gen/page.tsx
+++ b/packages/web/app/gen/page.tsx
@@ -5,6 +5,7 @@ import { ArrowRight, User } from "lucide-react"
 import { SiteShell } from "@/components/site-shell"
 import GeneratorClient from "./generator-client"
 import { GeneratorTourProvider, TourReplayButton } from "./generator-tour"
+import { GenUsersSection } from "./gen-users-stack"
 import { pageMetadata } from "@/lib/metadata"
 
 export const metadata: Metadata = pageMetadata({
@@ -75,6 +76,10 @@ export default function GeneratorPage() {
               </div>
               <ArrowRight className="size-4 shrink-0 text-muted-foreground" />
             </Link>
+
+            <Suspense>
+              <GenUsersSection />
+            </Suspense>
 
             <Suspense>
               <GeneratorClient />

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -11,6 +11,8 @@ import { SiteShell } from "@/components/site-shell"
 import { pageMetadata } from "@/lib/metadata"
 import { websiteJsonLd, softwareAppJsonLd } from "@/lib/json-ld"
 import { getGenCount } from "@shieldcn/core/gen-counter"
+import { getRecentGenUsers } from "@shieldcn/core/gen-users"
+import { GenUsersStack } from "@/components/gen-users-stack"
 
 export const metadata: Metadata = pageMetadata({
   title: "shieldcn — Beautiful README Badges",
@@ -21,7 +23,10 @@ export const metadata: Metadata = pageMetadata({
 })
 
 export default async function Home() {
-  const genCount = await getGenCount()
+  const [genCount, genUsers] = await Promise.all([
+    getGenCount(),
+    getRecentGenUsers(30),
+  ])
   return (
     <SiteShell>
       <script
@@ -48,13 +53,16 @@ export default async function Home() {
               </p>
 
               {genCount !== null && genCount > 0 && (
-                <p className="text-sm text-muted-foreground/70">
-                  Over{" "}
-                  <span className="font-medium text-foreground">
-                    {genCount.toLocaleString()}
-                  </span>{" "}
-                  badges generated and counting.
-                </p>
+                <div className="flex flex-col items-center gap-3">
+                  <p className="text-sm text-muted-foreground/70">
+                    Over{" "}
+                    <span className="font-medium text-foreground">
+                      {genCount.toLocaleString()}
+                    </span>{" "}
+                    badges generated and counting.
+                  </p>
+                  {genUsers.length > 0 && <GenUsersStack users={genUsers} />}
+                </div>
               )}
 
               <GenHeroInput />

--- a/packages/web/components/gen-users-stack.tsx
+++ b/packages/web/components/gen-users-stack.tsx
@@ -1,0 +1,34 @@
+import { AvatarStack } from "@/components/shadcncraft/pro-marketing/avatar-stack"
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
+
+interface GenUser {
+  owner: string
+  avatar_url: string
+  repo: string
+  badge_count: number
+}
+
+export function GenUsersStack({ users }: { users: GenUser[] }) {
+  if (users.length === 0) return null
+
+  return (
+    <div className="flex items-center gap-3">
+      <AvatarStack max={8} size={28} overlapRatio={0.3}>
+        {users.map((user) => (
+          <Avatar key={user.owner}>
+            <AvatarImage src={user.avatar_url} alt={user.owner} />
+            <AvatarFallback className="text-[10px]">
+              {user.owner.slice(0, 2).toUpperCase()}
+            </AvatarFallback>
+          </Avatar>
+        ))}
+      </AvatarStack>
+      <p className="text-xs text-muted-foreground">
+        {users.length === 1
+          ? "1 user has"
+          : `${users.length} users have`}{" "}
+        generated badges
+      </p>
+    </div>
+  )
+}

--- a/packages/web/components/shadcncraft/pro-marketing/avatar-stack.tsx
+++ b/packages/web/components/shadcncraft/pro-marketing/avatar-stack.tsx
@@ -1,0 +1,79 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+
+interface AvatarStackProps extends React.ComponentProps<"div"> {
+  orientation?: "horizontal" | "vertical";
+  max?: number;
+  size?: number;
+  overlapRatio?: number;
+  mask?: boolean;
+}
+
+export function AvatarStack({
+  children,
+  className,
+  orientation = "horizontal",
+  max, // Max visible avatars before "+N"
+  size = 32, // Avatar size in pixels
+  overlapRatio = 0.2, // 20% of avatar size
+  mask = true,
+  style,
+  ...props
+}: AvatarStackProps) {
+  const avatarItems = React.Children.toArray(children).filter(
+    (child): child is React.ReactElement<React.ComponentProps<typeof Avatar>> =>
+      React.isValidElement(child) && child.type === Avatar
+  );
+
+  const avatarsCount = avatarItems.length;
+  const showOverflow = max && avatarsCount > max;
+  const overflowCount = showOverflow ? avatarsCount - max : 0;
+  const visibleAvatars = showOverflow ? avatarItems.slice(0, max) : avatarItems;
+
+  const avatarClassName = cn(
+    "object-cover object-center",
+    mask && "bg-background ring-2 ring-background"
+  );
+
+  return (
+    <div
+      data-slot="avatar-stack"
+      data-orientation={orientation}
+      data-size={size}
+      data-overlap-ratio={overlapRatio}
+      data-mask={mask}
+      data-max={max}
+      className={cn(
+        "group flex items-center",
+        "data-[orientation=horizontal]:flex-row data-[orientation=horizontal]:-space-x-(--overlap)",
+        "data-[orientation=vertical]:flex-col data-[orientation=vertical]:-space-y-(--overlap)",
+        className
+      )}
+      style={
+        {
+          ...style,
+          "--overlap": `${overlapRatio * size}px`,
+        } as React.CSSProperties
+      }
+      {...props}
+    >
+      {visibleAvatars.map((child, index) =>
+        React.cloneElement(child, {
+          key: index,
+          className: cn(child.props.className, avatarClassName),
+          style: { ...child.props.style, width: size, height: size },
+        })
+      )}
+
+      {showOverflow && (
+        <Avatar className={avatarClassName} style={{ width: size, height: size }}>
+          <AvatarFallback className="text-xs font-medium text-muted-foreground">
+            +{overflowCount}
+          </AvatarFallback>
+        </Avatar>
+      )}
+    </div>
+  );
+}

--- a/packages/web/components/ui/avatar.tsx
+++ b/packages/web/components/ui/avatar.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import * as React from "react"
+import { Avatar as AvatarPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Avatar({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Root> & {
+  size?: "default" | "sm" | "lg"
+}) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      data-size={size}
+      className={cn(
+        "group/avatar relative flex size-8 shrink-0 overflow-hidden rounded-full select-none data-[size=lg]:size-10 data-[size=sm]:size-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarImage({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn("aspect-square size-full", className)}
+      {...props}
+    />
+  )
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "flex size-full items-center justify-center rounded-full bg-muted text-sm text-muted-foreground group-data-[size=sm]/avatar:text-xs",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="avatar-badge"
+      className={cn(
+        "absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-primary text-primary-foreground ring-2 ring-background select-none",
+        "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
+        "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
+        "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group"
+      className={cn(
+        "group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:ring-background",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroupCount({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group-count"
+      className={cn(
+        "relative flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm text-muted-foreground ring-2 ring-background group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  AvatarBadge,
+  AvatarGroup,
+  AvatarGroupCount,
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,13 +129,13 @@ importers:
         version: 0.8.212
       fumadocs-core:
         specifier: ^16.8.2
-        version: 16.8.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@1.8.0(react@19.2.4))(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+        version: 16.8.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@1.8.0(react@19.2.4))(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
       fumadocs-mdx:
         specifier: ^14.3.1
-        version: 14.3.1(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.8.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@1.8.0(react@19.2.4))(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 14.3.1(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.8.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@1.8.0(react@19.2.4))(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       fumadocs-ui:
         specifier: npm:@fumadocs/base-ui@^16.8.2
-        version: '@fumadocs/base-ui@16.8.2(@tailwindcss/oxide@4.2.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.8.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@1.8.0(react@19.2.4))(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.4)'
+        version: '@fumadocs/base-ui@16.8.2(@tailwindcss/oxide@4.2.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.8.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@1.8.0(react@19.2.4))(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.4)'
       jose:
         specifier: ^6.2.3
         version: 6.2.3
@@ -5928,12 +5928,12 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@fumadocs/base-ui@16.8.2(@tailwindcss/oxide@4.2.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.8.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@1.8.0(react@19.2.4))(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.4)':
+  '@fumadocs/base-ui@16.8.2(@tailwindcss/oxide@4.2.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.8.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@1.8.0(react@19.2.4))(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.4)':
     dependencies:
       '@base-ui/react': 1.4.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@fumadocs/tailwind': 0.0.5(@tailwindcss/oxide@4.2.4)(tailwindcss@4.2.4)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.8.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@1.8.0(react@19.2.4))(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      fumadocs-core: 16.8.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@1.8.0(react@19.2.4))(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
       lucide-react: 1.8.0(react@19.2.4)
       motion: 12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -8619,7 +8619,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.8.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@1.8.0(react@19.2.4))(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6):
+  fumadocs-core@16.8.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@1.8.0(react@19.2.4))(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76):
     dependencies:
       '@orama/orama': 3.1.18
       estree-util-value-to-estree: 3.5.0
@@ -8649,18 +8649,18 @@ snapshots:
       next: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      zod: 4.3.6
+      zod: 3.25.76
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.3.1(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.8.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@1.8.0(react@19.2.4))(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+  fumadocs-mdx@14.3.1(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.8.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@1.8.0(react@19.2.4))(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.28.0
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.8.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@1.8.0(react@19.2.4))(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      fumadocs-core: 16.8.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@1.8.0(react@19.2.4))(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
       js-yaml: 4.1.1
       mdast-util-mdx: 3.0.0
       mdast-util-to-markdown: 2.1.2


### PR DESCRIPTION
<!--begin:badgetizr-shieldcn--> 
![Ready](https://shieldcn.dev/badge/Ready-22C55E.svg?variant=default&mode=dark&size=sm&logo=ri:RiCheckFill&color=22C55E)  [![CI 25193854145](https://shieldcn.dev/badge/Build-25193854145-7C3AED.svg?variant=default&mode=dark&size=sm&logo=github&color=7C3AED)](https://github.com/jal-co/shieldcn/actions/runs/25193854145)
<!--end:badgetizr-shieldcn-->
## Summary

Tracks which GitHub users/orgs have used the badge generator and displays them as an avatar stack for social proof.

### Database
- New `gen_users` table: `owner` (PK), `avatar_url`, `repo`, `badge_count`, `last_used_at`
- Schema auto-created via `initDB()`

### Core
- `@shieldcn/core/gen-users` module with `trackGenUser()` and `getRecentGenUsers()`
- Exported from core `package.json`

### API
- `POST /api/gen-users` — upserts owner/repo/badgeCount on each generation
- `GET /api/gen-users` — returns up to 30 recent users (60s cache)

### Tracking
- Generator client fires `POST /api/gen-users` alongside the existing `POST /api/gen-count` on each generation

### Display
- `GenUsersStack` shared component using `@shadcncraft/avatar-stack`
- Shows up to 8 avatars with `+N` overflow and "{N} users have generated badges" text
- **Homepage** — server-rendered below the badge counter in the hero
- **Gen page** — server-rendered above the generator input

### Dependencies
- `@shadcncraft/avatar-stack` (pro-marketing)
- `shadcn/avatar` (ui primitive)