### PR TITLE
fix(web): fix sponsor page grid overflow on mobile

### DIFF
--- a/packages/web/app/sponsor/page.tsx
+++ b/packages/web/app/sponsor/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next"
 import type { ReactNode } from "react"
 import Image from "next/image"
 import { pageMetadata } from "@/lib/metadata"
-import Link from "next/link"
 import { Heart, ExternalLink, Star, Plus } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { SiteShell } from "@/components/site-shell"
@@ -263,7 +262,7 @@ export default async function SponsorPage() {
                   </div>
 
                   <div
-                    className="grid gap-2"
+                    className="grid gap-2 max-sm:grid-cols-[repeat(1,1fr)]! max-lg:grid-cols-[repeat(2,1fr)]!"
                     style={{ gridTemplateColumns: `repeat(${Math.min(tier.slots, 4)}, 1fr)` }}
                   >
                     {tier.sponsors.map((sponsor) => (


### PR DESCRIPTION
## What

Fix the sponsor tier grid overflowing horizontally on mobile viewports. The grid kept its full column count (up to 4) on all screen sizes, causing cards to shrink below readable width and content to bleed outside the container.

The fix keeps the original inline `gridTemplateColumns` style intact (preserving the exact desktop layout) and layers `!important` Tailwind responsive overrides on top to collapse the grid at smaller breakpoints:

- `< sm` (mobile): 1 column
- `sm – lg` (tablet): 2 columns
- `lg+` (desktop): unchanged: 4 cols for 4-slot tiers, 3 cols for 3-slot tiers

 And removed unused `Link` import.

Changed file: `packages/web/app/sponsor/page.tsx`

## Why

The sponsor section grid was set via an inline style (`gridTemplateColumns: repeat(N, 1fr)`) with no responsive override, causing a horizontal overflow on mobile screens.

## Type

<!-- Check the one that applies -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `docs` — Documentation
- [ ] `refactor` — Code restructuring
- [ ] `perf` — Performance improvement
- [ ] `style` — Visual / CSS changes
- [ ] `chore` — Maintenance / deps
- [ ] `ci` — CI/CD changes
- [ ] `test` — Tests

## Checklist

- [x] Branch follows conventional naming (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tested locally with `pnpm dev`
- [ ] Badge renders correctly in SVG and PNG (if applicable)
- [ ] Docs updated (if adding/changing a provider or query param)

## Screenshots

**Before (mobile):** Grid overflows horizontally, cards bleed outside the viewport:
<img width="632" height="3190" alt="scn-s-b-sm" src="https://github.com/user-attachments/assets/52005a03-04b3-4850-b51c-22939e6fd2ef" />

---

**After (mobile):** Grid collapses to 1 column on mobile, 2 on tablet, full width on desktop (identical to original).

*mobile (small)*:
<img width="696" height="6092" alt="scn-s-a-sm" src="https://github.com/user-attachments/assets/ed364e32-b1c5-4dcc-ac41-ea095b383f0e" />

*tablet (medium)*:
<img width="926" height="2596" alt="scn-s-a-md" src="https://github.com/user-attachments/assets/99c6bf30-b9e3-4977-9871-709ea504d8a6" />

*desktop (large)*:
<img width="3840" height="4444" alt="scn-s-a-lg" src="https://github.com/user-attachments/assets/e2fa8d59-6cf5-4df0-b03a-375916aba6cb" />