### PR TITLE
feat(cli): add shieldcn-cli package

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="https://shieldcn.dev">Homepage</a> · <a href="https://shieldcn.dev/docs">Docs</a> · <a href="https://shieldcn.dev/docs/api-reference">API Reference</a>
+  <a href="https://shieldcn.dev">Homepage</a> · <a href="https://shieldcn.dev/docs">Docs</a> · <a href="https://shieldcn.dev/docs/cli">CLI</a> · <a href="https://shieldcn.dev/docs/api-reference">API Reference</a>
 </p>
 
 <p align="center">
@@ -31,6 +31,26 @@ shieldcn is an open-source badge service by [Justin Levine](https://justinlevine
 Badges are rendered as actual [shadcn/ui](https://ui.shadcn.com) Button components via [Satori](https://github.com/vercel/satori) — same font (Inter), same border-radius, same padding, same color tokens per variant and size. Not "inspired by" — the real thing, as SVG.
 
 Built with [jal-co/ui](https://ui.justinlevine.me) components.
+
+## CLI
+
+Generate badges from your terminal:
+
+```bash
+# Scan current repo and generate badge markdown
+npx shieldcn-cli
+
+# Scan a GitHub repo
+npx shieldcn-cli vercel/next.js --variant branded
+
+# Inject badges into README
+npx shieldcn-cli --inject
+
+# Migrate shields.io URLs to shieldcn
+npx shieldcn-cli migrate
+```
+
+See the [CLI docs](https://shieldcn.dev/docs/cli) for full usage.
 
 ## Usage
 

--- a/packages/cli/.npmignore
+++ b/packages/cli/.npmignore
@@ -1,0 +1,4 @@
+src/
+tsconfig.json
+tsup.config.ts
+node_modules/

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Justin Levine
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,177 @@
+<p align="center">
+  <a href="https://shieldcn.dev">
+    <img src="https://shieldcn.dev/badge/shieldcn-CLI-18181b.svg?variant=branded&logo=data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMzQgMzQiIGZpbGw9IndoaXRlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXRoIGQ9Ik0yOC40NzEgNi43MDYzMlYxMi43NTIxSDE0LjI0NzVMMTAuMzk1NiAxOS4yMjY2QzEwLjI0NDkgMTkuNDgxMiA5Ljk3MTkgMTkuNjM1MiA5LjY3NTQ3IDE5LjYzNTJINi4zNjQ1M0M1LjkwMjMgMTkuNjM1MiA1LjUyNzE2IDE5LjI2MDEgNS41MjcxNiAxOC43OTc5VjEyLjc1MjFIMTMuNjMyOUwxNi45OTU3IDcuMDk2NTNDMTcuNDQ3OSA2LjMzNDUzIDE4LjI2ODUgNS44Njg5NiAxOS4xNTQ1IDUuODY4OTZIMjcuNjMzNkMyOC4wOTU4IDUuODY4OTYgMjguNDcxIDYuMjQ0MSAyOC40NzEgNi43MDYzMloiLz48cGF0aCBkPSJNNS41MjcyMyAyNy4yOTMyVjIxLjI0NzRIMTkuNzUwN0wyMy42MDI2IDE0Ljc3MjlDMjMuNzUzMyAxNC41MTg0IDI0LjAyNjMgMTQuMzY0MyAyNC4zMjI3IDE0LjM2NDNIMjcuNjM1NEMyOC4wOTc2IDE0LjM2NDMgMjguNDcyNyAxNC43Mzk0IDI4LjQ3MjcgMTUuMjAxN1YyMS4yNDc0SDIwLjM2N0wxNy4wMDQyIDI2LjkwM0MxNi41NTIgMjcuNjY1IDE1LjczMTQgMjguMTMwNiAxNC44NDU0IDI4LjEzMDZINi4zNjQ1OUM1LjkwMjM3IDI4LjEzMDYgNS41MjcyMyAyNy43NTU0IDUuNTI3MjMgMjcuMjkzMloiLz48L3N2Zz4=&size=lg" alt="shieldcn CLI" />
+  </a>
+</p>
+
+<p align="center">
+  Generate beautiful README badges from your terminal.<br />
+  Scans your repo, detects your stack, and outputs copy-paste markdown.
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/shieldcn-cli"><img src="https://shieldcn.dev/npm/shieldcn-cli.svg?variant=branded" alt="npm" /></a>
+  <a href="https://shieldcn.dev"><img src="https://shieldcn.dev/badge/docs-shieldcn.dev-18181b.svg?variant=secondary" alt="docs" /></a>
+  <a href="https://github.com/jal-co/shieldcn"><img src="https://shieldcn.dev/github/stars/jal-co/shieldcn.svg?variant=branded" alt="stars" /></a>
+  <a href="https://github.com/jal-co/shieldcn/blob/main/LICENSE"><img src="https://shieldcn.dev/github/license/jal-co/shieldcn.svg?variant=ghost" alt="license" /></a>
+</p>
+
+## Quick start
+
+```bash
+# Scan current repo
+npx shieldcn-cli
+
+# Scan a GitHub repo
+npx shieldcn-cli vercel/next.js
+
+# Scan with a specific variant
+npx shieldcn-cli vercel/next.js --variant branded
+```
+
+## What it does
+
+1. **Detects** your GitHub repo from git remote (or pass a URL)
+2. **Scans** package.json, lockfiles, config files, README, and FUNDING.yml
+3. **Generates** categorized badge markdown for GitHub, npm, tooling, stack, and community
+4. **Outputs** copy-paste markdown, HTML, or JSON
+
+## Install
+
+```bash
+# Run without installing (recommended)
+npx shieldcn-cli
+
+# Or install globally
+npm install -g shieldcn-cli
+```
+
+## Usage
+
+### Generate badges
+
+```bash
+# Current directory (reads .git/config for remote)
+npx shieldcn-cli
+
+# GitHub URL or owner/repo
+npx shieldcn-cli vercel/next.js
+npx shieldcn-cli https://github.com/vercel/next.js
+
+# Customize style
+npx shieldcn-cli --variant branded --theme blue --size default
+
+# Different output formats
+npx shieldcn-cli --format flat     # one-line badges
+npx shieldcn-cli --format html     # <img> tags
+npx shieldcn-cli --json            # JSON config
+
+# Copy to clipboard
+npx shieldcn-cli --copy
+
+# Compact output (no group headers)
+npx shieldcn-cli --compact
+```
+
+### Inject into README
+
+Add badges between markers in your README:
+
+```bash
+# Add markers to README (first time)
+npx shieldcn-cli init
+
+# Inject/update badges between markers
+npx shieldcn-cli --inject
+```
+
+This adds badges between `<!-- shieldcn-start -->` and `<!-- shieldcn-end -->` markers. Re-running `--inject` replaces the content between markers.
+
+### Migrate from shields.io
+
+Convert existing shields.io URLs in your README to shieldcn:
+
+```bash
+# Preview changes
+npx shieldcn-cli migrate --dry
+
+# Apply changes (interactive)
+npx shieldcn-cli migrate
+
+# Apply without confirmation
+npx shieldcn-cli migrate --write
+```
+
+## Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--variant` | Badge variant: `default`, `secondary`, `outline`, `ghost`, `destructive`, `branded` | `default` |
+| `--size` | Badge size: `xs`, `sm`, `default`, `lg` | `sm` |
+| `--theme` | Color theme: `zinc`, `slate`, `blue`, `green`, `rose`, `orange`, `violet`, `purple`, `cyan`, `emerald` | — |
+| `--mode` | Color mode: `dark`, `light` | `dark` |
+| `--format` | Output format: `markdown`, `flat`, `html`, `json` | `markdown` |
+| `--inject` | Inject badges into README between markers | `false` |
+| `--copy` | Copy output to clipboard | `false` |
+| `--json` | Output as JSON (shortcut for `--format json`) | `false` |
+| `--compact` | Output without group headers | `false` |
+
+## What gets detected
+
+| Category | Detects |
+|----------|---------|
+| **GitHub** | Stars, forks, watchers, contributors, last commit, issues, PRs, release, CI, license |
+| **Package** | npm version, downloads (weekly/monthly/total), types, license |
+| **Tooling** | Package manager (pnpm/yarn/bun/npm), TypeScript, ESLint, Prettier, Biome, Vite, Next.js, Nuxt, Astro, Svelte, Tailwind, Turborepo, Docker, Vitest, Playwright, Jest, Storybook, Vercel, Netlify, Cloudflare |
+| **Stack** | 100+ npm packages mapped to branded badges (React, Prisma, Drizzle, tRPC, Supabase, Stripe, OpenAI, etc.) |
+| **Modern** | ESM-only, tree-shakeable, dual package, monorepo, CLI tool, AGENTS.md, llms.txt, Claude/Cursor ready, MCP |
+| **Community** | Discord invite (from README), GitHub Sponsors, Open Collective, Patreon, Ko-fi (from FUNDING.yml), homepage |
+
+## Examples
+
+### Scan a popular repo
+
+```bash
+$ npx shieldcn-cli shadcn-ui/ui --variant branded --compact
+
+  shieldcn — beautiful README badges
+  https://www.shieldcn.dev
+
+  shadcn-ui/ui → https://github.com/shadcn-ui/ui
+
+  ✓ GitHub (10)
+  ✓ Package (6)
+  ✓ Tooling (5)
+  ✓ Stack (7)
+  ✓ Community (2)
+```
+
+### Use in CI
+
+```yaml
+# .github/workflows/badges.yml
+name: Update badges
+on:
+  push:
+    branches: [main]
+
+jobs:
+  badges:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npx shieldcn-cli --inject --variant branded
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: update badges"
+```
+
+## Related
+
+- [shieldcn.dev](https://shieldcn.dev) — Badge service & documentation
+- [shieldcn Generator](https://shieldcn.dev/gen) — Web-based badge generator
+- [shieldcn Docs](https://shieldcn.dev/docs/cli) — CLI documentation
+
+## License
+
+MIT © [Justin Levine](https://justinlevine.me)

--- a/packages/cli/dist/bin.js
+++ b/packages/cli/dist/bin.js
@@ -1,0 +1,1207 @@
+#!/usr/bin/env node
+
+// src/bin.ts
+import { defineCommand, runMain } from "citty";
+import consola from "consola";
+import pc from "picocolors";
+import { readFileSync as readFileSync3, writeFileSync as writeFileSync2 } from "fs";
+import { resolve as resolve2 } from "path";
+import { execSync } from "child_process";
+
+// src/detect.ts
+import { existsSync, readFileSync } from "fs";
+import { join, resolve } from "path";
+
+// src/brands.ts
+var BRANDS = {
+  // React ecosystem
+  react: { slug: "react", color: "61DAFB", label: "React" },
+  "react-dom": { slug: "react", color: "61DAFB", label: "React" },
+  next: { slug: "nextdotjs", color: "000000", label: "Next.js" },
+  "@next/env": { slug: "nextdotjs", color: "000000", label: "Next.js" },
+  "@t3-oss/env-nextjs": { slug: "nextdotjs", color: "000000", label: "Next.js" },
+  astro: { slug: "astro", color: "BC52EE", label: "Astro" },
+  "@astrojs/cloudflare": { slug: "astro", color: "BC52EE", label: "Astro" },
+  svelte: { slug: "svelte", color: "FF3E00", label: "Svelte" },
+  "@sveltejs/kit": { slug: "svelte", color: "FF3E00", label: "SvelteKit" },
+  vue: { slug: "vuedotjs", color: "4FC08D", label: "Vue" },
+  nuxt: { slug: "nuxt", color: "00DC82", label: "Nuxt" },
+  "solid-js": { slug: "solid", color: "2C4F7C", label: "Solid" },
+  "@builder.io/qwik": { slug: "qwik", color: "18B6F6", label: "Qwik" },
+  // CSS / UI
+  tailwindcss: { slug: "tailwindcss", color: "06B6D4", label: "Tailwind CSS" },
+  unocss: { slug: "unocss", color: "333333", label: "UnoCSS" },
+  "@radix-ui/react": { slug: "radixui", color: "000000", label: "Radix UI" },
+  "@shadcn/ui": { slug: "shadcnui", color: "000000", label: "shadcn/ui" },
+  // TypeScript & tools
+  typescript: { slug: "typescript", color: "3178C6", label: "TypeScript" },
+  "@biomejs/biome": { slug: "biome", color: "60A5FA", label: "Biome" },
+  eslint: { slug: "eslint", color: "4B32C3", label: "ESLint" },
+  prettier: { slug: "prettier", color: "F7B93E", label: "Prettier" },
+  // Build tools
+  vite: { slug: "vite", color: "646CFF", label: "Vite" },
+  webpack: { slug: "webpack", color: "8DD6F9", label: "Webpack" },
+  rollup: { slug: "rollupdotjs", color: "EC4A3F", label: "Rollup" },
+  esbuild: { slug: "esbuild", color: "FFCF00", label: "esbuild" },
+  turbo: { slug: "turborepo", color: "EF4444", label: "Turborepo" },
+  nx: { slug: "nx", color: "143055", label: "Nx" },
+  "@changesets/cli": { slug: "changesets", color: "5846F5", label: "Changesets" },
+  // Testing
+  vitest: { slug: "vitest", color: "6E9F18", label: "Vitest" },
+  playwright: { slug: "playwright", color: "2EAD33", label: "Playwright" },
+  "@playwright/test": { slug: "playwright", color: "2EAD33", label: "Playwright" },
+  jest: { slug: "jest", color: "C21325", label: "Jest" },
+  cypress: { slug: "cypress", color: "69D3A7", label: "Cypress" },
+  // Databases & ORMs
+  prisma: { slug: "prisma", color: "2D3748", label: "Prisma" },
+  "drizzle-orm": { slug: "drizzle", color: "C5F74F", label: "Drizzle" },
+  "drizzle-kit": { slug: "drizzle", color: "C5F74F", label: "Drizzle" },
+  kysely: { slug: "kysely", color: "1E88E5", label: "Kysely" },
+  typeorm: { slug: "typeorm", color: "FE0902", label: "TypeORM" },
+  mongoose: { slug: "mongodb", color: "47A248", label: "Mongoose" },
+  postgres: { slug: "postgresql", color: "4169E1", label: "PostgreSQL" },
+  pg: { slug: "postgresql", color: "4169E1", label: "PostgreSQL" },
+  mongodb: { slug: "mongodb", color: "47A248", label: "MongoDB" },
+  mysql2: { slug: "mysql", color: "4479A1", label: "MySQL" },
+  redis: { slug: "redis", color: "FF4438", label: "Redis" },
+  ioredis: { slug: "redis", color: "FF4438", label: "Redis" },
+  // Validation
+  zod: { slug: "zod", color: "3E67B1", label: "Zod" },
+  valibot: { slug: "valibot", color: "0284C7", label: "Valibot" },
+  // API / RPC
+  "@trpc/server": { slug: "trpc", color: "398CCB", label: "tRPC" },
+  "@trpc/client": { slug: "trpc", color: "398CCB", label: "tRPC" },
+  graphql: { slug: "graphql", color: "E10098", label: "GraphQL" },
+  // State / data
+  "@tanstack/react-query": { slug: "reactquery", color: "FF4154", label: "TanStack Query" },
+  "@tanstack/query-core": { slug: "reactquery", color: "FF4154", label: "TanStack Query" },
+  zustand: { slug: "zustand", color: "FFB800", label: "Zustand" },
+  jotai: { slug: "jotai", color: "000000", label: "Jotai" },
+  // Realtime
+  "socket.io": { slug: "socketdotio", color: "010101", label: "Socket.IO" },
+  "socket.io-client": { slug: "socketdotio", color: "010101", label: "Socket.IO" },
+  // Backend infra
+  supabase: { slug: "supabase", color: "3FCF8E", label: "Supabase" },
+  "@supabase/supabase-js": { slug: "supabase", color: "3FCF8E", label: "Supabase" },
+  firebase: { slug: "firebase", color: "DD2C00", label: "Firebase" },
+  "@firebase/app": { slug: "firebase", color: "DD2C00", label: "Firebase" },
+  convex: { slug: "convex", color: "EE342F", label: "Convex" },
+  // Payment
+  stripe: { slug: "stripe", color: "635BFF", label: "Stripe" },
+  "@stripe/stripe-js": { slug: "stripe", color: "635BFF", label: "Stripe" },
+  // AI
+  openai: { slug: "openai", color: "412991", label: "OpenAI" },
+  "@anthropic-ai/sdk": { slug: "anthropic", color: "D97757", label: "Anthropic" },
+  langchain: { slug: "langchain", color: "1C3C3C", label: "LangChain" },
+  "@langchain/core": { slug: "langchain", color: "1C3C3C", label: "LangChain" },
+  ai: { slug: "vercel", color: "000000", label: "AI SDK" },
+  // Hosting runtime libs
+  "@cloudflare/workers-types": { slug: "cloudflare", color: "F38020", label: "Cloudflare Workers" },
+  wrangler: { slug: "cloudflare", color: "F38020", label: "Cloudflare Workers" },
+  // Docs / content
+  "@docusaurus/core": { slug: "docusaurus", color: "3ECC5F", label: "Docusaurus" },
+  vitepress: { slug: "vitepress", color: "5E72E4", label: "VitePress" },
+  storybook: { slug: "storybook", color: "FF4785", label: "Storybook" },
+  // Pre-commit / quality
+  husky: { slug: "husky", color: "3B82F6", label: "Husky" },
+  "lint-staged": { slug: "git", color: "F05032", label: "lint-staged" },
+  // Misc
+  "@octokit/rest": { slug: "github", color: "181717", label: "Octokit" },
+  "@linear/sdk": { slug: "linear", color: "5E6AD2", label: "Linear" }
+};
+function matchBrand(pkg) {
+  if (BRANDS[pkg]) return BRANDS[pkg];
+  if (pkg.startsWith("@ai-sdk/")) return BRANDS["@ai-sdk/openai"] ?? BRANDS.ai;
+  if (pkg.startsWith("@supabase/")) return BRANDS["@supabase/supabase-js"];
+  if (pkg.startsWith("@firebase/")) return BRANDS["@firebase/app"];
+  if (pkg.startsWith("@radix-ui/")) return BRANDS["@radix-ui/react"];
+  if (pkg.startsWith("@trpc/")) return BRANDS["@trpc/server"];
+  if (pkg.startsWith("@langchain/")) return BRANDS["@langchain/core"];
+  if (pkg.startsWith("@tanstack/")) return BRANDS["@tanstack/react-query"];
+  return void 0;
+}
+
+// src/constants.ts
+var SHIELDCN_BASE = "https://www.shieldcn.dev";
+var RAW_GH = "https://raw.githubusercontent.com";
+var NPM_REGISTRY = "https://registry.npmjs.org";
+var INJECT_START = "<!-- shieldcn-start -->";
+var INJECT_END = "<!-- shieldcn-end -->";
+var VARIANTS = [
+  "default",
+  "secondary",
+  "outline",
+  "ghost",
+  "destructive",
+  "branded"
+];
+var SIZES = ["xs", "sm", "default", "lg"];
+var THEMES = [
+  "zinc",
+  "slate",
+  "stone",
+  "neutral",
+  "gray",
+  "blue",
+  "green",
+  "rose",
+  "orange",
+  "amber",
+  "violet",
+  "purple",
+  "red",
+  "cyan",
+  "emerald"
+];
+
+// src/url.ts
+var ENCODE_MAP = [
+  [/_/g, "__"],
+  [/-/g, "--"]
+];
+function encodeStaticSegment(raw) {
+  let s = raw;
+  for (const [re, rep] of ENCODE_MAP) s = s.replace(re, rep);
+  return s.replace(/ /g, "_");
+}
+function staticBadgePath(label, message, color) {
+  const enc = (s) => encodeURIComponent(encodeStaticSegment(s));
+  return `/badge/${enc(label)}-${enc(message)}-${color.replace(/^#/, "")}.svg`;
+}
+function mergeQuery(badge, global) {
+  const merged = { ...badge.query };
+  if (global.variant && global.variant !== "default" && !merged.variant) merged.variant = global.variant;
+  if (global.size && global.size !== "sm" && global.size !== "default" && !merged.size) merged.size = global.size;
+  if (global.mode && global.mode !== "dark" && !merged.mode) merged.mode = global.mode;
+  if (global.theme && !merged.theme) merged.theme = global.theme;
+  return merged;
+}
+function badgeUrl(badge, global) {
+  const qs = new URLSearchParams(mergeQuery(badge, global)).toString();
+  return `${SHIELDCN_BASE}${badge.path}${qs ? `?${qs}` : ""}`;
+}
+function badgeMarkdown(badge, global) {
+  const url = badgeUrl(badge, global);
+  const alt = badge.label.replace(/[\[\]]/g, "");
+  const img = `![${alt}](${url})`;
+  return badge.linkUrl ? `[${img}](${badge.linkUrl})` : img;
+}
+function badgeHtml(badge, global) {
+  const url = badgeUrl(badge, global);
+  const alt = badge.label.replace(/"/g, "&quot;");
+  const img = `<img src="${url}" alt="${alt}" />`;
+  return badge.linkUrl ? `<a href="${badge.linkUrl}">${img}</a>` : img;
+}
+
+// src/detect.ts
+var BRAND_CAP = 9;
+async function fetchText(url, signal) {
+  try {
+    const res = await fetch(url, { signal });
+    if (!res.ok) return null;
+    return await res.text();
+  } catch {
+    return null;
+  }
+}
+async function fetchJson(url, signal) {
+  try {
+    const res = await fetch(url, { signal });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+async function headExists(url, signal) {
+  try {
+    const res = await fetch(url, { method: "HEAD", signal });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+function rawUrl(owner, repo, path) {
+  return `${RAW_GH}/${owner}/${repo}/HEAD/${path}`;
+}
+function parseGithubUrl(input) {
+  const trimmed = input.trim();
+  if (!trimmed) return { error: "URL is required" };
+  const ownerRepoOnly = /^([\w.-]+)\/([\w.-]+)$/;
+  const m1 = trimmed.match(ownerRepoOnly);
+  if (m1) {
+    const owner = m1[1];
+    const repo = m1[2].replace(/\.git$/, "");
+    return { owner, repo, url: `https://github.com/${owner}/${repo}` };
+  }
+  try {
+    const u = new URL(trimmed.startsWith("http") ? trimmed : `https://${trimmed}`);
+    if (!/^github\.com$/i.test(u.hostname)) {
+      return { error: "URL must be a github.com repository" };
+    }
+    const parts = u.pathname.replace(/^\/+|\/+$/g, "").split("/");
+    if (parts.length < 2) return { error: "Could not parse owner/repo from URL" };
+    const owner = parts[0];
+    const repo = parts[1].replace(/\.git$/, "");
+    return { owner, repo, url: `https://github.com/${owner}/${repo}` };
+  } catch {
+    return { error: "Invalid URL" };
+  }
+}
+var PROBE_FILES = [
+  "pnpm-lock.yaml",
+  "yarn.lock",
+  "bun.lock",
+  "bun.lockb",
+  "package-lock.json",
+  "Dockerfile",
+  "docker-compose.yml",
+  "docker-compose.yaml",
+  ".nvmrc",
+  "tsconfig.json",
+  "biome.json",
+  ".prettierrc",
+  ".prettierrc.json",
+  "prettier.config.js",
+  ".eslintrc.json",
+  ".eslintrc.js",
+  ".eslintrc.cjs",
+  "eslint.config.js",
+  "eslint.config.mjs",
+  "vite.config.ts",
+  "vite.config.js",
+  "vite.config.mjs",
+  "next.config.ts",
+  "next.config.js",
+  "next.config.mjs",
+  "nuxt.config.ts",
+  "nuxt.config.js",
+  "astro.config.mjs",
+  "astro.config.ts",
+  "svelte.config.js",
+  "svelte.config.ts",
+  "tailwind.config.ts",
+  "tailwind.config.js",
+  "unocss.config.ts",
+  "unocss.config.js",
+  "turbo.json",
+  "nx.json",
+  ".changeset/README.md",
+  ".storybook/main.ts",
+  ".storybook/main.js",
+  "vitest.config.ts",
+  "vitest.config.js",
+  "playwright.config.ts",
+  "playwright.config.js",
+  "jest.config.js",
+  "jest.config.ts",
+  "cypress.config.ts",
+  "cypress.config.js",
+  "wrangler.toml",
+  "wrangler.jsonc",
+  "vercel.json",
+  "netlify.toml",
+  "fly.toml",
+  "AGENTS.md",
+  "llms.txt",
+  ".claude/CLAUDE.md",
+  ".cursor/rules",
+  "mcp.json",
+  "mcp-server.json"
+];
+function getGitRemote(dir) {
+  try {
+    const configPath = join(dir, ".git", "config");
+    if (!existsSync(configPath)) return null;
+    const content = readFileSync(configPath, "utf-8");
+    const match = content.match(
+      /url\s*=\s*(?:git@github\.com:|https:\/\/github\.com\/)([\w.-]+)\/([\w.-]+?)(?:\.git)?\s*$/m
+    );
+    if (!match) return null;
+    return { owner: match[1], repo: match[2] };
+  } catch {
+    return null;
+  }
+}
+function localProbe(dir) {
+  const result = {};
+  for (const file of PROBE_FILES) {
+    result[file] = existsSync(join(dir, file));
+  }
+  return result;
+}
+function localPackageJson(dir) {
+  const path = join(dir, "package.json");
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+function localReadme(dir) {
+  const candidates = ["README.md", "readme.md", "Readme.md", "README.MD"];
+  for (const name of candidates) {
+    const path = join(dir, name);
+    if (existsSync(path)) {
+      try {
+        return readFileSync(path, "utf-8");
+      } catch {
+        continue;
+      }
+    }
+  }
+  return null;
+}
+function githubMetricBadges(owner, repo) {
+  const mk = (id, label, path, query = {}) => ({
+    id,
+    group: "github",
+    label,
+    path,
+    query,
+    enabled: true
+  });
+  const p = (m) => `/github/${m}/${owner}/${repo}.svg`;
+  return [
+    mk("github.stars", "GitHub Stars", p("stars"), { variant: "secondary" }),
+    mk("github.forks", "GitHub Forks", p("forks"), { variant: "secondary" }),
+    mk("github.watchers", "Watchers", p("watchers"), { variant: "secondary" }),
+    mk("github.contributors", "Contributors", p("contributors"), { theme: "emerald" }),
+    mk("github.last-commit", "Last commit", p("last-commit"), { variant: "secondary" }),
+    mk("github.open-issues", "Open issues", p("open-issues"), { variant: "secondary" }),
+    mk("github.open-prs", "Open PRs", p("open-prs"), { variant: "secondary" }),
+    mk("github.release", "Release", p("release")),
+    mk("github.ci", "CI", p("ci"), { variant: "secondary" }),
+    mk("github.license", "License", p("license"), { variant: "ghost" })
+  ];
+}
+function npmBadges(pkg) {
+  const mk = (id, label, path, query = {}) => ({
+    id,
+    group: "package",
+    label,
+    path,
+    query,
+    enabled: true
+  });
+  return [
+    mk("npm.version", "npm Version", `/npm/${pkg}.svg`, { variant: "secondary" }),
+    mk("npm.dw", "npm Weekly Downloads", `/npm/dw/${pkg}.svg`),
+    mk("npm.dm", "npm Monthly Downloads", `/npm/dm/${pkg}.svg`, { variant: "ghost" }),
+    mk("npm.dt", "npm Total Downloads", `/npm/dt/${pkg}.svg`, { variant: "secondary" }),
+    mk("npm.types", "npm Types", `/npm/types/${pkg}.svg`, { theme: "blue" }),
+    mk("npm.license", "npm License", `/npm/license/${pkg}.svg`, { variant: "ghost" })
+  ];
+}
+function privatePackageBadge() {
+  return {
+    id: "package.private",
+    group: "package",
+    label: "Private package",
+    path: staticBadgePath("Private", "package", "red"),
+    query: { variant: "secondary" },
+    enabled: true
+  };
+}
+var TOOLING_RULES = [
+  { id: "tooling.pnpm", category: "Package mgr", name: "pnpm", slug: "pnpm", color: "F69220", requires: ["pnpm-lock.yaml"] },
+  { id: "tooling.bun", category: "Package mgr", name: "Bun", slug: "bun", color: "000000", requires: ["bun.lock", "bun.lockb"] },
+  { id: "tooling.yarn", category: "Package mgr", name: "Yarn", slug: "yarn", color: "2C8EBB", requires: ["yarn.lock"] },
+  { id: "tooling.npm", category: "Package mgr", name: "npm", slug: "npm", color: "CB3837", requires: ["package-lock.json"] },
+  { id: "tooling.docker", category: "Container", name: "Docker", slug: "docker", color: "2496ED", requires: ["Dockerfile", "docker-compose.yml", "docker-compose.yaml"] },
+  { id: "tooling.typescript", category: "Language", name: "TypeScript", slug: "typescript", color: "3178C6", requires: ["tsconfig.json"] },
+  { id: "tooling.biome", category: "Lint", name: "Biome", slug: "biome", color: "60A5FA", requires: ["biome.json"] },
+  { id: "tooling.eslint", category: "Lint", name: "ESLint", slug: "eslint", color: "4B32C3", requires: [".eslintrc.json", ".eslintrc.js", ".eslintrc.cjs", "eslint.config.js", "eslint.config.mjs"] },
+  { id: "tooling.prettier", category: "Format", name: "Prettier", slug: "prettier", color: "F7B93E", requires: [".prettierrc", ".prettierrc.json", "prettier.config.js"] },
+  { id: "tooling.vite", category: "Bundler", name: "Vite", slug: "vite", color: "646CFF", requires: ["vite.config.ts", "vite.config.js", "vite.config.mjs"] },
+  { id: "tooling.nextjs", category: "Framework", name: "Next.js", slug: "nextdotjs", color: "000000", requires: ["next.config.ts", "next.config.js", "next.config.mjs"] },
+  { id: "tooling.nuxt", category: "Framework", name: "Nuxt", slug: "nuxt", color: "00DC82", requires: ["nuxt.config.ts", "nuxt.config.js"] },
+  { id: "tooling.astro", category: "Framework", name: "Astro", slug: "astro", color: "BC52EE", requires: ["astro.config.mjs", "astro.config.ts"] },
+  { id: "tooling.svelte", category: "Framework", name: "Svelte", slug: "svelte", color: "FF3E00", requires: ["svelte.config.js", "svelte.config.ts"] },
+  { id: "tooling.tailwind", category: "CSS", name: "Tailwind", slug: "tailwindcss", color: "06B6D4", requires: ["tailwind.config.ts", "tailwind.config.js"] },
+  { id: "tooling.unocss", category: "CSS", name: "UnoCSS", slug: "unocss", color: "333333", requires: ["unocss.config.ts", "unocss.config.js"] },
+  { id: "tooling.turbo", category: "Monorepo", name: "Turborepo", slug: "turborepo", color: "EF4444", requires: ["turbo.json"] },
+  { id: "tooling.nx", category: "Monorepo", name: "Nx", slug: "nx", color: "143055", requires: ["nx.json"] },
+  { id: "tooling.changesets", category: "Releases", name: "Changesets", slug: "changesets", color: "5846F5", requires: [".changeset/README.md"] },
+  { id: "tooling.storybook", category: "Docs", name: "Storybook", slug: "storybook", color: "FF4785", requires: [".storybook/main.ts", ".storybook/main.js"] },
+  { id: "tooling.vitest", category: "Tests", name: "Vitest", slug: "vitest", color: "6E9F18", requires: ["vitest.config.ts", "vitest.config.js"] },
+  { id: "tooling.playwright", category: "Tests", name: "Playwright", slug: "playwright", color: "2EAD33", requires: ["playwright.config.ts", "playwright.config.js"] },
+  { id: "tooling.jest", category: "Tests", name: "Jest", slug: "jest", color: "C21325", requires: ["jest.config.js", "jest.config.ts"] },
+  { id: "tooling.cypress", category: "Tests", name: "Cypress", slug: "cypress", color: "69D3A7", requires: ["cypress.config.ts", "cypress.config.js"] },
+  { id: "tooling.cloudflare", category: "Hosting", name: "Cloudflare Workers", slug: "cloudflare", color: "F38020", requires: ["wrangler.toml", "wrangler.jsonc"] },
+  { id: "tooling.vercel", category: "Hosting", name: "Vercel", slug: "vercel", color: "000000", requires: ["vercel.json"] },
+  { id: "tooling.netlify", category: "Hosting", name: "Netlify", slug: "netlify", color: "00AD9F", requires: ["netlify.toml"] },
+  { id: "tooling.fly", category: "Hosting", name: "Fly.io", slug: "flydotio", color: "24175B", requires: ["fly.toml"] }
+];
+function toolingBadges(probes) {
+  const found = [];
+  const seenSlugs = /* @__PURE__ */ new Set();
+  for (const rule of TOOLING_RULES) {
+    if (!rule.requires.some((f) => probes[f])) continue;
+    if (seenSlugs.has(rule.slug)) continue;
+    seenSlugs.add(rule.slug);
+    found.push({
+      id: rule.id,
+      group: "tooling",
+      label: `${rule.category} \xB7 ${rule.name}`,
+      path: staticBadgePath(rule.category, rule.name, rule.color),
+      query: { logo: rule.slug, variant: "branded" },
+      enabled: true
+    });
+  }
+  return found;
+}
+function stackBadges(pkg, toolingSlugs) {
+  const deps = {
+    ...pkg.dependencies,
+    ...pkg.devDependencies,
+    ...pkg.peerDependencies
+  };
+  const out = [];
+  const seen = /* @__PURE__ */ new Set();
+  for (const name of Object.keys(deps)) {
+    const brand = matchBrand(name);
+    if (!brand) continue;
+    if (toolingSlugs.has(brand.slug)) continue;
+    if (seen.has(brand.slug)) continue;
+    seen.add(brand.slug);
+    out.push({
+      id: `stack.${brand.slug}`,
+      group: "stack",
+      label: brand.label,
+      path: staticBadgePath("Stack", brand.label, brand.color),
+      query: { logo: brand.slug, variant: "branded" },
+      enabled: true
+    });
+    if (out.length >= BRAND_CAP) break;
+  }
+  return out;
+}
+function modernBadges(pkg, probes) {
+  const out = [];
+  const add = (id, label, message, color, variant = "secondary") => out.push({
+    id,
+    group: "modern",
+    label: `${label} ${message}`.trim(),
+    path: staticBadgePath(label, message, color),
+    query: { variant },
+    enabled: true
+  });
+  if (pkg.type === "module") add("modern.esm", "ESM", "only", "16a34a");
+  if (pkg.sideEffects === false) add("modern.tree-shakeable", "Tree-shakeable", "yes", "16a34a");
+  if (pkg.bin) add("modern.cli", "CLI", "tool", "7c3aed");
+  if (pkg.workspaces) add("modern.monorepo", "Monorepo", "yes", "2563eb");
+  if (pkg.exports && typeof pkg.exports === "object") {
+    const serialized = JSON.stringify(pkg.exports);
+    if (serialized.includes("import") && serialized.includes("require")) {
+      add("modern.dual-package", "Dual package", "ESM+CJS", "2563eb");
+    }
+  }
+  if (probes["AGENTS.md"]) add("modern.agents-md", "Agent-friendly", "AGENTS.md", "D97757");
+  if (probes["llms.txt"]) add("modern.llms-txt", "LLM-indexed", "llms.txt", "7C3AED");
+  if (probes[".claude/CLAUDE.md"]) add("modern.claude", "Claude Code", "ready", "D97757");
+  if (probes[".cursor/rules"]) add("modern.cursor", "Cursor", "ready", "000000");
+  if (probes["mcp.json"]) add("modern.mcp", "MCP", "server", "111827");
+  return out;
+}
+function extractDiscordInvite(readme) {
+  const re = /discord\.(?:gg|com\/invite)\/([a-zA-Z0-9-]+)/i;
+  const m = readme.match(re);
+  return m ? m[1] : null;
+}
+function extractShieldsIoUrls(readme) {
+  const re = /https?:\/\/img\.shields\.io\/[^\s)"'>]+/g;
+  return Array.from(new Set(readme.match(re) ?? []));
+}
+async function communityBadges(owner, repo, pkg, readme, signal) {
+  const out = [];
+  if (readme) {
+    const code = extractDiscordInvite(readme);
+    if (code) {
+      out.push({
+        id: "community.discord-members",
+        group: "community",
+        label: "Discord Members",
+        path: `/discord/members/${code}.svg`,
+        query: { variant: "secondary" },
+        enabled: true
+      });
+      out.push({
+        id: "community.discord-online",
+        group: "community",
+        label: "Discord Online",
+        path: `/discord/online-members/${code}.svg`,
+        query: { variant: "branded" },
+        enabled: true
+      });
+    }
+  }
+  const fundingText = await fetchText(rawUrl(owner, repo, ".github/FUNDING.yml"), signal);
+  if (fundingText) {
+    let data = null;
+    try {
+      const { parse: parseYaml } = await import("yaml");
+      data = parseYaml(fundingText);
+    } catch {
+      data = null;
+    }
+    if (data) {
+      if (data.github) {
+        out.push({
+          id: "community.sponsor-github",
+          group: "community",
+          label: "GitHub Sponsors",
+          path: staticBadgePath("Sponsor", "GitHub", "ea4aaa"),
+          query: { logo: "githubsponsors", variant: "secondary" },
+          enabled: true
+        });
+      }
+      if (data.open_collective) {
+        out.push({
+          id: "community.sponsor-opencollective",
+          group: "community",
+          label: "Open Collective",
+          path: staticBadgePath("Open Collective", "sponsor", "7FADF2"),
+          query: { logo: "opencollective", variant: "secondary" },
+          enabled: true
+        });
+      }
+    }
+  }
+  if (pkg?.homepage && /^https?:\/\//.test(pkg.homepage)) {
+    out.push({
+      id: "community.homepage",
+      group: "community",
+      label: "Homepage",
+      path: staticBadgePath("Homepage", "link", "2563eb"),
+      query: { variant: "ghost" },
+      enabled: true,
+      linkUrl: pkg.homepage
+    });
+  }
+  return out;
+}
+async function inspectLocal(dir) {
+  const resolvedDir = resolve(dir);
+  const remote = getGitRemote(resolvedDir);
+  if (!remote) {
+    return { error: "No GitHub remote found in .git/config. Use a GitHub URL instead, or run from inside a git repo." };
+  }
+  const { owner, repo } = remote;
+  const pkg = localPackageJson(resolvedDir);
+  const readme = localReadme(resolvedDir);
+  const probes = localProbe(resolvedDir);
+  const notes = [];
+  const badges = [];
+  badges.push(...githubMetricBadges(owner, repo));
+  if (pkg) {
+    if (pkg.private === true) {
+      badges.push(privatePackageBadge());
+      notes.push("package.json is private \u2014 npm badges suppressed.");
+    } else if (pkg.name) {
+      const npmInfo = await fetchJson(`${NPM_REGISTRY}/${pkg.name}`);
+      if (npmInfo && npmInfo.name) {
+        badges.push(...npmBadges(pkg.name));
+      } else {
+        notes.push(`Package "${pkg.name}" not found on npm \u2014 npm badges skipped.`);
+      }
+    }
+  } else {
+    notes.push("No package.json detected \u2014 npm badges skipped.");
+  }
+  const toolBadges = toolingBadges(probes);
+  const toolingSlugs = new Set(toolBadges.map((b) => b.query.logo).filter((v) => !!v));
+  badges.push(...toolBadges);
+  if (pkg) {
+    badges.push(...stackBadges(pkg, toolingSlugs));
+    badges.push(...modernBadges(pkg, probes));
+  } else {
+    badges.push(...modernBadges({}, probes));
+  }
+  badges.push(...await communityBadges(owner, repo, pkg, readme));
+  const existingShieldsIoUrls = readme ? extractShieldsIoUrls(readme) : [];
+  return {
+    source: { owner, repo, url: `https://github.com/${owner}/${repo}` },
+    badges,
+    notes,
+    existingShieldsIoUrls
+  };
+}
+async function inspectRemote(urlOrSlug) {
+  const parsed = parseGithubUrl(urlOrSlug);
+  if ("error" in parsed) return { error: parsed.error };
+  const { owner, repo, url } = parsed;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 15e3);
+  const signal = controller.signal;
+  try {
+    const [pkgText, readme] = await Promise.all([
+      fetchText(rawUrl(owner, repo, "package.json"), signal),
+      (async () => {
+        const candidates = ["README.md", "readme.md", "Readme.md"];
+        for (const path of candidates) {
+          const text = await fetchText(rawUrl(owner, repo, path), signal);
+          if (text) return text;
+        }
+        return null;
+      })()
+    ]);
+    const pkg = pkgText ? (() => {
+      try {
+        return JSON.parse(pkgText);
+      } catch {
+        return null;
+      }
+    })() : null;
+    const probeEntries = await Promise.all(
+      PROBE_FILES.map(async (path) => {
+        const exists = await headExists(rawUrl(owner, repo, path), signal);
+        return [path, exists];
+      })
+    );
+    const probes = Object.fromEntries(probeEntries);
+    const notes = [];
+    const badges = [];
+    badges.push(...githubMetricBadges(owner, repo));
+    if (pkg) {
+      if (pkg.private === true) {
+        badges.push(privatePackageBadge());
+        notes.push("package.json is private \u2014 npm badges suppressed.");
+      } else if (pkg.name) {
+        const npmInfo = await fetchJson(`${NPM_REGISTRY}/${pkg.name}`, signal);
+        if (npmInfo && npmInfo.name) {
+          badges.push(...npmBadges(pkg.name));
+        } else {
+          notes.push(`Package "${pkg.name}" not found on npm \u2014 npm badges skipped.`);
+        }
+      }
+    } else {
+      notes.push("No package.json detected \u2014 npm badges skipped.");
+    }
+    const toolBadges = toolingBadges(probes);
+    const toolingSlugs = new Set(toolBadges.map((b) => b.query.logo).filter((v) => !!v));
+    badges.push(...toolBadges);
+    if (pkg) {
+      badges.push(...stackBadges(pkg, toolingSlugs));
+      badges.push(...modernBadges(pkg, probes));
+    } else {
+      badges.push(...modernBadges({}, probes));
+    }
+    badges.push(...await communityBadges(owner, repo, pkg, readme, signal));
+    const existingShieldsIoUrls = readme ? extractShieldsIoUrls(readme) : [];
+    return { source: { owner, repo, url }, badges, notes, existingShieldsIoUrls };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// src/output.ts
+var GROUP_TITLES = {
+  github: "GitHub",
+  package: "Package",
+  tooling: "Tooling",
+  stack: "Stack",
+  modern: "Modern",
+  community: "Community"
+};
+var GROUP_ORDER = [
+  "github",
+  "package",
+  "tooling",
+  "stack",
+  "modern",
+  "community"
+];
+function groupBadges(badges) {
+  const groups = /* @__PURE__ */ new Map();
+  for (const badge of badges) {
+    if (!badge.enabled) continue;
+    const list = groups.get(badge.group) ?? [];
+    list.push(badge);
+    groups.set(badge.group, list);
+  }
+  return groups;
+}
+function formatMarkdown(result, global, options = {}) {
+  const { grouped = true, compact = false } = options;
+  const enabled = result.badges.filter((b) => b.enabled);
+  if (!grouped || compact) {
+    return enabled.map((b) => badgeMarkdown(b, global)).join("\n");
+  }
+  const groups = groupBadges(enabled);
+  const sections = [];
+  for (const group of GROUP_ORDER) {
+    const badges = groups.get(group);
+    if (!badges || badges.length === 0) continue;
+    const title = GROUP_TITLES[group];
+    const lines = badges.map((b) => badgeMarkdown(b, global));
+    sections.push(`### ${title}
+
+${lines.join("\n")}`);
+  }
+  return sections.join("\n\n");
+}
+function formatFlatMarkdown(result, global) {
+  return result.badges.filter((b) => b.enabled).map((b) => badgeMarkdown(b, global)).join(" ");
+}
+function formatHtml(result, global) {
+  const enabled = result.badges.filter((b) => b.enabled);
+  const groups = groupBadges(enabled);
+  const sections = [];
+  sections.push('<p align="center">');
+  for (const group of GROUP_ORDER) {
+    const badges = groups.get(group);
+    if (!badges || badges.length === 0) continue;
+    for (const b of badges) {
+      sections.push(`  ${badgeHtml(b, global)}`);
+    }
+  }
+  sections.push("</p>");
+  return sections.join("\n");
+}
+function formatJson(result, global) {
+  return JSON.stringify(
+    {
+      version: 1,
+      source: result.source,
+      global,
+      badges: result.badges.map((b) => ({
+        ...b,
+        url: badgeUrl(b, global)
+      })),
+      notes: result.notes
+    },
+    null,
+    2
+  );
+}
+
+// src/migrate.ts
+function convertShieldsUrl(url) {
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname !== "img.shields.io") return null;
+    const path = parsed.pathname.replace(/^\/+/, "");
+    const params = parsed.searchParams;
+    const query = new URLSearchParams();
+    const style = params.get("style");
+    if (style === "flat-square" || style === "flat") query.set("variant", "secondary");
+    else if (style === "for-the-badge") query.set("variant", "default");
+    else if (style === "social") query.set("variant", "ghost");
+    else if (style === "plastic") query.set("variant", "outline");
+    const logo = params.get("logo");
+    if (logo) query.set("logo", logo);
+    const logoColor = params.get("logoColor");
+    if (logoColor) query.set("logoColor", logoColor.replace(/^#/, ""));
+    const color = params.get("color");
+    if (color) query.set("color", color.replace(/^#/, ""));
+    const labelColor = params.get("labelColor");
+    if (labelColor) query.set("labelColor", labelColor.replace(/^#/, ""));
+    const label = params.get("label");
+    if (label) query.set("label", label);
+    let shieldcnPath;
+    let provider;
+    if (path.startsWith("badge/")) {
+      shieldcnPath = path;
+      provider = "badge";
+      if (!shieldcnPath.endsWith(".svg") && !shieldcnPath.endsWith(".png")) {
+        shieldcnPath += ".svg";
+      }
+    } else if (path.startsWith("npm/")) {
+      shieldcnPath = path.replace(/^npm\/l\//, "npm/license/").replace(/^npm\/v\//, "npm/");
+      if (!shieldcnPath.endsWith(".svg")) shieldcnPath += ".svg";
+      provider = "npm";
+    } else if (path.startsWith("github/")) {
+      shieldcnPath = path;
+      if (!shieldcnPath.endsWith(".svg")) shieldcnPath += ".svg";
+      provider = "github";
+    } else if (path.startsWith("discord/")) {
+      shieldcnPath = path;
+      if (!shieldcnPath.endsWith(".svg")) shieldcnPath += ".svg";
+      provider = "discord";
+    } else if (path.startsWith("pypi/")) {
+      shieldcnPath = path.replace(/^pypi\/v\//, "pypi/");
+      if (!shieldcnPath.endsWith(".svg")) shieldcnPath += ".svg";
+      provider = "pypi";
+    } else if (path.startsWith("crates/")) {
+      shieldcnPath = path.replace(/^crates\/v\//, "crates/");
+      if (!shieldcnPath.endsWith(".svg")) shieldcnPath += ".svg";
+      provider = "crates";
+    } else if (path.startsWith("docker/")) {
+      shieldcnPath = path;
+      if (!shieldcnPath.endsWith(".svg")) shieldcnPath += ".svg";
+      provider = "docker";
+    } else {
+      shieldcnPath = path;
+      if (!shieldcnPath.endsWith(".svg")) shieldcnPath += ".svg";
+      provider = path.split("/")[0] || "unknown";
+    }
+    const qs = query.toString();
+    const converted = `${SHIELDCN_BASE}/${shieldcnPath}${qs ? `?${qs}` : ""}`;
+    return { original: url, converted, provider };
+  } catch {
+    return null;
+  }
+}
+function migrateAll(content) {
+  const re = /https?:\/\/img\.shields\.io\/[^\s)"'>]+/g;
+  const urls = Array.from(new Set(content.match(re) ?? []));
+  return urls.map(convertShieldsUrl).filter((m) => m !== null);
+}
+function replaceShieldsUrls(content, migrations) {
+  let result = content;
+  for (const m of migrations) {
+    result = result.replaceAll(m.original, m.converted);
+  }
+  return result;
+}
+
+// src/inject.ts
+import { readFileSync as readFileSync2, writeFileSync, existsSync as existsSync2 } from "fs";
+import { join as join2 } from "path";
+var README_NAMES = ["README.md", "readme.md", "Readme.md", "README.MD"];
+function findReadme(dir) {
+  for (const name of README_NAMES) {
+    const path = join2(dir, name);
+    if (existsSync2(path)) return path;
+  }
+  return null;
+}
+function hasMarkers(content) {
+  return content.includes(INJECT_START) && content.includes(INJECT_END);
+}
+function injectBadges(content, badgeMarkdown2) {
+  const block = `${INJECT_START}
+${badgeMarkdown2}
+${INJECT_END}`;
+  if (hasMarkers(content)) {
+    const startIdx = content.indexOf(INJECT_START);
+    const endIdx = content.indexOf(INJECT_END) + INJECT_END.length;
+    return content.slice(0, startIdx) + block + content.slice(endIdx);
+  }
+  const headingMatch = content.match(/^#\s+.+$/m);
+  if (headingMatch && headingMatch.index !== void 0) {
+    const insertAt = headingMatch.index + headingMatch[0].length;
+    return content.slice(0, insertAt) + "\n\n" + block + "\n" + content.slice(insertAt);
+  }
+  return block + "\n\n" + content;
+}
+
+// src/bin.ts
+var version = "1.0.0";
+function copyToClipboard(text) {
+  try {
+    const platform = process.platform;
+    if (platform === "darwin") {
+      execSync("pbcopy", { input: text });
+      return true;
+    } else if (platform === "linux") {
+      try {
+        execSync("xclip -selection clipboard", { input: text });
+        return true;
+      } catch {
+        try {
+          execSync("xsel --clipboard --input", { input: text });
+          return true;
+        } catch {
+          return false;
+        }
+      }
+    } else if (platform === "win32") {
+      execSync("clip", { input: text });
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+function printHeader() {
+  console.log();
+  console.log(pc.bold("  shieldcn") + pc.dim(" \u2014 beautiful README badges"));
+  console.log(pc.dim(`  ${SHIELDCN_BASE}`));
+  console.log();
+}
+function printBadgeSummary(badges) {
+  const enabled = badges.filter((b) => b.enabled);
+  const groups = /* @__PURE__ */ new Map();
+  for (const b of enabled) {
+    const list = groups.get(b.group) ?? [];
+    list.push(b);
+    groups.set(b.group, list);
+  }
+  const groupNames = {
+    github: "GitHub",
+    package: "Package",
+    tooling: "Tooling",
+    stack: "Stack",
+    modern: "Modern",
+    community: "Community"
+  };
+  for (const [group, list] of groups) {
+    const name = groupNames[group] ?? group;
+    const labels = list.map((b) => b.label).join(", ");
+    console.log(`  ${pc.green("\u2713")} ${pc.bold(name)} ${pc.dim(`(${list.length})`)} ${pc.dim(labels)}`);
+  }
+  console.log();
+  console.log(pc.dim(`  ${enabled.length} badges total`));
+}
+var generate = defineCommand({
+  meta: {
+    name: "shieldcn",
+    version,
+    description: "Generate beautiful README badges from your terminal."
+  },
+  args: {
+    target: {
+      type: "positional",
+      description: "GitHub URL, owner/repo, or local path (defaults to current directory)",
+      required: false
+    },
+    variant: {
+      type: "string",
+      description: `Badge variant: ${VARIANTS.join(", ")}`
+    },
+    size: {
+      type: "string",
+      description: `Badge size: ${SIZES.join(", ")}`
+    },
+    theme: {
+      type: "string",
+      description: `Color theme: ${THEMES.join(", ")}`
+    },
+    mode: {
+      type: "string",
+      description: "Color mode: dark, light"
+    },
+    format: {
+      type: "string",
+      description: "Output format: markdown (default), flat, html, json",
+      default: "markdown"
+    },
+    inject: {
+      type: "boolean",
+      description: "Inject badges into README between <!-- shieldcn-start/end --> markers",
+      default: false
+    },
+    copy: {
+      type: "boolean",
+      description: "Copy output to clipboard",
+      default: false
+    },
+    json: {
+      type: "boolean",
+      description: "Output as JSON (shortcut for --format json)",
+      default: false
+    },
+    compact: {
+      type: "boolean",
+      description: "Output badges without group headers",
+      default: false
+    }
+  },
+  run: async ({ args: args2 }) => {
+    printHeader();
+    const target = args2.target || ".";
+    const isLocal = target === "." || target.startsWith("/") || target.startsWith("./") || target.startsWith("../");
+    const global = {
+      variant: args2.variant || "default",
+      size: args2.size || "sm",
+      mode: args2.mode || "dark",
+      theme: args2.theme || ""
+    };
+    if (global.variant && !VARIANTS.includes(global.variant)) {
+      consola.error(`Invalid variant "${global.variant}". Valid: ${VARIANTS.join(", ")}`);
+      process.exit(1);
+    }
+    if (global.size && !SIZES.includes(global.size)) {
+      consola.error(`Invalid size "${global.size}". Valid: ${SIZES.join(", ")}`);
+      process.exit(1);
+    }
+    consola.start(
+      isLocal ? `Scanning local directory ${pc.cyan(resolve2(target))}...` : `Scanning ${pc.cyan(target)}...`
+    );
+    const result = isLocal ? await inspectLocal(resolve2(target)) : await inspectRemote(target);
+    if ("error" in result) {
+      consola.error(result.error);
+      process.exit(1);
+    }
+    if (result.notes.length > 0) {
+      for (const note of result.notes) {
+        consola.info(pc.dim(note));
+      }
+    }
+    console.log();
+    console.log(
+      `  ${pc.bold(result.source.owner)}/${pc.bold(result.source.repo)} ${pc.dim("\u2192")} ${pc.dim(result.source.url)}`
+    );
+    console.log();
+    printBadgeSummary(result.badges);
+    if (result.existingShieldsIoUrls.length > 0) {
+      console.log();
+      consola.info(
+        `Found ${pc.yellow(String(result.existingShieldsIoUrls.length))} shields.io URLs in README. Run ${pc.cyan("shieldcn migrate")} to convert them.`
+      );
+    }
+    const format = args2.json ? "json" : args2.format || "markdown";
+    let output;
+    switch (format) {
+      case "json":
+        output = formatJson(result, global);
+        break;
+      case "html":
+        output = formatHtml(result, global);
+        break;
+      case "flat":
+        output = formatFlatMarkdown(result, global);
+        break;
+      case "markdown":
+      default:
+        output = formatMarkdown(result, global, { compact: args2.compact });
+        break;
+    }
+    if (args2.inject) {
+      const readmePath = findReadme(isLocal ? resolve2(target) : ".");
+      if (!readmePath) {
+        consola.error("No README.md found to inject into.");
+        process.exit(1);
+      }
+      const flatOutput = formatFlatMarkdown(result, global);
+      const content = readFileSync3(readmePath, "utf-8");
+      const updated = injectBadges(content, flatOutput);
+      writeFileSync2(readmePath, updated, "utf-8");
+      const verb = hasMarkers(content) ? "Updated" : "Added";
+      consola.success(`${verb} badges in ${pc.cyan(readmePath)}`);
+      return;
+    }
+    console.log();
+    console.log(pc.dim("\u2500".repeat(60)));
+    console.log();
+    console.log(output);
+    console.log();
+    console.log(pc.dim("\u2500".repeat(60)));
+    if (args2.copy) {
+      if (copyToClipboard(output)) {
+        consola.success("Copied to clipboard");
+      } else {
+        consola.warn("Could not copy to clipboard");
+      }
+    }
+  }
+});
+var migrate = defineCommand({
+  meta: {
+    name: "migrate",
+    description: "Convert shields.io URLs in README to shieldcn."
+  },
+  args: {
+    file: {
+      type: "positional",
+      description: "Path to README file (defaults to README.md in current directory)",
+      required: false
+    },
+    dry: {
+      type: "boolean",
+      description: "Preview changes without writing",
+      default: false
+    },
+    write: {
+      type: "boolean",
+      description: "Write changes to file",
+      default: false
+    }
+  },
+  run: async ({ args: args2 }) => {
+    printHeader();
+    const filePath = args2.file || findReadme(".") || "README.md";
+    let content;
+    try {
+      content = readFileSync3(filePath, "utf-8");
+    } catch {
+      consola.error(`Could not read ${pc.cyan(filePath)}`);
+      process.exit(1);
+    }
+    const migrations = migrateAll(content);
+    if (migrations.length === 0) {
+      consola.success("No shields.io URLs found. Nothing to migrate.");
+      return;
+    }
+    console.log(`  Found ${pc.yellow(String(migrations.length))} shields.io badge(s):
+`);
+    for (let i = 0; i < migrations.length; i++) {
+      const m = migrations[i];
+      console.log(`  ${pc.dim(`${i + 1}.`)} ${pc.strikethrough(pc.red(m.original))}`);
+      console.log(`     ${pc.green("\u2192")} ${pc.green(m.converted)}`);
+      console.log();
+    }
+    if (args2.dry) {
+      consola.info("Dry run \u2014 no changes written.");
+      return;
+    }
+    if (args2.write) {
+      const updated = replaceShieldsUrls(content, migrations);
+      writeFileSync2(filePath, updated, "utf-8");
+      consola.success(`Updated ${pc.cyan(filePath)} with ${migrations.length} replacement(s).`);
+      return;
+    }
+    const confirmed = await consola.prompt(
+      `Replace ${migrations.length} URL(s) in ${filePath}?`,
+      { type: "confirm" }
+    );
+    if (confirmed) {
+      const updated = replaceShieldsUrls(content, migrations);
+      writeFileSync2(filePath, updated, "utf-8");
+      consola.success(`Updated ${pc.cyan(filePath)} with ${migrations.length} replacement(s).`);
+    } else {
+      consola.info("No changes made.");
+    }
+  }
+});
+var init = defineCommand({
+  meta: {
+    name: "init",
+    description: "Add shieldcn markers to your README for badge injection."
+  },
+  args: {
+    file: {
+      type: "positional",
+      description: "Path to README file",
+      required: false
+    }
+  },
+  run: async ({ args: args2 }) => {
+    printHeader();
+    const filePath = args2.file || findReadme(".") || "README.md";
+    let content;
+    try {
+      content = readFileSync3(filePath, "utf-8");
+    } catch {
+      consola.error(`Could not read ${pc.cyan(filePath)}`);
+      process.exit(1);
+    }
+    if (hasMarkers(content)) {
+      consola.info(`${pc.cyan(filePath)} already has shieldcn markers.`);
+      return;
+    }
+    const updated = injectBadges(content, "<!-- your badges will appear here -->");
+    writeFileSync2(filePath, updated, "utf-8");
+    consola.success(`Added shieldcn markers to ${pc.cyan(filePath)}`);
+    consola.info(`Run ${pc.cyan("shieldcn --inject")} to populate them.`);
+  }
+});
+var args = process.argv.slice(2);
+var firstArg = args[0];
+if (firstArg === "migrate") {
+  process.argv = [process.argv[0], process.argv[1], ...args.slice(1)];
+  runMain(migrate);
+} else if (firstArg === "init") {
+  process.argv = [process.argv[0], process.argv[1], ...args.slice(1)];
+  runMain(init);
+} else if (firstArg === "--help" || firstArg === "-h") {
+  runMain(generate);
+} else if (firstArg === "--version" || firstArg === "-v") {
+  console.log(version);
+} else {
+  runMain(generate);
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "shieldcn-cli",
+  "version": "1.0.0",
+  "description": "Generate beautiful README badges from your terminal. Scans your repo, detects your stack, and outputs copy-paste markdown.",
+  "type": "module",
+  "bin": {
+    "shieldcn": "dist/bin.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "badges",
+    "readme",
+    "shields",
+    "shields.io",
+    "shadcn",
+    "github",
+    "npm",
+    "cli",
+    "markdown",
+    "svg"
+  ],
+  "author": "Justin Levine <hey@justinlevine.me> (https://justinlevine.me)",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jal-co/shieldcn",
+    "directory": "packages/cli"
+  },
+  "homepage": "https://shieldcn.dev/docs/cli",
+  "bugs": {
+    "url": "https://github.com/jal-co/shieldcn/issues"
+  },
+  "dependencies": {
+    "citty": "^0.1.6",
+    "consola": "^3.4.2",
+    "picocolors": "^1.1.1",
+    "yaml": "^2.7.1"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.0",
+    "typescript": "^5"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1,0 +1,407 @@
+/**
+ * shieldcn CLI
+ * src/bin.ts
+ *
+ * Main entry point. Scans a GitHub repo (remote or local), detects the
+ * stack, and outputs copy-paste badge markdown for your README.
+ */
+
+import { defineCommand, runMain } from "citty"
+import consola from "consola"
+import pc from "picocolors"
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { execSync } from "node:child_process"
+import { inspectLocal, inspectRemote } from "./detect.js"
+import { formatMarkdown, formatFlatMarkdown, formatHtml, formatJson } from "./output.js"
+import { migrateAll, replaceShieldsUrls } from "./migrate.js"
+import { findReadme, injectBadges, hasMarkers } from "./inject.js"
+import { VARIANTS, SIZES, THEMES, SHIELDCN_BASE } from "./constants.js"
+import type { GlobalSettings, Badge } from "./types.js"
+
+const version = "1.0.0"
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function copyToClipboard(text: string): boolean {
+  try {
+    const platform = process.platform
+    if (platform === "darwin") {
+      execSync("pbcopy", { input: text })
+      return true
+    } else if (platform === "linux") {
+      try {
+        execSync("xclip -selection clipboard", { input: text })
+        return true
+      } catch {
+        try {
+          execSync("xsel --clipboard --input", { input: text })
+          return true
+        } catch {
+          return false
+        }
+      }
+    } else if (platform === "win32") {
+      execSync("clip", { input: text })
+      return true
+    }
+    return false
+  } catch {
+    return false
+  }
+}
+
+function printHeader() {
+  console.log()
+  console.log(pc.bold("  shieldcn") + pc.dim(" — beautiful README badges"))
+  console.log(pc.dim(`  ${SHIELDCN_BASE}`))
+  console.log()
+}
+
+function printBadgeSummary(badges: Badge[]) {
+  const enabled = badges.filter((b) => b.enabled)
+  const groups = new Map<string, Badge[]>()
+  for (const b of enabled) {
+    const list = groups.get(b.group) ?? []
+    list.push(b)
+    groups.set(b.group, list)
+  }
+
+  const groupNames: Record<string, string> = {
+    github: "GitHub",
+    package: "Package",
+    tooling: "Tooling",
+    stack: "Stack",
+    modern: "Modern",
+    community: "Community",
+  }
+
+  for (const [group, list] of groups) {
+    const name = groupNames[group] ?? group
+    const labels = list.map((b) => b.label).join(", ")
+    console.log(`  ${pc.green("✓")} ${pc.bold(name)} ${pc.dim(`(${list.length})`)} ${pc.dim(labels)}`)
+  }
+  console.log()
+  console.log(pc.dim(`  ${enabled.length} badges total`))
+}
+
+// ── Generate command ──────────────────────────────────────────────────
+
+const generate = defineCommand({
+  meta: {
+    name: "shieldcn",
+    version,
+    description: "Generate beautiful README badges from your terminal.",
+  },
+  args: {
+    target: {
+      type: "positional",
+      description: "GitHub URL, owner/repo, or local path (defaults to current directory)",
+      required: false,
+    },
+    variant: {
+      type: "string",
+      description: `Badge variant: ${VARIANTS.join(", ")}`,
+    },
+    size: {
+      type: "string",
+      description: `Badge size: ${SIZES.join(", ")}`,
+    },
+    theme: {
+      type: "string",
+      description: `Color theme: ${THEMES.join(", ")}`,
+    },
+    mode: {
+      type: "string",
+      description: "Color mode: dark, light",
+    },
+    format: {
+      type: "string",
+      description: "Output format: markdown (default), flat, html, json",
+      default: "markdown",
+    },
+    inject: {
+      type: "boolean",
+      description: "Inject badges into README between <!-- shieldcn-start/end --> markers",
+      default: false,
+    },
+    copy: {
+      type: "boolean",
+      description: "Copy output to clipboard",
+      default: false,
+    },
+    json: {
+      type: "boolean",
+      description: "Output as JSON (shortcut for --format json)",
+      default: false,
+    },
+    compact: {
+      type: "boolean",
+      description: "Output badges without group headers",
+      default: false,
+    },
+  },
+  run: async ({ args }) => {
+    printHeader()
+
+    const target = (args.target as string) || "."
+    const isLocal = target === "." || target.startsWith("/") || target.startsWith("./") || target.startsWith("../")
+
+    // Build global settings
+    const global: GlobalSettings = {
+      variant: (args.variant as string) || "default",
+      size: (args.size as string) || "sm",
+      mode: (args.mode as string) || "dark",
+      theme: (args.theme as string) || "",
+    }
+
+    // Validate variant
+    if (global.variant && !VARIANTS.includes(global.variant as typeof VARIANTS[number])) {
+      consola.error(`Invalid variant "${global.variant}". Valid: ${VARIANTS.join(", ")}`)
+      process.exit(1)
+    }
+
+    // Validate size
+    if (global.size && !SIZES.includes(global.size as typeof SIZES[number])) {
+      consola.error(`Invalid size "${global.size}". Valid: ${SIZES.join(", ")}`)
+      process.exit(1)
+    }
+
+    // Inspect
+    consola.start(
+      isLocal
+        ? `Scanning local directory ${pc.cyan(resolve(target))}...`
+        : `Scanning ${pc.cyan(target)}...`,
+    )
+
+    const result = isLocal
+      ? await inspectLocal(resolve(target))
+      : await inspectRemote(target)
+
+    if ("error" in result) {
+      consola.error(result.error)
+      process.exit(1)
+    }
+
+    // Print notes
+    if (result.notes.length > 0) {
+      for (const note of result.notes) {
+        consola.info(pc.dim(note))
+      }
+    }
+
+    // Print summary
+    console.log()
+    console.log(
+      `  ${pc.bold(result.source.owner)}/${pc.bold(result.source.repo)} ${pc.dim("→")} ${pc.dim(result.source.url)}`,
+    )
+    console.log()
+
+    printBadgeSummary(result.badges)
+
+    // shields.io migration hint
+    if (result.existingShieldsIoUrls.length > 0) {
+      console.log()
+      consola.info(
+        `Found ${pc.yellow(String(result.existingShieldsIoUrls.length))} shields.io URLs in README. Run ${pc.cyan("shieldcn migrate")} to convert them.`,
+      )
+    }
+
+    // Format output
+    const format = args.json ? "json" : (args.format as string) || "markdown"
+    let output: string
+
+    switch (format) {
+      case "json":
+        output = formatJson(result, global)
+        break
+      case "html":
+        output = formatHtml(result, global)
+        break
+      case "flat":
+        output = formatFlatMarkdown(result, global)
+        break
+      case "markdown":
+      default:
+        output = formatMarkdown(result, global, { compact: args.compact })
+        break
+    }
+
+    // Inject into README
+    if (args.inject) {
+      const readmePath = findReadme(isLocal ? resolve(target) : ".")
+      if (!readmePath) {
+        consola.error("No README.md found to inject into.")
+        process.exit(1)
+      }
+
+      const flatOutput = formatFlatMarkdown(result, global)
+      const content = readFileSync(readmePath, "utf-8")
+      const updated = injectBadges(content, flatOutput)
+      writeFileSync(readmePath, updated, "utf-8")
+
+      const verb = hasMarkers(content) ? "Updated" : "Added"
+      consola.success(`${verb} badges in ${pc.cyan(readmePath)}`)
+      return
+    }
+
+    // Output
+    console.log()
+    console.log(pc.dim("─".repeat(60)))
+    console.log()
+    console.log(output)
+    console.log()
+    console.log(pc.dim("─".repeat(60)))
+
+    // Copy to clipboard
+    if (args.copy) {
+      if (copyToClipboard(output)) {
+        consola.success("Copied to clipboard")
+      } else {
+        consola.warn("Could not copy to clipboard")
+      }
+    }
+  },
+})
+
+// ── Migrate subcommand ────────────────────────────────────────────────
+
+const migrate = defineCommand({
+  meta: {
+    name: "migrate",
+    description: "Convert shields.io URLs in README to shieldcn.",
+  },
+  args: {
+    file: {
+      type: "positional",
+      description: "Path to README file (defaults to README.md in current directory)",
+      required: false,
+    },
+    dry: {
+      type: "boolean",
+      description: "Preview changes without writing",
+      default: false,
+    },
+    write: {
+      type: "boolean",
+      description: "Write changes to file",
+      default: false,
+    },
+  },
+  run: async ({ args }) => {
+    printHeader()
+
+    const filePath = (args.file as string) || findReadme(".") || "README.md"
+    let content: string
+
+    try {
+      content = readFileSync(filePath, "utf-8")
+    } catch {
+      consola.error(`Could not read ${pc.cyan(filePath)}`)
+      process.exit(1)
+    }
+
+    const migrations = migrateAll(content)
+
+    if (migrations.length === 0) {
+      consola.success("No shields.io URLs found. Nothing to migrate.")
+      return
+    }
+
+    console.log(`  Found ${pc.yellow(String(migrations.length))} shields.io badge(s):\n`)
+
+    for (let i = 0; i < migrations.length; i++) {
+      const m = migrations[i]!
+      console.log(`  ${pc.dim(`${i + 1}.`)} ${pc.strikethrough(pc.red(m.original))}`)
+      console.log(`     ${pc.green("→")} ${pc.green(m.converted)}`)
+      console.log()
+    }
+
+    if (args.dry) {
+      consola.info("Dry run — no changes written.")
+      return
+    }
+
+    if (args.write) {
+      const updated = replaceShieldsUrls(content, migrations)
+      writeFileSync(filePath, updated, "utf-8")
+      consola.success(`Updated ${pc.cyan(filePath)} with ${migrations.length} replacement(s).`)
+      return
+    }
+
+    // Interactive prompt
+    const confirmed = await consola.prompt(
+      `Replace ${migrations.length} URL(s) in ${filePath}?`,
+      { type: "confirm" },
+    )
+
+    if (confirmed) {
+      const updated = replaceShieldsUrls(content, migrations)
+      writeFileSync(filePath, updated, "utf-8")
+      consola.success(`Updated ${pc.cyan(filePath)} with ${migrations.length} replacement(s).`)
+    } else {
+      consola.info("No changes made.")
+    }
+  },
+})
+
+// ── Init subcommand ───────────────────────────────────────────────────
+
+const init = defineCommand({
+  meta: {
+    name: "init",
+    description: "Add shieldcn markers to your README for badge injection.",
+  },
+  args: {
+    file: {
+      type: "positional",
+      description: "Path to README file",
+      required: false,
+    },
+  },
+  run: async ({ args }) => {
+    printHeader()
+
+    const filePath = (args.file as string) || findReadme(".") || "README.md"
+    let content: string
+
+    try {
+      content = readFileSync(filePath, "utf-8")
+    } catch {
+      consola.error(`Could not read ${pc.cyan(filePath)}`)
+      process.exit(1)
+    }
+
+    if (hasMarkers(content)) {
+      consola.info(`${pc.cyan(filePath)} already has shieldcn markers.`)
+      return
+    }
+
+    const updated = injectBadges(content, "<!-- your badges will appear here -->")
+    writeFileSync(filePath, updated, "utf-8")
+    consola.success(`Added shieldcn markers to ${pc.cyan(filePath)}`)
+    consola.info(`Run ${pc.cyan("shieldcn --inject")} to populate them.`)
+  },
+})
+
+// ── Run ───────────────────────────────────────────────────────────────
+
+// Use manual arg routing to support both positional target AND subcommands.
+// citty doesn't handle `shieldcn vercel/next.js` + `shieldcn migrate` together.
+
+const args = process.argv.slice(2)
+const firstArg = args[0]
+
+if (firstArg === "migrate") {
+  process.argv = [process.argv[0]!, process.argv[1]!, ...args.slice(1)]
+  runMain(migrate)
+} else if (firstArg === "init") {
+  process.argv = [process.argv[0]!, process.argv[1]!, ...args.slice(1)]
+  runMain(init)
+} else if (firstArg === "--help" || firstArg === "-h") {
+  runMain(generate)
+} else if (firstArg === "--version" || firstArg === "-v") {
+  console.log(version)
+} else {
+  runMain(generate)
+}

--- a/packages/cli/src/brands.ts
+++ b/packages/cli/src/brands.ts
@@ -1,0 +1,138 @@
+/**
+ * shieldcn CLI
+ * src/brands.ts
+ *
+ * npm package name → brand icon/color mapping.
+ * Extracted from packages/web/lib/gen/brands.ts.
+ */
+
+export type Brand = {
+  slug: string
+  color: string
+  label: string
+}
+
+export const BRANDS: Record<string, Brand> = {
+  // React ecosystem
+  react: { slug: "react", color: "61DAFB", label: "React" },
+  "react-dom": { slug: "react", color: "61DAFB", label: "React" },
+  next: { slug: "nextdotjs", color: "000000", label: "Next.js" },
+  "@next/env": { slug: "nextdotjs", color: "000000", label: "Next.js" },
+  "@t3-oss/env-nextjs": { slug: "nextdotjs", color: "000000", label: "Next.js" },
+  astro: { slug: "astro", color: "BC52EE", label: "Astro" },
+  "@astrojs/cloudflare": { slug: "astro", color: "BC52EE", label: "Astro" },
+  svelte: { slug: "svelte", color: "FF3E00", label: "Svelte" },
+  "@sveltejs/kit": { slug: "svelte", color: "FF3E00", label: "SvelteKit" },
+  vue: { slug: "vuedotjs", color: "4FC08D", label: "Vue" },
+  nuxt: { slug: "nuxt", color: "00DC82", label: "Nuxt" },
+  "solid-js": { slug: "solid", color: "2C4F7C", label: "Solid" },
+  "@builder.io/qwik": { slug: "qwik", color: "18B6F6", label: "Qwik" },
+
+  // CSS / UI
+  tailwindcss: { slug: "tailwindcss", color: "06B6D4", label: "Tailwind CSS" },
+  unocss: { slug: "unocss", color: "333333", label: "UnoCSS" },
+  "@radix-ui/react": { slug: "radixui", color: "000000", label: "Radix UI" },
+  "@shadcn/ui": { slug: "shadcnui", color: "000000", label: "shadcn/ui" },
+
+  // TypeScript & tools
+  typescript: { slug: "typescript", color: "3178C6", label: "TypeScript" },
+  "@biomejs/biome": { slug: "biome", color: "60A5FA", label: "Biome" },
+  eslint: { slug: "eslint", color: "4B32C3", label: "ESLint" },
+  prettier: { slug: "prettier", color: "F7B93E", label: "Prettier" },
+
+  // Build tools
+  vite: { slug: "vite", color: "646CFF", label: "Vite" },
+  webpack: { slug: "webpack", color: "8DD6F9", label: "Webpack" },
+  rollup: { slug: "rollupdotjs", color: "EC4A3F", label: "Rollup" },
+  esbuild: { slug: "esbuild", color: "FFCF00", label: "esbuild" },
+  turbo: { slug: "turborepo", color: "EF4444", label: "Turborepo" },
+  nx: { slug: "nx", color: "143055", label: "Nx" },
+  "@changesets/cli": { slug: "changesets", color: "5846F5", label: "Changesets" },
+
+  // Testing
+  vitest: { slug: "vitest", color: "6E9F18", label: "Vitest" },
+  playwright: { slug: "playwright", color: "2EAD33", label: "Playwright" },
+  "@playwright/test": { slug: "playwright", color: "2EAD33", label: "Playwright" },
+  jest: { slug: "jest", color: "C21325", label: "Jest" },
+  cypress: { slug: "cypress", color: "69D3A7", label: "Cypress" },
+
+  // Databases & ORMs
+  prisma: { slug: "prisma", color: "2D3748", label: "Prisma" },
+  "drizzle-orm": { slug: "drizzle", color: "C5F74F", label: "Drizzle" },
+  "drizzle-kit": { slug: "drizzle", color: "C5F74F", label: "Drizzle" },
+  kysely: { slug: "kysely", color: "1E88E5", label: "Kysely" },
+  typeorm: { slug: "typeorm", color: "FE0902", label: "TypeORM" },
+  mongoose: { slug: "mongodb", color: "47A248", label: "Mongoose" },
+  postgres: { slug: "postgresql", color: "4169E1", label: "PostgreSQL" },
+  pg: { slug: "postgresql", color: "4169E1", label: "PostgreSQL" },
+  mongodb: { slug: "mongodb", color: "47A248", label: "MongoDB" },
+  mysql2: { slug: "mysql", color: "4479A1", label: "MySQL" },
+  redis: { slug: "redis", color: "FF4438", label: "Redis" },
+  ioredis: { slug: "redis", color: "FF4438", label: "Redis" },
+
+  // Validation
+  zod: { slug: "zod", color: "3E67B1", label: "Zod" },
+  valibot: { slug: "valibot", color: "0284C7", label: "Valibot" },
+
+  // API / RPC
+  "@trpc/server": { slug: "trpc", color: "398CCB", label: "tRPC" },
+  "@trpc/client": { slug: "trpc", color: "398CCB", label: "tRPC" },
+  graphql: { slug: "graphql", color: "E10098", label: "GraphQL" },
+
+  // State / data
+  "@tanstack/react-query": { slug: "reactquery", color: "FF4154", label: "TanStack Query" },
+  "@tanstack/query-core": { slug: "reactquery", color: "FF4154", label: "TanStack Query" },
+  zustand: { slug: "zustand", color: "FFB800", label: "Zustand" },
+  jotai: { slug: "jotai", color: "000000", label: "Jotai" },
+
+  // Realtime
+  "socket.io": { slug: "socketdotio", color: "010101", label: "Socket.IO" },
+  "socket.io-client": { slug: "socketdotio", color: "010101", label: "Socket.IO" },
+
+  // Backend infra
+  supabase: { slug: "supabase", color: "3FCF8E", label: "Supabase" },
+  "@supabase/supabase-js": { slug: "supabase", color: "3FCF8E", label: "Supabase" },
+  firebase: { slug: "firebase", color: "DD2C00", label: "Firebase" },
+  "@firebase/app": { slug: "firebase", color: "DD2C00", label: "Firebase" },
+  convex: { slug: "convex", color: "EE342F", label: "Convex" },
+
+  // Payment
+  stripe: { slug: "stripe", color: "635BFF", label: "Stripe" },
+  "@stripe/stripe-js": { slug: "stripe", color: "635BFF", label: "Stripe" },
+
+  // AI
+  openai: { slug: "openai", color: "412991", label: "OpenAI" },
+  "@anthropic-ai/sdk": { slug: "anthropic", color: "D97757", label: "Anthropic" },
+  langchain: { slug: "langchain", color: "1C3C3C", label: "LangChain" },
+  "@langchain/core": { slug: "langchain", color: "1C3C3C", label: "LangChain" },
+  ai: { slug: "vercel", color: "000000", label: "AI SDK" },
+
+  // Hosting runtime libs
+  "@cloudflare/workers-types": { slug: "cloudflare", color: "F38020", label: "Cloudflare Workers" },
+  wrangler: { slug: "cloudflare", color: "F38020", label: "Cloudflare Workers" },
+
+  // Docs / content
+  "@docusaurus/core": { slug: "docusaurus", color: "3ECC5F", label: "Docusaurus" },
+  vitepress: { slug: "vitepress", color: "5E72E4", label: "VitePress" },
+  storybook: { slug: "storybook", color: "FF4785", label: "Storybook" },
+
+  // Pre-commit / quality
+  husky: { slug: "husky", color: "3B82F6", label: "Husky" },
+  "lint-staged": { slug: "git", color: "F05032", label: "lint-staged" },
+
+  // Misc
+  "@octokit/rest": { slug: "github", color: "181717", label: "Octokit" },
+  "@linear/sdk": { slug: "linear", color: "5E6AD2", label: "Linear" },
+}
+
+export function matchBrand(pkg: string): Brand | undefined {
+  if (BRANDS[pkg]) return BRANDS[pkg]
+  if (pkg.startsWith("@ai-sdk/")) return BRANDS["@ai-sdk/openai"] ?? BRANDS.ai
+  if (pkg.startsWith("@supabase/")) return BRANDS["@supabase/supabase-js"]
+  if (pkg.startsWith("@firebase/")) return BRANDS["@firebase/app"]
+  if (pkg.startsWith("@radix-ui/")) return BRANDS["@radix-ui/react"]
+  if (pkg.startsWith("@trpc/")) return BRANDS["@trpc/server"]
+  if (pkg.startsWith("@langchain/")) return BRANDS["@langchain/core"]
+  if (pkg.startsWith("@tanstack/")) return BRANDS["@tanstack/react-query"]
+  return undefined
+}

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -1,0 +1,48 @@
+/**
+ * shieldcn CLI
+ * src/constants.ts
+ */
+
+export const SHIELDCN_BASE = "https://www.shieldcn.dev"
+
+export const RAW_GH = "https://raw.githubusercontent.com"
+export const NPM_REGISTRY = "https://registry.npmjs.org"
+
+export const INJECT_START = "<!-- shieldcn-start -->"
+export const INJECT_END = "<!-- shieldcn-end -->"
+
+export const VARIANTS = [
+  "default",
+  "secondary",
+  "outline",
+  "ghost",
+  "destructive",
+  "branded",
+] as const
+
+export type Variant = (typeof VARIANTS)[number]
+
+export const SIZES = ["xs", "sm", "default", "lg"] as const
+export type Size = (typeof SIZES)[number]
+
+export const MODES = ["dark", "light"] as const
+export type Mode = (typeof MODES)[number]
+
+export const THEMES = [
+  "zinc",
+  "slate",
+  "stone",
+  "neutral",
+  "gray",
+  "blue",
+  "green",
+  "rose",
+  "orange",
+  "amber",
+  "violet",
+  "purple",
+  "red",
+  "cyan",
+  "emerald",
+] as const
+export type Theme = (typeof THEMES)[number]

--- a/packages/cli/src/detect.ts
+++ b/packages/cli/src/detect.ts
@@ -1,0 +1,625 @@
+/**
+ * shieldcn CLI
+ * src/detect.ts
+ *
+ * Repo inspection — scans a GitHub repo or local directory for
+ * package.json, config files, README, and detects the stack.
+ * Adapted from packages/web/lib/gen/detect.ts for Node.js usage.
+ */
+
+import { existsSync, readFileSync } from "node:fs"
+import { join, resolve } from "node:path"
+import { matchBrand } from "./brands.js"
+import { staticBadgePath } from "./url.js"
+import { RAW_GH, NPM_REGISTRY } from "./constants.js"
+import type { Badge, InspectResult, PackageJson } from "./types.js"
+
+const BRAND_CAP = 9
+
+// ── Remote fetch helpers ──────────────────────────────────────────────
+
+async function fetchText(url: string, signal?: AbortSignal): Promise<string | null> {
+  try {
+    const res = await fetch(url, { signal })
+    if (!res.ok) return null
+    return await res.text()
+  } catch {
+    return null
+  }
+}
+
+async function fetchJson<T = unknown>(url: string, signal?: AbortSignal): Promise<T | null> {
+  try {
+    const res = await fetch(url, { signal })
+    if (!res.ok) return null
+    return (await res.json()) as T
+  } catch {
+    return null
+  }
+}
+
+async function headExists(url: string, signal?: AbortSignal): Promise<boolean> {
+  try {
+    const res = await fetch(url, { method: "HEAD", signal })
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+function rawUrl(owner: string, repo: string, path: string): string {
+  return `${RAW_GH}/${owner}/${repo}/HEAD/${path}`
+}
+
+// ── GitHub URL parsing ────────────────────────────────────────────────
+
+export function parseGithubUrl(input: string):
+  | { owner: string; repo: string; url: string }
+  | { error: string } {
+  const trimmed = input.trim()
+  if (!trimmed) return { error: "URL is required" }
+
+  const ownerRepoOnly = /^([\w.-]+)\/([\w.-]+)$/
+  const m1 = trimmed.match(ownerRepoOnly)
+  if (m1) {
+    const owner = m1[1]!
+    const repo = m1[2]!.replace(/\.git$/, "")
+    return { owner, repo, url: `https://github.com/${owner}/${repo}` }
+  }
+
+  try {
+    const u = new URL(trimmed.startsWith("http") ? trimmed : `https://${trimmed}`)
+    if (!/^github\.com$/i.test(u.hostname)) {
+      return { error: "URL must be a github.com repository" }
+    }
+    const parts = u.pathname.replace(/^\/+|\/+$/g, "").split("/")
+    if (parts.length < 2) return { error: "Could not parse owner/repo from URL" }
+    const owner = parts[0]!
+    const repo = parts[1]!.replace(/\.git$/, "")
+    return { owner, repo, url: `https://github.com/${owner}/${repo}` }
+  } catch {
+    return { error: "Invalid URL" }
+  }
+}
+
+// ── Probe files ───────────────────────────────────────────────────────
+
+const PROBE_FILES = [
+  "pnpm-lock.yaml",
+  "yarn.lock",
+  "bun.lock",
+  "bun.lockb",
+  "package-lock.json",
+  "Dockerfile",
+  "docker-compose.yml",
+  "docker-compose.yaml",
+  ".nvmrc",
+  "tsconfig.json",
+  "biome.json",
+  ".prettierrc",
+  ".prettierrc.json",
+  "prettier.config.js",
+  ".eslintrc.json",
+  ".eslintrc.js",
+  ".eslintrc.cjs",
+  "eslint.config.js",
+  "eslint.config.mjs",
+  "vite.config.ts",
+  "vite.config.js",
+  "vite.config.mjs",
+  "next.config.ts",
+  "next.config.js",
+  "next.config.mjs",
+  "nuxt.config.ts",
+  "nuxt.config.js",
+  "astro.config.mjs",
+  "astro.config.ts",
+  "svelte.config.js",
+  "svelte.config.ts",
+  "tailwind.config.ts",
+  "tailwind.config.js",
+  "unocss.config.ts",
+  "unocss.config.js",
+  "turbo.json",
+  "nx.json",
+  ".changeset/README.md",
+  ".storybook/main.ts",
+  ".storybook/main.js",
+  "vitest.config.ts",
+  "vitest.config.js",
+  "playwright.config.ts",
+  "playwright.config.js",
+  "jest.config.js",
+  "jest.config.ts",
+  "cypress.config.ts",
+  "cypress.config.js",
+  "wrangler.toml",
+  "wrangler.jsonc",
+  "vercel.json",
+  "netlify.toml",
+  "fly.toml",
+  "AGENTS.md",
+  "llms.txt",
+  ".claude/CLAUDE.md",
+  ".cursor/rules",
+  "mcp.json",
+  "mcp-server.json",
+] as const
+
+type ProbeKey = (typeof PROBE_FILES)[number]
+type ProbeResult = Record<ProbeKey, boolean>
+
+// ── Local detection ───────────────────────────────────────────────────
+
+function getGitRemote(dir: string): { owner: string; repo: string } | null {
+  try {
+    const configPath = join(dir, ".git", "config")
+    if (!existsSync(configPath)) return null
+    const content = readFileSync(configPath, "utf-8")
+    // Match SSH or HTTPS GitHub remotes
+    const match = content.match(
+      /url\s*=\s*(?:git@github\.com:|https:\/\/github\.com\/)([\w.-]+)\/([\w.-]+?)(?:\.git)?\s*$/m,
+    )
+    if (!match) return null
+    return { owner: match[1]!, repo: match[2]! }
+  } catch {
+    return null
+  }
+}
+
+function localProbe(dir: string): ProbeResult {
+  const result = {} as ProbeResult
+  for (const file of PROBE_FILES) {
+    result[file] = existsSync(join(dir, file))
+  }
+  return result
+}
+
+function localPackageJson(dir: string): PackageJson | null {
+  const path = join(dir, "package.json")
+  if (!existsSync(path)) return null
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as PackageJson
+  } catch {
+    return null
+  }
+}
+
+function localReadme(dir: string): string | null {
+  const candidates = ["README.md", "readme.md", "Readme.md", "README.MD"]
+  for (const name of candidates) {
+    const path = join(dir, name)
+    if (existsSync(path)) {
+      try {
+        return readFileSync(path, "utf-8")
+      } catch {
+        continue
+      }
+    }
+  }
+  return null
+}
+
+// ── Badge generators ──────────────────────────────────────────────────
+
+function githubMetricBadges(owner: string, repo: string): Badge[] {
+  const mk = (
+    id: string,
+    label: string,
+    path: string,
+    query: Record<string, string> = {},
+  ): Badge => ({
+    id,
+    group: "github",
+    label,
+    path,
+    query,
+    enabled: true,
+  })
+  const p = (m: string) => `/github/${m}/${owner}/${repo}.svg`
+  return [
+    mk("github.stars", "GitHub Stars", p("stars"), { variant: "secondary" }),
+    mk("github.forks", "GitHub Forks", p("forks"), { variant: "secondary" }),
+    mk("github.watchers", "Watchers", p("watchers"), { variant: "secondary" }),
+    mk("github.contributors", "Contributors", p("contributors"), { theme: "emerald" }),
+    mk("github.last-commit", "Last commit", p("last-commit"), { variant: "secondary" }),
+    mk("github.open-issues", "Open issues", p("open-issues"), { variant: "secondary" }),
+    mk("github.open-prs", "Open PRs", p("open-prs"), { variant: "secondary" }),
+    mk("github.release", "Release", p("release")),
+    mk("github.ci", "CI", p("ci"), { variant: "secondary" }),
+    mk("github.license", "License", p("license"), { variant: "ghost" }),
+  ]
+}
+
+function npmBadges(pkg: string): Badge[] {
+  const mk = (
+    id: string,
+    label: string,
+    path: string,
+    query: Record<string, string> = {},
+  ): Badge => ({
+    id,
+    group: "package",
+    label,
+    path,
+    query,
+    enabled: true,
+  })
+  return [
+    mk("npm.version", "npm Version", `/npm/${pkg}.svg`, { variant: "secondary" }),
+    mk("npm.dw", "npm Weekly Downloads", `/npm/dw/${pkg}.svg`),
+    mk("npm.dm", "npm Monthly Downloads", `/npm/dm/${pkg}.svg`, { variant: "ghost" }),
+    mk("npm.dt", "npm Total Downloads", `/npm/dt/${pkg}.svg`, { variant: "secondary" }),
+    mk("npm.types", "npm Types", `/npm/types/${pkg}.svg`, { theme: "blue" }),
+    mk("npm.license", "npm License", `/npm/license/${pkg}.svg`, { variant: "ghost" }),
+  ]
+}
+
+function privatePackageBadge(): Badge {
+  return {
+    id: "package.private",
+    group: "package",
+    label: "Private package",
+    path: staticBadgePath("Private", "package", "red"),
+    query: { variant: "secondary" },
+    enabled: true,
+  }
+}
+
+// ── Tooling rules ─────────────────────────────────────────────────────
+
+type ToolingRule = {
+  id: string
+  category: string
+  name: string
+  slug: string
+  color: string
+  requires: ProbeKey[]
+}
+
+const TOOLING_RULES: ToolingRule[] = [
+  { id: "tooling.pnpm", category: "Package mgr", name: "pnpm", slug: "pnpm", color: "F69220", requires: ["pnpm-lock.yaml"] },
+  { id: "tooling.bun", category: "Package mgr", name: "Bun", slug: "bun", color: "000000", requires: ["bun.lock", "bun.lockb"] },
+  { id: "tooling.yarn", category: "Package mgr", name: "Yarn", slug: "yarn", color: "2C8EBB", requires: ["yarn.lock"] },
+  { id: "tooling.npm", category: "Package mgr", name: "npm", slug: "npm", color: "CB3837", requires: ["package-lock.json"] },
+  { id: "tooling.docker", category: "Container", name: "Docker", slug: "docker", color: "2496ED", requires: ["Dockerfile", "docker-compose.yml", "docker-compose.yaml"] },
+  { id: "tooling.typescript", category: "Language", name: "TypeScript", slug: "typescript", color: "3178C6", requires: ["tsconfig.json"] },
+  { id: "tooling.biome", category: "Lint", name: "Biome", slug: "biome", color: "60A5FA", requires: ["biome.json"] },
+  { id: "tooling.eslint", category: "Lint", name: "ESLint", slug: "eslint", color: "4B32C3", requires: [".eslintrc.json", ".eslintrc.js", ".eslintrc.cjs", "eslint.config.js", "eslint.config.mjs"] },
+  { id: "tooling.prettier", category: "Format", name: "Prettier", slug: "prettier", color: "F7B93E", requires: [".prettierrc", ".prettierrc.json", "prettier.config.js"] },
+  { id: "tooling.vite", category: "Bundler", name: "Vite", slug: "vite", color: "646CFF", requires: ["vite.config.ts", "vite.config.js", "vite.config.mjs"] },
+  { id: "tooling.nextjs", category: "Framework", name: "Next.js", slug: "nextdotjs", color: "000000", requires: ["next.config.ts", "next.config.js", "next.config.mjs"] },
+  { id: "tooling.nuxt", category: "Framework", name: "Nuxt", slug: "nuxt", color: "00DC82", requires: ["nuxt.config.ts", "nuxt.config.js"] },
+  { id: "tooling.astro", category: "Framework", name: "Astro", slug: "astro", color: "BC52EE", requires: ["astro.config.mjs", "astro.config.ts"] },
+  { id: "tooling.svelte", category: "Framework", name: "Svelte", slug: "svelte", color: "FF3E00", requires: ["svelte.config.js", "svelte.config.ts"] },
+  { id: "tooling.tailwind", category: "CSS", name: "Tailwind", slug: "tailwindcss", color: "06B6D4", requires: ["tailwind.config.ts", "tailwind.config.js"] },
+  { id: "tooling.unocss", category: "CSS", name: "UnoCSS", slug: "unocss", color: "333333", requires: ["unocss.config.ts", "unocss.config.js"] },
+  { id: "tooling.turbo", category: "Monorepo", name: "Turborepo", slug: "turborepo", color: "EF4444", requires: ["turbo.json"] },
+  { id: "tooling.nx", category: "Monorepo", name: "Nx", slug: "nx", color: "143055", requires: ["nx.json"] },
+  { id: "tooling.changesets", category: "Releases", name: "Changesets", slug: "changesets", color: "5846F5", requires: [".changeset/README.md"] },
+  { id: "tooling.storybook", category: "Docs", name: "Storybook", slug: "storybook", color: "FF4785", requires: [".storybook/main.ts", ".storybook/main.js"] },
+  { id: "tooling.vitest", category: "Tests", name: "Vitest", slug: "vitest", color: "6E9F18", requires: ["vitest.config.ts", "vitest.config.js"] },
+  { id: "tooling.playwright", category: "Tests", name: "Playwright", slug: "playwright", color: "2EAD33", requires: ["playwright.config.ts", "playwright.config.js"] },
+  { id: "tooling.jest", category: "Tests", name: "Jest", slug: "jest", color: "C21325", requires: ["jest.config.js", "jest.config.ts"] },
+  { id: "tooling.cypress", category: "Tests", name: "Cypress", slug: "cypress", color: "69D3A7", requires: ["cypress.config.ts", "cypress.config.js"] },
+  { id: "tooling.cloudflare", category: "Hosting", name: "Cloudflare Workers", slug: "cloudflare", color: "F38020", requires: ["wrangler.toml", "wrangler.jsonc"] },
+  { id: "tooling.vercel", category: "Hosting", name: "Vercel", slug: "vercel", color: "000000", requires: ["vercel.json"] },
+  { id: "tooling.netlify", category: "Hosting", name: "Netlify", slug: "netlify", color: "00AD9F", requires: ["netlify.toml"] },
+  { id: "tooling.fly", category: "Hosting", name: "Fly.io", slug: "flydotio", color: "24175B", requires: ["fly.toml"] },
+]
+
+function toolingBadges(probes: ProbeResult): Badge[] {
+  const found: Badge[] = []
+  const seenSlugs = new Set<string>()
+  for (const rule of TOOLING_RULES) {
+    if (!rule.requires.some((f) => probes[f])) continue
+    if (seenSlugs.has(rule.slug)) continue
+    seenSlugs.add(rule.slug)
+    found.push({
+      id: rule.id,
+      group: "tooling",
+      label: `${rule.category} · ${rule.name}`,
+      path: staticBadgePath(rule.category, rule.name, rule.color),
+      query: { logo: rule.slug, variant: "branded" },
+      enabled: true,
+    })
+  }
+  return found
+}
+
+function stackBadges(pkg: PackageJson, toolingSlugs: Set<string>): Badge[] {
+  const deps = {
+    ...pkg.dependencies,
+    ...pkg.devDependencies,
+    ...pkg.peerDependencies,
+  }
+  const out: Badge[] = []
+  const seen = new Set<string>()
+  for (const name of Object.keys(deps)) {
+    const brand = matchBrand(name)
+    if (!brand) continue
+    if (toolingSlugs.has(brand.slug)) continue
+    if (seen.has(brand.slug)) continue
+    seen.add(brand.slug)
+    out.push({
+      id: `stack.${brand.slug}`,
+      group: "stack",
+      label: brand.label,
+      path: staticBadgePath("Stack", brand.label, brand.color),
+      query: { logo: brand.slug, variant: "branded" },
+      enabled: true,
+    })
+    if (out.length >= BRAND_CAP) break
+  }
+  return out
+}
+
+function modernBadges(pkg: PackageJson, probes: ProbeResult): Badge[] {
+  const out: Badge[] = []
+
+  const add = (id: string, label: string, message: string, color: string, variant = "secondary") =>
+    out.push({
+      id,
+      group: "modern",
+      label: `${label} ${message}`.trim(),
+      path: staticBadgePath(label, message, color),
+      query: { variant },
+      enabled: true,
+    })
+
+  if (pkg.type === "module") add("modern.esm", "ESM", "only", "16a34a")
+  if (pkg.sideEffects === false) add("modern.tree-shakeable", "Tree-shakeable", "yes", "16a34a")
+  if (pkg.bin) add("modern.cli", "CLI", "tool", "7c3aed")
+  if (pkg.workspaces) add("modern.monorepo", "Monorepo", "yes", "2563eb")
+
+  if (pkg.exports && typeof pkg.exports === "object") {
+    const serialized = JSON.stringify(pkg.exports)
+    if (serialized.includes("import") && serialized.includes("require")) {
+      add("modern.dual-package", "Dual package", "ESM+CJS", "2563eb")
+    }
+  }
+
+  if (probes["AGENTS.md"]) add("modern.agents-md", "Agent-friendly", "AGENTS.md", "D97757")
+  if (probes["llms.txt"]) add("modern.llms-txt", "LLM-indexed", "llms.txt", "7C3AED")
+  if (probes[".claude/CLAUDE.md"]) add("modern.claude", "Claude Code", "ready", "D97757")
+  if (probes[".cursor/rules"]) add("modern.cursor", "Cursor", "ready", "000000")
+  if (probes["mcp.json"]) add("modern.mcp", "MCP", "server", "111827")
+
+  return out
+}
+
+function extractDiscordInvite(readme: string): string | null {
+  const re = /discord\.(?:gg|com\/invite)\/([a-zA-Z0-9-]+)/i
+  const m = readme.match(re)
+  return m ? m[1]! : null
+}
+
+function extractShieldsIoUrls(readme: string): string[] {
+  const re = /https?:\/\/img\.shields\.io\/[^\s)"'>]+/g
+  return Array.from(new Set(readme.match(re) ?? []))
+}
+
+async function communityBadges(
+  owner: string,
+  repo: string,
+  pkg: PackageJson | null,
+  readme: string | null,
+  signal?: AbortSignal,
+): Promise<Badge[]> {
+  const out: Badge[] = []
+  if (readme) {
+    const code = extractDiscordInvite(readme)
+    if (code) {
+      out.push({
+        id: "community.discord-members",
+        group: "community",
+        label: "Discord Members",
+        path: `/discord/members/${code}.svg`,
+        query: { variant: "secondary" },
+        enabled: true,
+      })
+      out.push({
+        id: "community.discord-online",
+        group: "community",
+        label: "Discord Online",
+        path: `/discord/online-members/${code}.svg`,
+        query: { variant: "branded" },
+        enabled: true,
+      })
+    }
+  }
+
+  const fundingText = await fetchText(rawUrl(owner, repo, ".github/FUNDING.yml"), signal)
+  if (fundingText) {
+    let data: Record<string, unknown> | null = null
+    try {
+      const { parse: parseYaml } = await import("yaml")
+      data = parseYaml(fundingText) as Record<string, unknown>
+    } catch {
+      data = null
+    }
+    if (data) {
+      if (data.github) {
+        out.push({
+          id: "community.sponsor-github",
+          group: "community",
+          label: "GitHub Sponsors",
+          path: staticBadgePath("Sponsor", "GitHub", "ea4aaa"),
+          query: { logo: "githubsponsors", variant: "secondary" },
+          enabled: true,
+        })
+      }
+      if (data.open_collective) {
+        out.push({
+          id: "community.sponsor-opencollective",
+          group: "community",
+          label: "Open Collective",
+          path: staticBadgePath("Open Collective", "sponsor", "7FADF2"),
+          query: { logo: "opencollective", variant: "secondary" },
+          enabled: true,
+        })
+      }
+    }
+  }
+
+  if (pkg?.homepage && /^https?:\/\//.test(pkg.homepage)) {
+    out.push({
+      id: "community.homepage",
+      group: "community",
+      label: "Homepage",
+      path: staticBadgePath("Homepage", "link", "2563eb"),
+      query: { variant: "ghost" },
+      enabled: true,
+      linkUrl: pkg.homepage,
+    })
+  }
+
+  return out
+}
+
+// ── Main inspect functions ────────────────────────────────────────────
+
+/**
+ * Inspect a local directory for badges.
+ * Reads package.json, config files, and README from disk.
+ * Uses git remote to determine the GitHub owner/repo.
+ */
+export async function inspectLocal(dir: string): Promise<InspectResult | { error: string }> {
+  const resolvedDir = resolve(dir)
+  const remote = getGitRemote(resolvedDir)
+  if (!remote) {
+    return { error: "No GitHub remote found in .git/config. Use a GitHub URL instead, or run from inside a git repo." }
+  }
+
+  const { owner, repo } = remote
+  const pkg = localPackageJson(resolvedDir)
+  const readme = localReadme(resolvedDir)
+  const probes = localProbe(resolvedDir)
+
+  const notes: string[] = []
+  const badges: Badge[] = []
+
+  badges.push(...githubMetricBadges(owner, repo))
+
+  if (pkg) {
+    if (pkg.private === true) {
+      badges.push(privatePackageBadge())
+      notes.push("package.json is private — npm badges suppressed.")
+    } else if (pkg.name) {
+      const npmInfo = await fetchJson<{ name?: string }>(`${NPM_REGISTRY}/${pkg.name}`)
+      if (npmInfo && npmInfo.name) {
+        badges.push(...npmBadges(pkg.name))
+      } else {
+        notes.push(`Package "${pkg.name}" not found on npm — npm badges skipped.`)
+      }
+    }
+  } else {
+    notes.push("No package.json detected — npm badges skipped.")
+  }
+
+  const toolBadges = toolingBadges(probes)
+  const toolingSlugs = new Set(toolBadges.map((b) => b.query.logo).filter((v): v is string => !!v))
+  badges.push(...toolBadges)
+
+  if (pkg) {
+    badges.push(...stackBadges(pkg, toolingSlugs))
+    badges.push(...modernBadges(pkg, probes))
+  } else {
+    badges.push(...modernBadges({} as PackageJson, probes))
+  }
+
+  badges.push(...(await communityBadges(owner, repo, pkg, readme)))
+
+  const existingShieldsIoUrls = readme ? extractShieldsIoUrls(readme) : []
+
+  return {
+    source: { owner, repo, url: `https://github.com/${owner}/${repo}` },
+    badges,
+    notes,
+    existingShieldsIoUrls,
+  }
+}
+
+/**
+ * Inspect a remote GitHub repo for badges.
+ * Fetches package.json, config files, and README via raw.githubusercontent.com.
+ */
+export async function inspectRemote(
+  urlOrSlug: string,
+): Promise<InspectResult | { error: string }> {
+  const parsed = parseGithubUrl(urlOrSlug)
+  if ("error" in parsed) return { error: parsed.error }
+  const { owner, repo, url } = parsed
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), 15_000)
+  const signal = controller.signal
+
+  try {
+    // Fetch package.json and README in parallel
+    const [pkgText, readme] = await Promise.all([
+      fetchText(rawUrl(owner, repo, "package.json"), signal),
+      (async () => {
+        const candidates = ["README.md", "readme.md", "Readme.md"]
+        for (const path of candidates) {
+          const text = await fetchText(rawUrl(owner, repo, path), signal)
+          if (text) return text
+        }
+        return null
+      })(),
+    ])
+
+    const pkg: PackageJson | null = pkgText ? (() => { try { return JSON.parse(pkgText) } catch { return null } })() : null
+
+    // Probe config files in parallel
+    const probeEntries = await Promise.all(
+      PROBE_FILES.map(async (path) => {
+        const exists = await headExists(rawUrl(owner, repo, path), signal)
+        return [path, exists] as const
+      }),
+    )
+    const probes = Object.fromEntries(probeEntries) as ProbeResult
+
+    const notes: string[] = []
+    const badges: Badge[] = []
+
+    badges.push(...githubMetricBadges(owner, repo))
+
+    if (pkg) {
+      if (pkg.private === true) {
+        badges.push(privatePackageBadge())
+        notes.push("package.json is private — npm badges suppressed.")
+      } else if (pkg.name) {
+        const npmInfo = await fetchJson<{ name?: string }>(`${NPM_REGISTRY}/${pkg.name}`, signal)
+        if (npmInfo && npmInfo.name) {
+          badges.push(...npmBadges(pkg.name))
+        } else {
+          notes.push(`Package "${pkg.name}" not found on npm — npm badges skipped.`)
+        }
+      }
+    } else {
+      notes.push("No package.json detected — npm badges skipped.")
+    }
+
+    const toolBadges = toolingBadges(probes)
+    const toolingSlugs = new Set(toolBadges.map((b) => b.query.logo).filter((v): v is string => !!v))
+    badges.push(...toolBadges)
+
+    if (pkg) {
+      badges.push(...stackBadges(pkg, toolingSlugs))
+      badges.push(...modernBadges(pkg, probes))
+    } else {
+      badges.push(...modernBadges({} as PackageJson, probes))
+    }
+
+    badges.push(...(await communityBadges(owner, repo, pkg, readme, signal)))
+
+    const existingShieldsIoUrls = readme ? extractShieldsIoUrls(readme) : []
+
+    return { source: { owner, repo, url }, badges, notes, existingShieldsIoUrls }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export { extractShieldsIoUrls }

--- a/packages/cli/src/inject.ts
+++ b/packages/cli/src/inject.ts
@@ -1,0 +1,71 @@
+/**
+ * shieldcn CLI
+ * src/inject.ts
+ *
+ * Inject/replace badges between <!-- shieldcn-start --> markers in README.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs"
+import { join } from "node:path"
+import { INJECT_START, INJECT_END } from "./constants.js"
+
+const README_NAMES = ["README.md", "readme.md", "Readme.md", "README.MD"]
+
+/**
+ * Find the README file in a directory.
+ */
+export function findReadme(dir: string): string | null {
+  for (const name of README_NAMES) {
+    const path = join(dir, name)
+    if (existsSync(path)) return path
+  }
+  return null
+}
+
+/**
+ * Check if a README already has shieldcn markers.
+ */
+export function hasMarkers(content: string): boolean {
+  return content.includes(INJECT_START) && content.includes(INJECT_END)
+}
+
+/**
+ * Inject badge markdown between markers.
+ * If markers exist, replaces content between them.
+ * If not, inserts markers + badges after the first heading.
+ */
+export function injectBadges(content: string, badgeMarkdown: string): string {
+  const block = `${INJECT_START}\n${badgeMarkdown}\n${INJECT_END}`
+
+  if (hasMarkers(content)) {
+    // Replace existing markers
+    const startIdx = content.indexOf(INJECT_START)
+    const endIdx = content.indexOf(INJECT_END) + INJECT_END.length
+    return content.slice(0, startIdx) + block + content.slice(endIdx)
+  }
+
+  // Insert after first heading
+  const headingMatch = content.match(/^#\s+.+$/m)
+  if (headingMatch && headingMatch.index !== undefined) {
+    const insertAt = headingMatch.index + headingMatch[0].length
+    return (
+      content.slice(0, insertAt) +
+      "\n\n" +
+      block +
+      "\n" +
+      content.slice(insertAt)
+    )
+  }
+
+  // No heading found — prepend
+  return block + "\n\n" + content
+}
+
+/**
+ * Read, inject, and write back to README.
+ */
+export function injectIntoFile(readmePath: string, badgeMarkdown: string): void {
+  const content = readFileSync(readmePath, "utf-8")
+  const updated = injectBadges(content, badgeMarkdown)
+  writeFileSync(readmePath, updated, "utf-8")
+}

--- a/packages/cli/src/migrate.ts
+++ b/packages/cli/src/migrate.ts
@@ -1,0 +1,142 @@
+/**
+ * shieldcn CLI
+ * src/migrate.ts
+ *
+ * Parse shields.io URLs and convert them to shieldcn equivalents.
+ */
+
+import { SHIELDCN_BASE } from "./constants.js"
+
+export type Migration = {
+  original: string
+  converted: string
+  provider: string
+}
+
+/**
+ * Convert a shields.io URL to a shieldcn URL.
+ * Handles common patterns:
+ *   - /badge/{label}-{message}-{color}
+ *   - /npm/v/{package}
+ *   - /github/stars/{owner}/{repo}
+ *   - /discord/{serverId}
+ *   etc.
+ */
+export function convertShieldsUrl(url: string): Migration | null {
+  try {
+    const parsed = new URL(url)
+    if (parsed.hostname !== "img.shields.io") return null
+
+    const path = parsed.pathname.replace(/^\/+/, "")
+    const params = parsed.searchParams
+
+    // Map shields.io query params to shieldcn equivalents
+    const query = new URLSearchParams()
+
+    // style → variant mapping
+    const style = params.get("style")
+    if (style === "flat-square" || style === "flat") query.set("variant", "secondary")
+    else if (style === "for-the-badge") query.set("variant", "default")
+    else if (style === "social") query.set("variant", "ghost")
+    else if (style === "plastic") query.set("variant", "outline")
+
+    // logo
+    const logo = params.get("logo")
+    if (logo) query.set("logo", logo)
+
+    // logoColor
+    const logoColor = params.get("logoColor")
+    if (logoColor) query.set("logoColor", logoColor.replace(/^#/, ""))
+
+    // color / labelColor
+    const color = params.get("color")
+    if (color) query.set("color", color.replace(/^#/, ""))
+
+    const labelColor = params.get("labelColor")
+    if (labelColor) query.set("labelColor", labelColor.replace(/^#/, ""))
+
+    // label override
+    const label = params.get("label")
+    if (label) query.set("label", label)
+
+    // Determine the shieldcn path
+    let shieldcnPath: string
+    let provider: string
+
+    if (path.startsWith("badge/")) {
+      // Static badge: /badge/{text}
+      shieldcnPath = path
+      provider = "badge"
+      // shields.io uses {label}-{message}-{color} with URL encoding
+      // shieldcn uses the same format, just pass through
+      if (!shieldcnPath.endsWith(".svg") && !shieldcnPath.endsWith(".png")) {
+        shieldcnPath += ".svg"
+      }
+    } else if (path.startsWith("npm/")) {
+      // /npm/v/{pkg} → /npm/{pkg}.svg
+      // /npm/dw/{pkg} → /npm/dw/{pkg}.svg
+      // /npm/dm/{pkg} → /npm/dm/{pkg}.svg
+      // /npm/dt/{pkg} → /npm/dt/{pkg}.svg
+      // /npm/l/{pkg} → /npm/license/{pkg}.svg
+      shieldcnPath = path
+        .replace(/^npm\/l\//, "npm/license/")
+        .replace(/^npm\/v\//, "npm/")
+      if (!shieldcnPath.endsWith(".svg")) shieldcnPath += ".svg"
+      provider = "npm"
+    } else if (path.startsWith("github/")) {
+      shieldcnPath = path
+      if (!shieldcnPath.endsWith(".svg")) shieldcnPath += ".svg"
+      provider = "github"
+    } else if (path.startsWith("discord/")) {
+      shieldcnPath = path
+      if (!shieldcnPath.endsWith(".svg")) shieldcnPath += ".svg"
+      provider = "discord"
+    } else if (path.startsWith("pypi/")) {
+      shieldcnPath = path.replace(/^pypi\/v\//, "pypi/")
+      if (!shieldcnPath.endsWith(".svg")) shieldcnPath += ".svg"
+      provider = "pypi"
+    } else if (path.startsWith("crates/")) {
+      shieldcnPath = path.replace(/^crates\/v\//, "crates/")
+      if (!shieldcnPath.endsWith(".svg")) shieldcnPath += ".svg"
+      provider = "crates"
+    } else if (path.startsWith("docker/")) {
+      shieldcnPath = path
+      if (!shieldcnPath.endsWith(".svg")) shieldcnPath += ".svg"
+      provider = "docker"
+    } else {
+      // Unknown provider — do a best-effort pass-through
+      shieldcnPath = path
+      if (!shieldcnPath.endsWith(".svg")) shieldcnPath += ".svg"
+      provider = path.split("/")[0] || "unknown"
+    }
+
+    const qs = query.toString()
+    const converted = `${SHIELDCN_BASE}/${shieldcnPath}${qs ? `?${qs}` : ""}`
+
+    return { original: url, converted, provider }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Find all shields.io URLs in a string and convert them.
+ */
+export function migrateAll(content: string): Migration[] {
+  const re = /https?:\/\/img\.shields\.io\/[^\s)"'>]+/g
+  const urls = Array.from(new Set(content.match(re) ?? []))
+  return urls
+    .map(convertShieldsUrl)
+    .filter((m): m is Migration => m !== null)
+}
+
+/**
+ * Replace all shields.io URLs in content with shieldcn URLs.
+ */
+export function replaceShieldsUrls(content: string, migrations: Migration[]): string {
+  let result = content
+  for (const m of migrations) {
+    result = result.replaceAll(m.original, m.converted)
+  }
+  return result
+}

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -1,0 +1,130 @@
+/**
+ * shieldcn CLI
+ * src/output.ts
+ *
+ * Format badges as markdown, HTML, or JSON output.
+ */
+
+import type { Badge, GlobalSettings, InspectResult } from "./types.js"
+import { badgeMarkdown, badgeHtml, badgeUrl } from "./url.js"
+
+type BadgeGroup = Badge["group"]
+
+const GROUP_TITLES: Record<BadgeGroup, string> = {
+  github: "GitHub",
+  package: "Package",
+  tooling: "Tooling",
+  stack: "Stack",
+  modern: "Modern",
+  community: "Community",
+}
+
+const GROUP_ORDER: BadgeGroup[] = [
+  "github",
+  "package",
+  "tooling",
+  "stack",
+  "modern",
+  "community",
+]
+
+function groupBadges(badges: Badge[]): Map<BadgeGroup, Badge[]> {
+  const groups = new Map<BadgeGroup, Badge[]>()
+  for (const badge of badges) {
+    if (!badge.enabled) continue
+    const list = groups.get(badge.group) ?? []
+    list.push(badge)
+    groups.set(badge.group, list)
+  }
+  return groups
+}
+
+/**
+ * Format badges as grouped markdown.
+ */
+export function formatMarkdown(
+  result: InspectResult,
+  global: GlobalSettings,
+  options: { grouped?: boolean; compact?: boolean } = {},
+): string {
+  const { grouped = true, compact = false } = options
+  const enabled = result.badges.filter((b) => b.enabled)
+
+  if (!grouped || compact) {
+    return enabled.map((b) => badgeMarkdown(b, global)).join("\n")
+  }
+
+  const groups = groupBadges(enabled)
+  const sections: string[] = []
+
+  for (const group of GROUP_ORDER) {
+    const badges = groups.get(group)
+    if (!badges || badges.length === 0) continue
+    const title = GROUP_TITLES[group]
+    const lines = badges.map((b) => badgeMarkdown(b, global))
+    sections.push(`### ${title}\n\n${lines.join("\n")}`)
+  }
+
+  return sections.join("\n\n")
+}
+
+/**
+ * Format badges as flat markdown (all in one line, no groups).
+ */
+export function formatFlatMarkdown(
+  result: InspectResult,
+  global: GlobalSettings,
+): string {
+  return result.badges
+    .filter((b) => b.enabled)
+    .map((b) => badgeMarkdown(b, global))
+    .join(" ")
+}
+
+/**
+ * Format badges as HTML.
+ */
+export function formatHtml(
+  result: InspectResult,
+  global: GlobalSettings,
+): string {
+  const enabled = result.badges.filter((b) => b.enabled)
+  const groups = groupBadges(enabled)
+  const sections: string[] = []
+
+  sections.push('<p align="center">')
+
+  for (const group of GROUP_ORDER) {
+    const badges = groups.get(group)
+    if (!badges || badges.length === 0) continue
+    for (const b of badges) {
+      sections.push(`  ${badgeHtml(b, global)}`)
+    }
+  }
+
+  sections.push("</p>")
+  return sections.join("\n")
+}
+
+/**
+ * Format badges as JSON config.
+ */
+export function formatJson(
+  result: InspectResult,
+  global: GlobalSettings,
+): string {
+  return JSON.stringify(
+    {
+      version: 1,
+      source: result.source,
+      global,
+      badges: result.badges.map((b) => ({
+        ...b,
+        url: badgeUrl(b, global),
+      })),
+      notes: result.notes,
+    },
+    null,
+    2,
+  )
+}

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,0 +1,56 @@
+/**
+ * shieldcn CLI
+ * src/types.ts
+ */
+
+export type BadgeGroup =
+  | "github"
+  | "package"
+  | "stack"
+  | "tooling"
+  | "modern"
+  | "community"
+
+export type Badge = {
+  id: string
+  group: BadgeGroup
+  label: string
+  path: string
+  query: Record<string, string>
+  enabled: boolean
+  linkUrl?: string
+}
+
+export type InspectResult = {
+  source: { owner: string; repo: string; url: string }
+  badges: Badge[]
+  notes: string[]
+  existingShieldsIoUrls: string[]
+}
+
+export type PackageJson = {
+  name?: string
+  version?: string
+  private?: boolean
+  license?: string
+  type?: string
+  types?: string
+  typings?: string
+  bin?: unknown
+  sideEffects?: unknown
+  workspaces?: unknown
+  exports?: unknown
+  engines?: Record<string, string>
+  packageManager?: string
+  homepage?: string
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+}
+
+export type GlobalSettings = {
+  variant: string
+  size: string
+  mode: string
+  theme: string
+}

--- a/packages/cli/src/url.ts
+++ b/packages/cli/src/url.ts
@@ -1,0 +1,63 @@
+/**
+ * shieldcn CLI
+ * src/url.ts
+ *
+ * Badge URL construction and formatting.
+ */
+
+import { SHIELDCN_BASE } from "./constants.js"
+import type { Badge, GlobalSettings } from "./types.js"
+
+const ENCODE_MAP: Array<[RegExp, string]> = [
+  [/_/g, "__"],
+  [/-/g, "--"],
+]
+
+export function encodeStaticSegment(raw: string): string {
+  let s = raw
+  for (const [re, rep] of ENCODE_MAP) s = s.replace(re, rep)
+  return s.replace(/ /g, "_")
+}
+
+export function staticBadgePath(
+  label: string,
+  message: string,
+  color: string,
+): string {
+  const enc = (s: string) => encodeURIComponent(encodeStaticSegment(s))
+  return `/badge/${enc(label)}-${enc(message)}-${color.replace(/^#/, "")}.svg`
+}
+
+function mergeQuery(
+  badge: Badge,
+  global: GlobalSettings,
+): Record<string, string> {
+  const merged: Record<string, string> = { ...badge.query }
+
+  // Only add global overrides when they differ from server defaults
+  if (global.variant && global.variant !== "default" && !merged.variant) merged.variant = global.variant
+  if (global.size && global.size !== "sm" && global.size !== "default" && !merged.size) merged.size = global.size
+  if (global.mode && global.mode !== "dark" && !merged.mode) merged.mode = global.mode
+  if (global.theme && !merged.theme) merged.theme = global.theme
+
+  return merged
+}
+
+export function badgeUrl(badge: Badge, global: GlobalSettings): string {
+  const qs = new URLSearchParams(mergeQuery(badge, global)).toString()
+  return `${SHIELDCN_BASE}${badge.path}${qs ? `?${qs}` : ""}`
+}
+
+export function badgeMarkdown(badge: Badge, global: GlobalSettings): string {
+  const url = badgeUrl(badge, global)
+  const alt = badge.label.replace(/[\[\]]/g, "")
+  const img = `![${alt}](${url})`
+  return badge.linkUrl ? `[${img}](${badge.linkUrl})` : img
+}
+
+export function badgeHtml(badge: Badge, global: GlobalSettings): string {
+  const url = badgeUrl(badge, global)
+  const alt = badge.label.replace(/"/g, "&quot;")
+  const img = `<img src="${url}" alt="${alt}" />`
+  return badge.linkUrl ? `<a href="${badge.linkUrl}">${img}</a>` : img
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "tsup"
+
+export default defineConfig({
+  entry: ["src/bin.ts"],
+  format: ["esm"],
+  target: "node18",
+  clean: true,
+  minify: false,
+  splitting: false,
+  banner: {
+    js: "#!/usr/bin/env node",
+  },
+})

--- a/packages/web/components/sidebar.tsx
+++ b/packages/web/components/sidebar.tsx
@@ -44,6 +44,7 @@ const docsNav: NavGroup[] = [
     alwaysOpen: true,
     items: [
       { title: "Introduction", href: "/docs" },
+      { title: "CLI", href: "/docs/cli" },
       { title: "Agent Skill", href: "/docs/skill" },
       { title: "Self-Hosting", href: "/docs/self-hosting" },
       { title: "API Reference", href: "/docs/api-reference" },

--- a/packages/web/content/docs/cli.mdx
+++ b/packages/web/content/docs/cli.mdx
@@ -1,0 +1,313 @@
+---
+title: CLI
+description: Generate badges from your terminal. Scans your repo, detects your stack, and outputs copy-paste markdown.
+badge: "/badge/CLI-npx%20shieldcn--cli-18181b.svg?variant=branded&logo=npm"
+---
+
+The shieldcn CLI scans a GitHub repo — local or remote — detects your stack, and generates categorized badge markdown you can paste straight into your README.
+
+```bash
+npx shieldcn-cli
+```
+
+No install required. Works with any GitHub repository.
+
+## Install
+
+```bash
+# Run without installing (recommended)
+npx shieldcn-cli
+
+# Or install globally
+npm install -g shieldcn-cli
+
+# Or with your preferred package manager
+pnpm add -g shieldcn-cli
+yarn global add shieldcn-cli
+bun add -g shieldcn-cli
+```
+
+## Generate badges
+
+### Scan current repo
+
+Run from inside any git repo to auto-detect the GitHub remote:
+
+```bash
+npx shieldcn-cli
+```
+
+The CLI reads `.git/config` to find your `owner/repo`, then scans `package.json`, config files, lockfiles, README, and `FUNDING.yml` to detect your full stack.
+
+### Scan a remote repo
+
+Pass a GitHub URL or `owner/repo` slug:
+
+```bash
+npx shieldcn-cli vercel/next.js
+npx shieldcn-cli https://github.com/shadcn-ui/ui
+```
+
+Remote scanning uses `raw.githubusercontent.com` HEAD requests to detect config files — no GitHub token required.
+
+### Customize style
+
+Override the default variant, size, theme, or mode:
+
+```bash
+# Branded badges with blue theme
+npx shieldcn-cli --variant branded --theme blue
+
+# Large outline badges in light mode
+npx shieldcn-cli --variant outline --size lg --mode light
+
+# Ghost badges with compact output
+npx shieldcn-cli --variant ghost --compact
+```
+
+## Output formats
+
+### Markdown (default)
+
+Grouped by category with headers:
+
+```bash
+npx shieldcn-cli
+```
+
+```markdown
+### GitHub
+
+![GitHub Stars](https://shieldcn.dev/github/stars/owner/repo.svg?variant=secondary)
+![License](https://shieldcn.dev/github/license/owner/repo.svg?variant=ghost)
+
+### Tooling
+
+![TypeScript](https://shieldcn.dev/badge/Language-TypeScript-3178C6.svg?logo=typescript&variant=branded)
+```
+
+### Flat
+
+All badges on one line, no headers — ready to paste into a `<p align="center">` block:
+
+```bash
+npx shieldcn-cli --format flat
+```
+
+### HTML
+
+Wrapped in `<p align="center">` with `<img>` tags:
+
+```bash
+npx shieldcn-cli --format html
+```
+
+### JSON
+
+Full config object for programmatic use or CI pipelines:
+
+```bash
+npx shieldcn-cli --json
+```
+
+### Copy to clipboard
+
+Add `--copy` to any command:
+
+```bash
+npx shieldcn-cli --variant branded --copy
+```
+
+## Inject into README
+
+Automatically insert or update badges in your README between marker comments.
+
+### Step 1: Add markers
+
+```bash
+npx shieldcn-cli init
+```
+
+This adds `<!-- shieldcn-start -->` and `<!-- shieldcn-end -->` markers to your README after the first heading. You can also add them manually:
+
+```markdown
+# My Project
+
+<!-- shieldcn-start -->
+<!-- shieldcn-end -->
+
+Description goes here...
+```
+
+### Step 2: Inject badges
+
+```bash
+npx shieldcn-cli --inject
+```
+
+Badges are inserted between the markers as flat inline markdown. Running `--inject` again replaces the content between markers — your README stays clean.
+
+### Use in CI
+
+Auto-update badges on every push to `main`:
+
+```yaml
+# .github/workflows/badges.yml
+name: Update badges
+on:
+  push:
+    branches: [main]
+
+jobs:
+  badges:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npx shieldcn-cli --inject --variant branded
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: update badges"
+```
+
+## Migrate from shields.io
+
+Convert existing `img.shields.io` URLs in your README to shieldcn equivalents.
+
+### Preview changes
+
+```bash
+npx shieldcn-cli migrate --dry
+```
+
+```
+  Found 4 shields.io badge(s):
+
+  1. https://img.shields.io/npm/v/next.svg
+     → https://shieldcn.dev/npm/next.svg
+
+  2. https://img.shields.io/github/stars/vercel/next.js
+     → https://shieldcn.dev/github/stars/vercel/next.js.svg?variant=branded
+
+  3. https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=fff
+     → https://shieldcn.dev/badge/TypeScript-3178C6.svg?variant=branded&logo=typescript
+```
+
+### Apply changes
+
+```bash
+# Interactive (asks for confirmation)
+npx shieldcn-cli migrate
+
+# Skip confirmation
+npx shieldcn-cli migrate --write
+
+# Migrate a specific file
+npx shieldcn-cli migrate docs/README.md --write
+```
+
+The migrator maps shields.io query params to shieldcn equivalents:
+
+| shields.io | shieldcn |
+|------------|----------|
+| `?style=flat-square` | `?variant=secondary` |
+| `?style=for-the-badge` | `?variant=default` |
+| `?style=social` | `?variant=ghost` |
+| `?style=plastic` | `?variant=outline` |
+| `?logo=react` | `?logo=react` |
+| `?logoColor=fff` | `?logoColor=fff` |
+| `?color=blue` | `?color=blue` |
+| `?labelColor=555` | `?labelColor=555` |
+
+## What gets detected
+
+The CLI inspects your repository and generates badges across six categories:
+
+### GitHub
+
+Stars, forks, watchers, contributors, last commit, open issues, open PRs, release, CI status, and license. Always generated when a GitHub remote is found.
+
+### Package
+
+npm version, weekly/monthly/total downloads, types, and license. Only generated when `package.json` exists and the package is published to npm. Private packages get a "Private package" badge instead.
+
+### Tooling
+
+Detected from config files and lockfiles in the repo root:
+
+| Tool | Detected by |
+|------|-------------|
+| pnpm | `pnpm-lock.yaml` |
+| Yarn | `yarn.lock` |
+| Bun | `bun.lock` / `bun.lockb` |
+| npm | `package-lock.json` |
+| TypeScript | `tsconfig.json` |
+| ESLint | `.eslintrc.*` / `eslint.config.*` |
+| Prettier | `.prettierrc*` / `prettier.config.js` |
+| Biome | `biome.json` |
+| Vite | `vite.config.*` |
+| Next.js | `next.config.*` |
+| Nuxt | `nuxt.config.*` |
+| Astro | `astro.config.*` |
+| Svelte | `svelte.config.*` |
+| Tailwind CSS | `tailwind.config.*` |
+| Turborepo | `turbo.json` |
+| Nx | `nx.json` |
+| Docker | `Dockerfile` / `docker-compose.*` |
+| Vitest | `vitest.config.*` |
+| Playwright | `playwright.config.*` |
+| Jest | `jest.config.*` |
+| Cypress | `cypress.config.*` |
+| Storybook | `.storybook/main.*` |
+| Vercel | `vercel.json` |
+| Netlify | `netlify.toml` |
+| Cloudflare | `wrangler.toml` / `wrangler.jsonc` |
+| Fly.io | `fly.toml` |
+
+### Stack
+
+Matched from `dependencies`, `devDependencies`, and `peerDependencies` in `package.json`. Over 100 packages are mapped to branded badges including React, Vue, Svelte, Prisma, Drizzle, tRPC, Supabase, Stripe, OpenAI, Anthropic, and more.
+
+### Modern
+
+Detects modern project signals:
+
+| Signal | Detected by |
+|--------|-------------|
+| ESM-only | `"type": "module"` in package.json |
+| Tree-shakeable | `"sideEffects": false` |
+| Dual package | `"exports"` with both `import` and `require` |
+| Monorepo | `"workspaces"` field |
+| CLI tool | `"bin"` field |
+| Agent-friendly | `AGENTS.md` file |
+| LLM-indexed | `llms.txt` file |
+| Claude Code ready | `.claude/CLAUDE.md` file |
+| Cursor ready | `.cursor/rules` file |
+| MCP server | `mcp.json` file |
+
+### Community
+
+- **Discord** — extracted from `discord.gg` or `discord.com/invite` links in README
+- **Sponsors** — parsed from `.github/FUNDING.yml` (GitHub Sponsors, Open Collective, Patreon, Ko-fi)
+- **Homepage** — from `"homepage"` in package.json
+
+## Options reference
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--variant` | `default` · `secondary` · `outline` · `ghost` · `destructive` · `branded` | `default` |
+| `--size` | `xs` · `sm` · `default` · `lg` | `sm` |
+| `--theme` | `zinc` · `slate` · `stone` · `neutral` · `gray` · `blue` · `green` · `rose` · `orange` · `amber` · `violet` · `purple` · `red` · `cyan` · `emerald` | — |
+| `--mode` | `dark` · `light` | `dark` |
+| `--format` | `markdown` · `flat` · `html` · `json` | `markdown` |
+| `--inject` | Insert/update badges between README markers | `false` |
+| `--copy` | Copy output to clipboard | `false` |
+| `--json` | Shortcut for `--format json` | `false` |
+| `--compact` | Omit group headers from output | `false` |
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `shieldcn [target]` | Generate badges (default command) |
+| `shieldcn migrate [file]` | Convert shields.io URLs to shieldcn |
+| `shieldcn init [file]` | Add marker comments to README |

--- a/packages/web/content/docs/meta.json
+++ b/packages/web/content/docs/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "---Getting Started---",
     "index",
+    "cli",
     "skill",
     "self-hosting",
     "---Badges---",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,28 @@ importers:
         specifier: ^2
         version: 2.9.6
 
+  packages/cli:
+    dependencies:
+      citty:
+        specifier: ^0.1.6
+        version: 0.1.6
+      consola:
+        specifier: ^3.4.2
+        version: 3.4.2
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+      yaml:
+        specifier: ^2.7.1
+        version: 2.8.3
+    devDependencies:
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
   packages/core:
     dependencies:
       '@resvg/resvg-wasm':
@@ -1876,6 +1898,144 @@ packages:
     resolution: {integrity: sha512-FqALmHI8D4o6lk/LRWDnhw95z5eO+eAa6ORjVg09YRR7BkcM6oPHU9uyC0gtQG5vpFLvgpeU4+zEAz2H8APHNw==}
     engines: {node: '>= 10'}
 
+  '@rollup/rollup-android-arm-eabi@4.60.3':
+    resolution: {integrity: sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.3':
+    resolution: {integrity: sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.3':
+    resolution: {integrity: sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.3':
+    resolution: {integrity: sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.3':
+    resolution: {integrity: sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.3':
+    resolution: {integrity: sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
+    resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.3':
+    resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.3':
+    resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.3':
+    resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.3':
+    resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.3':
+    resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.3':
+    resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.3':
+    resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.3':
+    resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.3':
+    resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.3':
+    resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.3':
+    resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.3':
+    resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.3':
+    resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.3':
+    resolution: {integrity: sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.3':
+    resolution: {integrity: sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.3':
+    resolution: {integrity: sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.3':
+    resolution: {integrity: sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.3':
+    resolution: {integrity: sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==}
+    cpu: [x64]
+    os: [win32]
+
   '@rrweb/types@2.0.0-alpha.20':
     resolution: {integrity: sha512-RbnDgKxA/odwB1R4gF7eUUj+rdSrq6ROQJsnMw7MIsGzlbSYvJeZN8YY4XqU0G6sKJvXI6bSzk7w/G94jNwzhw==}
 
@@ -2368,6 +2528,9 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -2499,9 +2662,19 @@ packages:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
 
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -2559,9 +2732,16 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
+
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -2638,11 +2818,22 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
   compute-scroll-into-view@3.1.1:
     resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
@@ -3221,6 +3412,9 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
@@ -3802,6 +3996,10 @@ packages:
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3960,6 +4158,10 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
   linebreak@1.1.0:
     resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
 
@@ -3974,6 +4176,10 @@ packages:
   listr2@9.0.5:
     resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
     engines: {node: '>=20.0.0'}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -4233,6 +4439,9 @@ packages:
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
   motion-dom@12.38.0:
     resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
 
@@ -4269,6 +4478,9 @@ packages:
   mute-stream@3.0.0:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -4508,6 +4720,9 @@ packages:
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   pg-cloudflare@1.3.0:
     resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
 
@@ -4553,13 +4768,38 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
@@ -4705,6 +4945,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
@@ -4783,6 +5027,10 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -4804,6 +5052,11 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rollup@4.60.3:
+    resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
 
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
@@ -5076,6 +5329,11 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -5103,11 +5361,21 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
@@ -5136,6 +5404,10 @@ packages:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
@@ -5147,6 +5419,9 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
   ts-morph@26.0.0:
     resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
@@ -5160,6 +5435,25 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
 
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
@@ -5212,6 +5506,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -7029,6 +7326,81 @@ snapshots:
 
   '@resvg/resvg-wasm@2.6.2': {}
 
+  '@rollup/rollup-android-arm-eabi@4.60.3':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.3':
+    optional: true
+
   '@rrweb/types@2.0.0-alpha.20': {}
 
   '@rrweb/utils@2.0.0-alpha.20': {}
@@ -7470,6 +7842,8 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  any-promise@1.3.0: {}
+
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
@@ -7625,7 +7999,14 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
+  bundle-require@5.1.0(esbuild@0.27.7):
+    dependencies:
+      esbuild: 0.27.7
+      load-tsconfig: 0.2.5
+
   bytes@3.1.2: {}
+
+  cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -7702,9 +8083,17 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
+
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -7773,9 +8162,15 @@ snapshots:
 
   commander@14.0.3: {}
 
+  commander@4.1.1: {}
+
   compute-scroll-into-view@3.1.1: {}
 
   concat-map@0.0.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
 
   content-disposition@1.1.0: {}
 
@@ -8187,8 +8582,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.4
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
@@ -8210,7 +8605,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -8221,22 +8616,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -8247,7 +8642,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -8579,6 +8974,12 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      rollup: 4.60.3
 
   flat-cache@4.0.1:
     dependencies:
@@ -9165,6 +9566,8 @@ snapshots:
 
   jose@6.2.3: {}
 
+  joycon@3.1.1: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
@@ -9284,6 +9687,8 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lilconfig@3.1.3: {}
+
   linebreak@1.1.0:
     dependencies:
       base64-js: 0.0.8
@@ -9308,6 +9713,8 @@ snapshots:
       log-update: 6.1.0
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
+
+  load-tsconfig@0.2.5: {}
 
   locate-path@6.0.0:
     dependencies:
@@ -9832,6 +10239,13 @@ snapshots:
 
   mitt@3.0.1: {}
 
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
   motion-dom@12.38.0:
     dependencies:
       motion-utils: 12.36.0
@@ -9874,6 +10288,12 @@ snapshots:
       - '@types/node'
 
   mute-stream@3.0.0: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
 
@@ -10124,6 +10544,8 @@ snapshots:
 
   path-to-regexp@8.4.2: {}
 
+  pathe@2.0.3: {}
+
   pg-cloudflare@1.3.0:
     optional: true
 
@@ -10165,9 +10587,26 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pirates@4.0.7: {}
+
   pkce-challenge@5.0.1: {}
 
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
   possible-typed-array-names@1.1.0: {}
+
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.6.1
+      postcss: 8.5.10
+      tsx: 4.21.0
+      yaml: 2.8.3
 
   postcss-selector-parser@6.0.10:
     dependencies:
@@ -10353,6 +10792,8 @@ snapshots:
     dependencies:
       picomatch: 2.3.2
 
+  readdirp@4.1.2: {}
+
   readdirp@5.0.0: {}
 
   recast@0.23.11:
@@ -10494,6 +10935,8 @@ snapshots:
 
   resolve-from@4.0.0: {}
 
+  resolve-from@5.0.0: {}
+
   resolve-pkg-maps@1.0.0: {}
 
   resolve@2.0.0-next.6:
@@ -10515,6 +10958,37 @@ snapshots:
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
+
+  rollup@4.60.3:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.3
+      '@rollup/rollup-android-arm64': 4.60.3
+      '@rollup/rollup-darwin-arm64': 4.60.3
+      '@rollup/rollup-darwin-x64': 4.60.3
+      '@rollup/rollup-freebsd-arm64': 4.60.3
+      '@rollup/rollup-freebsd-x64': 4.60.3
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.3
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.3
+      '@rollup/rollup-linux-arm64-gnu': 4.60.3
+      '@rollup/rollup-linux-arm64-musl': 4.60.3
+      '@rollup/rollup-linux-loong64-gnu': 4.60.3
+      '@rollup/rollup-linux-loong64-musl': 4.60.3
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.3
+      '@rollup/rollup-linux-ppc64-musl': 4.60.3
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.3
+      '@rollup/rollup-linux-riscv64-musl': 4.60.3
+      '@rollup/rollup-linux-s390x-gnu': 4.60.3
+      '@rollup/rollup-linux-x64-gnu': 4.60.3
+      '@rollup/rollup-linux-x64-musl': 4.60.3
+      '@rollup/rollup-openbsd-x64': 4.60.3
+      '@rollup/rollup-openharmony-arm64': 4.60.3
+      '@rollup/rollup-win32-arm64-msvc': 4.60.3
+      '@rollup/rollup-win32-ia32-msvc': 4.60.3
+      '@rollup/rollup-win32-x64-gnu': 4.60.3
+      '@rollup/rollup-win32-x64-msvc': 4.60.3
+      fsevents: 2.3.3
 
   router@2.2.0:
     dependencies:
@@ -10923,6 +11397,16 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.0
 
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.16
+      ts-interface-checker: 0.1.13
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -10947,9 +11431,19 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
   tiny-inflate@1.0.3: {}
 
   tiny-invariant@1.3.3: {}
+
+  tinyexec@0.3.2: {}
 
   tinyexec@1.1.1: {}
 
@@ -10974,6 +11468,8 @@ snapshots:
     dependencies:
       tldts: 7.0.29
 
+  tree-kill@1.2.2: {}
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
@@ -10981,6 +11477,8 @@ snapshots:
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  ts-interface-checker@0.1.13: {}
 
   ts-morph@26.0.0:
     dependencies:
@@ -11001,6 +11499,34 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3)
+      resolve-from: 5.0.0
+      rollup: 4.60.3
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.10
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   tsx@4.21.0:
     dependencies:
@@ -11079,6 +11605,8 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
+
+  ufo@1.6.4: {}
 
   unbox-primitive@1.1.0:
     dependencies:


### PR DESCRIPTION
<!--begin:badgetizr-shieldcn--> 
![Ready](https://shieldcn.dev/badge/Ready-22C55E.svg?variant=default&mode=dark&size=sm&logo=ri:RiCheckFill&color=22C55E)  [![CI 25405258133](https://shieldcn.dev/badge/Build-25405258133-7C3AED.svg?variant=default&mode=dark&size=sm&logo=github&color=7C3AED)](https://github.com/jal-co/shieldcn/actions/runs/25405258133)
<!--end:badgetizr-shieldcn-->
## Summary

Adds `shieldcn-cli` — a CLI tool that scans GitHub repos, detects your stack, and generates copy-paste badge markdown.

**Published:** [`shieldcn-cli@1.0.0` on npm](https://www.npmjs.com/package/shieldcn-cli)

```bash
npx shieldcn-cli
npx shieldcn-cli vercel/next.js --variant branded
npx shieldcn-cli --inject
npx shieldcn-cli migrate
```

## What's included

### CLI package (`packages/cli/`)
- **Generate** — scan local (`.git/config`) or remote repos, output grouped badge markdown
- **Migrate** — find shields.io URLs in README and convert to shieldcn equivalents
- **Init** — add `<!-- shieldcn-start/end -->` markers to README
- **Inject** — insert/update badges between markers (great for CI)
- Outputs: markdown (grouped/flat), HTML, JSON
- Options: `--variant`, `--size`, `--theme`, `--mode`, `--inject`, `--copy`, `--compact`
- 43KB single-file bundle via tsup, zero post-install scripts

### Detection
- **GitHub**: stars, forks, watchers, contributors, last commit, issues, PRs, release, CI, license
- **Package**: npm version, downloads, types, license (skipped for private packages)
- **Tooling**: 28 config file probes (pnpm, TypeScript, ESLint, Vite, Next.js, Docker, Vitest, Playwright, Vercel, etc.)
- **Stack**: 100+ npm packages mapped to branded badges (React, Prisma, Drizzle, tRPC, Supabase, Stripe, OpenAI, etc.)
- **Modern**: ESM-only, tree-shakeable, monorepo, AGENTS.md, llms.txt, Claude/Cursor ready, MCP
- **Community**: Discord (from README), sponsors (from FUNDING.yml), homepage

### Docs & site updates
- New docs page at `/docs/cli` with full usage guide, detection tables, CI workflow example, and options reference
- Sidebar updated with CLI link in Getting Started
- Root README updated with CLI section

## Test it

```bash
npx shieldcn-cli@1.0.0 vercel/next.js --variant branded --compact
```