### PR TITLE
refactor(web): remove user avatars from landing page

### DIFF
--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -11,8 +11,7 @@ import { SiteShell } from "@/components/site-shell"
 import { pageMetadata } from "@/lib/metadata"
 import { websiteJsonLd, softwareAppJsonLd } from "@/lib/json-ld"
 import { getGenCount } from "@shieldcn/core/gen-counter"
-import { getRecentGenUsers } from "@shieldcn/core/gen-users"
-import { GenUsersStack } from "@/components/gen-users-stack"
+
 
 export const metadata: Metadata = pageMetadata({
   title: "shieldcn — Beautiful README Badges",
@@ -23,10 +22,7 @@ export const metadata: Metadata = pageMetadata({
 })
 
 export default async function Home() {
-  const [genCount, genUsers] = await Promise.all([
-    getGenCount(),
-    getRecentGenUsers(30),
-  ])
+  const [genCount] = await Promise.all([getGenCount()])
   return (
     <SiteShell>
       <script
@@ -61,7 +57,7 @@ export default async function Home() {
                     </span>{" "}
                     badges generated and counting.
                   </p>
-                  {genUsers.length > 0 && <GenUsersStack users={genUsers} />}
+
                 </div>
               )}
 


### PR DESCRIPTION
<!--begin:badgetizr-shieldcn--> 
![Ready](https://shieldcn.dev/badge/Ready-22C55E.svg?variant=default&mode=dark&size=sm&logo=ri:RiCheckFill&color=22C55E)  [![CI 25243575330](https://shieldcn.dev/badge/Build-25243575330-7C3AED.svg?variant=default&mode=dark&size=sm&logo=github&color=7C3AED)](https://github.com/jal-co/shieldcn/actions/runs/25243575330)
<!--end:badgetizr-shieldcn-->
Remove the `GenUsersStack` avatar component and `getRecentGenUsers` data fetch from the homepage. The badge generation counter ("Over X badges generated and counting") is preserved.