### PR TITLE
feat(showcase): consolidate community badges from @itzzjustmateo

### DIFF
--- a/packages/web/lib/showcase-data.ts
+++ b/packages/web/lib/showcase-data.ts
@@ -216,6 +216,8 @@ export const categories: Category[] = [
       makeLogoBadge("bun", "Bun", "000000", "&variant=branded"),
       makeLogoBadge("yarn", "Yarn", "2C8EBB", "&variant=branded"),
       makeLogoBadge("npm", "npm", "CB3837", "&variant=branded"),
+      makeLogoBadge("uv", "uv", "DE5FE9", "&variant=branded"),
+      dynamicBadge("Cargo", "brand badge", "/badge/Cargo-E64B11.svg?logo=rust&logoColor=fff&variant=branded", "Branded Cargo badge using the Rust logo. Best for stack rows and Rust project READMEs."),
     ],
   },
   {
@@ -280,6 +282,12 @@ export const categories: Category[] = [
       makeLogoBadge("playwright", "Playwright", "2EAD33", "&variant=branded"),
       makeLogoBadge("jest", "Jest", "C21325", "&variant=branded"),
       makeLogoBadge("cypress", "Cypress", "69D3A7", "&variant=branded"),
+      makeLogoBadge("gradle", "Gradle", "02303A", "&variant=branded"),
+      makeLogoBadge("cmake", "CMake", "064F8C", "&variant=branded"),
+      makeLogoBadge("apachemaven", "Maven", "C71A36", "&variant=branded"),
+      dynamicBadge("Compiled using CMake", "build system", "/badge/Compiled%20using-CMake-064F8C.svg?logo=cmake&logoColor=fff", "Build system badge indicating a project is compiled using CMake."),
+      dynamicBadge("Compiled using Gradle", "build system", "/badge/Compiled%20using-Gradle-02303A.svg?logo=gradle&logoColor=fff", "Build system badge indicating a project is compiled using Gradle."),
+      dynamicBadge("Compiled using Maven", "build system", "/badge/Compiled%20using-Maven-C71A36.svg?logo=apachemaven&logoColor=fff", "Build system badge indicating a project is compiled using Maven."),
     ],
   },
   {
@@ -304,6 +312,8 @@ export const categories: Category[] = [
       makeLogoBadge("turborepo", "Turborepo", "FF1E56", "&variant=branded"),
       makeLogoBadge("biome", "Biome", "60A5FA", "&variant=branded"),
       makeLogoBadge("eslint", "ESLint", "4B32C3", "&variant=branded"),
+      makeLogoBadge("cplusplus", "C++", "00599C", "&variant=branded"),
+      dynamicBadge("Java", "brand badge", "/badge/Java-ED8B00.svg?logo=ri:FaJava&logoColor=fff&variant=branded", "Branded Java badge using the Java icon. Best for stack rows and JVM project READMEs."),
     ],
   },
   {


### PR DESCRIPTION
<!--begin:badgetizr-shieldcn--> 
![Ready](https://shieldcn.dev/badge/Ready-22C55E.svg?variant=default&mode=dark&size=sm&logo=ri:RiCheckFill&color=22C55E)  [![CI 25403226138](https://shieldcn.dev/badge/Build-25403226138-7C3AED.svg?variant=default&mode=dark&size=sm&logo=github&color=7C3AED)](https://github.com/jal-co/shieldcn/actions/runs/25403226138)
<!--end:badgetizr-shieldcn-->
## Summary

Consolidates 8 community badge PRs from **@itzzjustmateo** into one, placing each badge in the correct showcase category instead of dumping them all into "Community".

## What changed

All badges added to `packages/web/lib/showcase-data.ts` in the proper categories:

### Package Managers
| Badge | Details |
|-------|---------|
| **uv** | `makeLogoBadge` · SimpleIcons `uv` · `#DE5FE9` |
| **Cargo** | `dynamicBadge` · Rust logo (`rust`) · `#E64B11` (no SimpleIcons `cargo` slug) |

### Brand Badges
| Badge | Details |
|-------|---------|
| **C++** | `makeLogoBadge` · SimpleIcons `cplusplus` · `#00599C` (original PR used `cplusplusbuilder` which is a Borland IDE — wrong icon) |
| **Java** | `dynamicBadge` · React Icons `ri:FaJava` · `#ED8B00` (no SimpleIcons entry for Java) |

### Testing & Build
| Badge | Details |
|-------|---------|
| **Gradle** | `makeLogoBadge` · SimpleIcons `gradle` · `#02303A` |
| **CMake** | `makeLogoBadge` · SimpleIcons `cmake` · `#064F8C` |
| **Maven** | `makeLogoBadge` · SimpleIcons `apachemaven` · `#C71A36` |
| **Compiled using CMake** | `dynamicBadge` · split label pattern |
| **Compiled using Gradle** | `dynamicBadge` · split label pattern |
| **Compiled using Maven** | `dynamicBadge` · split label pattern |

## Fixes from original PRs
- Used correct SimpleIcons slugs and official brand hex colors
- Fixed C++ using `cplusplusbuilder` (Borland IDE) → `cplusplus` (the language)
- Converted simple brand badges to `makeLogoBadge()` for consistency with existing showcase entries
- All 10 badge URLs verified rendering correctly (HTTP 200, valid SVG)

## Closes
Closes #76, closes #77, closes #78, closes #79, closes #80, closes #81, closes #82, closes #83

All badges originally submitted by **@itzzjustmateo** — thank you! 🎉