### PR TITLE
fix(migrate): use branded variant for providers and resolve transferred repos

### DIFF
--- a/packages/cli/src/migrate.ts
+++ b/packages/cli/src/migrate.ts
@@ -7,6 +7,17 @@
 
 import { SHIELDCN_BASE } from "./constants.js"
 
+/** Providers that support the branded variant (have a known brand color). */
+const BRANDED_PROVIDERS = new Set([
+  "npm", "github", "discord", "reddit", "pypi", "crates", "docker",
+  "bluesky", "jsr", "youtube", "vscode", "opencollective", "hackernews",
+  "mastodon", "lemmy", "packagist", "rubygems", "nuget", "pub", "homebrew",
+  "maven", "cocoapods", "twitch", "codecov", "wakatime", "gitlab", "conda",
+  "chrome", "amo", "coveralls", "sonar", "jsdelivr", "chocolatey", "flathub",
+  "snapcraft", "fdroid", "discourse", "stackexchange", "modrinth", "openvsx",
+  "liberapay", "matrix", "weblate",
+])
+
 export type Migration = {
   original: string
   converted: string
@@ -108,6 +119,17 @@ export function convertShieldsUrl(url: string): Migration | null {
       shieldcnPath = path
       if (!shieldcnPath.endsWith(".svg")) shieldcnPath += ".svg"
       provider = path.split("/")[0] || "unknown"
+    }
+
+    // Use branded variant for providers that have a brand color
+    if (!query.has("variant")) {
+      if (provider !== "badge" && BRANDED_PROVIDERS.has(provider)) {
+        query.set("variant", "branded")
+        query.delete("logoColor")
+      } else if (provider === "badge" && logo && BRANDED_PROVIDERS.has(logo)) {
+        query.set("variant", "branded")
+        query.delete("logoColor")
+      }
     }
 
     const qs = query.toString()

--- a/packages/core/src/migrate/transform.ts
+++ b/packages/core/src/migrate/transform.ts
@@ -6,6 +6,8 @@
  * into equivalent shieldcn badge URLs.
  */
 
+import { providerBrandColors } from "../badges/brand-colors"
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -848,6 +850,30 @@ export function transformShieldsUrl(
       const result = transformer(match, parsed.searchParams, baseUrl)
       if (result) {
         const mappedParams = mapShieldsParams(parsed.searchParams, result.query)
+
+        // Use branded variant for providers that have a brand color,
+        // unless the user explicitly set a style that mapped to a variant.
+        // For static badges (/badge/...), use branded if the logo param
+        // matches a provider with a known brand color.
+        const provider = result.path.split("/")[1] // e.g. "/npm/v/foo" → "npm"
+        if (!mappedParams.has("variant")) {
+          let useBranded = false
+          if (provider && provider !== "badge" && providerBrandColors[provider]) {
+            useBranded = true
+          } else if (provider === "badge") {
+            const logo = mappedParams.get("logo") ?? parsed.searchParams.get("logo")
+            if (logo && providerBrandColors[logo]) {
+              useBranded = true
+            }
+          }
+          if (useBranded) {
+            mappedParams.set("variant", "branded")
+            // branded auto-calculates icon color based on contrast —
+            // drop explicit logoColor so it doesn't fight the auto value
+            mappedParams.delete("logoColor")
+          }
+        }
+
         const queryString = mappedParams.toString()
         const ext = ".svg" // always output SVG
         const shieldcnUrl =

--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -80,6 +80,22 @@ async function repoData(owner: string, repo: string) {
   return githubJson(`https://api.github.com/repos/${owner}/${repo}`)
 }
 
+/**
+ * Resolve the canonical owner/repo (follows GitHub 301 redirects for
+ * transferred or renamed repos). The Search API does NOT follow repo
+ * redirects, so any function that builds a `repo:owner/repo` search
+ * query must resolve through here first.
+ */
+async function resolveRepo(owner: string, repo: string): Promise<{ owner: string; repo: string } | null> {
+  const d = await repoData(owner, repo)
+  if (!d) return null
+  const fullName = d.full_name as string | undefined
+  if (!fullName) return null
+  const [o, r] = fullName.split("/")
+  if (!o || !r) return null
+  return { owner: o, repo: r }
+}
+
 // ---------------------------------------------------------------------------
 // Badge functions
 // ---------------------------------------------------------------------------
@@ -245,7 +261,10 @@ export async function getGitHubChecks(
 // ---------------------------------------------------------------------------
 
 async function issueCount(owner: string, repo: string, state: string, isPR: boolean): Promise<number | null> {
-  const q = `repo:${owner}/${repo} is:${isPR ? "pr" : "issue"} is:${state}`
+  // Resolve canonical owner/repo — the Search API does not follow repo redirects
+  const resolved = await resolveRepo(owner, repo)
+  if (!resolved) return null
+  const q = `repo:${resolved.owner}/${resolved.repo} is:${isPR ? "pr" : "issue"} is:${state}`
   const d = await githubJson(
     `https://api.github.com/search/issues?q=${encodeURIComponent(q)}&per_page=1`
   )
@@ -272,8 +291,11 @@ export async function getGitHubIssues(owner: string, repo: string, filter: strin
 export async function getGitHubLabelIssues(
   owner: string, repo: string, label: string, states?: string
 ): Promise<BadgeData | null> {
+  // Resolve canonical owner/repo — the Search API does not follow repo redirects
+  const resolved = await resolveRepo(owner, repo)
+  if (!resolved) return null
   const state = states === "closed" ? "closed" : states === "open" ? "open" : "open"
-  const q = `repo:${owner}/${repo} is:issue is:${state} label:"${label}"`
+  const q = `repo:${resolved.owner}/${resolved.repo} is:issue is:${state} label:"${label}"`
   const d = await githubJson(
     `https://api.github.com/search/issues?q=${encodeURIComponent(q)}&per_page=1`
   )
@@ -291,7 +313,10 @@ export async function getGitHubPRs(owner: string, repo: string, filter: string):
     case "closed-prs":
       count = await issueCount(owner, repo, "closed", true); lbl = "closed PRs"; break
     case "merged-prs": {
-      const q = `repo:${owner}/${repo} is:pr is:merged`
+      // Resolve canonical owner/repo — the Search API does not follow repo redirects
+      const resolved = await resolveRepo(owner, repo)
+      if (!resolved) return null
+      const q = `repo:${resolved.owner}/${resolved.repo} is:pr is:merged`
       const d = await githubJson(`https://api.github.com/search/issues?q=${encodeURIComponent(q)}&per_page=1`)
       if (!d || typeof d.total_count !== "number") return null
       return { label: "merged PRs", value: formatCount(d.total_count as number), link: link(owner, repo, "/pulls?q=is:merged") }


### PR DESCRIPTION
<!--begin:badgetizr-shieldcn--> 
![Ready](https://shieldcn.dev/badge/Ready-22C55E.svg?variant=default&mode=dark&size=sm&logo=ri:RiCheckFill&color=22C55E)  [![CI 25478303908](https://shieldcn.dev/badge/Build-25478303908-7C3AED.svg?variant=default&mode=dark&size=sm&logo=github&color=7C3AED)](https://github.com/jal-co/shieldcn/actions/runs/25478303908)
<!--end:badgetizr-shieldcn-->
## Summary

Two fixes for the migrate tool:

### 1. Use `variant=branded` for providers with brand colors

The migrate tool was defaulting to `variant=default` for all badges. Now it automatically sets `variant=branded` for providers that have a known brand color (Discord, npm, GitHub, PyPI, Docker, etc.), which uses the provider's brand color as the badge background with contrast-aware icon/text colors.

For static badges (`/badge/...`), it detects when the `logo` param matches a branded provider and applies `variant=branded` as well. When setting branded, explicit `logoColor` is dropped since the variant auto-calculates icon color based on contrast.

**Before:** Discord badge migrated with `variant=default` (generic styling, logo uses brand color on neutral bg)
**After:** Discord badge migrated with `variant=branded` (Discord blue bg, white logo/text)

### 2. Fix GitHub issues/PRs showing "not found" for transferred repos

GitHub's Search API (`/search/issues?q=repo:owner/repo`) does **not** follow 301 redirects for repos that have been transferred or renamed. This caused issues, PRs, label-issues, and merged-PRs badges to show "github not found" when the original owner/repo had changed.

Added a `resolveRepo()` helper that hits `/repos/{owner}/{repo}` (which follows redirects) and returns the canonical `full_name`, then uses the resolved owner/repo in search queries.

### Changes

- `packages/core/src/migrate/transform.ts` — Import `providerBrandColors`, set `variant=branded` for provider badges and static badges with branded logos
- `packages/core/src/providers/github.ts` — Add `resolveRepo()`, use in `issueCount()`, `getGitHubLabelIssues()`, and `getGitHubPRs()` merged case
- `packages/cli/src/migrate.ts` — Mirror branded variant logic for CLI