### PR TITLE
feat(web): redesign badge builder

### DIFF
--- a/packages/cli/src/migrate.ts
+++ b/packages/cli/src/migrate.ts
@@ -7,6 +7,17 @@
 
 import { SHIELDCN_BASE } from "./constants.js"
 
+/** Providers that support the branded variant (have a known brand color). */
+const BRANDED_PROVIDERS = new Set([
+  "npm", "github", "discord", "reddit", "pypi", "crates", "docker",
+  "bluesky", "jsr", "youtube", "vscode", "opencollective", "hackernews",
+  "mastodon", "lemmy", "packagist", "rubygems", "nuget", "pub", "homebrew",
+  "maven", "cocoapods", "twitch", "codecov", "wakatime", "gitlab", "conda",
+  "chrome", "amo", "coveralls", "sonar", "jsdelivr", "chocolatey", "flathub",
+  "snapcraft", "fdroid", "discourse", "stackexchange", "modrinth", "openvsx",
+  "liberapay", "matrix", "weblate",
+])
+
 export type Migration = {
   original: string
   converted: string
@@ -108,6 +119,17 @@ export function convertShieldsUrl(url: string): Migration | null {
       shieldcnPath = path
       if (!shieldcnPath.endsWith(".svg")) shieldcnPath += ".svg"
       provider = path.split("/")[0] || "unknown"
+    }
+
+    // Use branded variant for providers that have a brand color
+    if (!query.has("variant")) {
+      if (provider !== "badge" && BRANDED_PROVIDERS.has(provider)) {
+        query.set("variant", "branded")
+        query.delete("logoColor")
+      } else if (provider === "badge" && logo && BRANDED_PROVIDERS.has(logo)) {
+        query.set("variant", "branded")
+        query.delete("logoColor")
+      }
     }
 
     const qs = query.toString()

--- a/packages/core/src/migrate/transform.ts
+++ b/packages/core/src/migrate/transform.ts
@@ -6,6 +6,8 @@
  * into equivalent shieldcn badge URLs.
  */
 
+import { providerBrandColors } from "../badges/brand-colors"
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -848,6 +850,30 @@ export function transformShieldsUrl(
       const result = transformer(match, parsed.searchParams, baseUrl)
       if (result) {
         const mappedParams = mapShieldsParams(parsed.searchParams, result.query)
+
+        // Use branded variant for providers that have a brand color,
+        // unless the user explicitly set a style that mapped to a variant.
+        // For static badges (/badge/...), use branded if the logo param
+        // matches a provider with a known brand color.
+        const provider = result.path.split("/")[1] // e.g. "/npm/v/foo" → "npm"
+        if (!mappedParams.has("variant")) {
+          let useBranded = false
+          if (provider && provider !== "badge" && providerBrandColors[provider]) {
+            useBranded = true
+          } else if (provider === "badge") {
+            const logo = mappedParams.get("logo") ?? parsed.searchParams.get("logo")
+            if (logo && providerBrandColors[logo]) {
+              useBranded = true
+            }
+          }
+          if (useBranded) {
+            mappedParams.set("variant", "branded")
+            // branded auto-calculates icon color based on contrast —
+            // drop explicit logoColor so it doesn't fight the auto value
+            mappedParams.delete("logoColor")
+          }
+        }
+
         const queryString = mappedParams.toString()
         const ext = ".svg" // always output SVG
         const shieldcnUrl =

--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -80,6 +80,22 @@ async function repoData(owner: string, repo: string) {
   return githubJson(`https://api.github.com/repos/${owner}/${repo}`)
 }
 
+/**
+ * Resolve the canonical owner/repo (follows GitHub 301 redirects for
+ * transferred or renamed repos). The Search API does NOT follow repo
+ * redirects, so any function that builds a `repo:owner/repo` search
+ * query must resolve through here first.
+ */
+async function resolveRepo(owner: string, repo: string): Promise<{ owner: string; repo: string } | null> {
+  const d = await repoData(owner, repo)
+  if (!d) return null
+  const fullName = d.full_name as string | undefined
+  if (!fullName) return null
+  const [o, r] = fullName.split("/")
+  if (!o || !r) return null
+  return { owner: o, repo: r }
+}
+
 // ---------------------------------------------------------------------------
 // Badge functions
 // ---------------------------------------------------------------------------
@@ -245,7 +261,10 @@ export async function getGitHubChecks(
 // ---------------------------------------------------------------------------
 
 async function issueCount(owner: string, repo: string, state: string, isPR: boolean): Promise<number | null> {
-  const q = `repo:${owner}/${repo} is:${isPR ? "pr" : "issue"} is:${state}`
+  // Resolve canonical owner/repo — the Search API does not follow repo redirects
+  const resolved = await resolveRepo(owner, repo)
+  if (!resolved) return null
+  const q = `repo:${resolved.owner}/${resolved.repo} is:${isPR ? "pr" : "issue"} is:${state}`
   const d = await githubJson(
     `https://api.github.com/search/issues?q=${encodeURIComponent(q)}&per_page=1`
   )
@@ -272,8 +291,11 @@ export async function getGitHubIssues(owner: string, repo: string, filter: strin
 export async function getGitHubLabelIssues(
   owner: string, repo: string, label: string, states?: string
 ): Promise<BadgeData | null> {
+  // Resolve canonical owner/repo — the Search API does not follow repo redirects
+  const resolved = await resolveRepo(owner, repo)
+  if (!resolved) return null
   const state = states === "closed" ? "closed" : states === "open" ? "open" : "open"
-  const q = `repo:${owner}/${repo} is:issue is:${state} label:"${label}"`
+  const q = `repo:${resolved.owner}/${resolved.repo} is:issue is:${state} label:"${label}"`
   const d = await githubJson(
     `https://api.github.com/search/issues?q=${encodeURIComponent(q)}&per_page=1`
   )
@@ -291,7 +313,10 @@ export async function getGitHubPRs(owner: string, repo: string, filter: string):
     case "closed-prs":
       count = await issueCount(owner, repo, "closed", true); lbl = "closed PRs"; break
     case "merged-prs": {
-      const q = `repo:${owner}/${repo} is:pr is:merged`
+      // Resolve canonical owner/repo — the Search API does not follow repo redirects
+      const resolved = await resolveRepo(owner, repo)
+      if (!resolved) return null
+      const q = `repo:${resolved.owner}/${resolved.repo} is:pr is:merged`
       const d = await githubJson(`https://api.github.com/search/issues?q=${encodeURIComponent(q)}&per_page=1`)
       if (!d || typeof d.total_count !== "number") return null
       return { label: "merged PRs", value: formatCount(d.total_count as number), link: link(owner, repo, "/pulls?q=is:merged") }

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -64,6 +64,12 @@ export default async function Home() {
 
           {/* Badge Builder */}
           <section id="builder" className="py-16 scroll-mt-16">
+            <div className="mb-8 max-w-lg">
+              <h2 className="text-2xl font-bold tracking-tight sm:text-3xl">Build your badge</h2>
+              <p className="mt-2 text-muted-foreground">
+                Pick a type, customize the look, copy the output.
+              </p>
+            </div>
             <BadgeBuilder />
           </section>
         </div>

--- a/packages/web/components/badge-builder-core.tsx
+++ b/packages/web/components/badge-builder-core.tsx
@@ -311,36 +311,36 @@ export function BadgeBuilderCore({
           {/* ── Row 1: Badge type + params ── */}
           <div className="space-y-3">
             <SectionLabel>Badge type</SectionLabel>
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-              <div className="space-y-1">
-                <Label className="text-xs text-muted-foreground">Type</Label>
-                <Select value={String(selectedPresetIndex)} onValueChange={handlePresetChange}>
-                  <SelectTrigger className="w-full text-sm h-9">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {PRESET_GROUP_ORDER.map(group => {
-                      const presets = PRESET_GROUPS.get(group)
-                      if (!presets) return null
-                      return (
-                        <SelectGroup key={group}>
-                          <SelectLabel className="text-xs text-muted-foreground font-medium">{group}</SelectLabel>
-                          {presets.map(preset => {
-                            const idx = BADGE_PRESETS.indexOf(preset)
-                            return (
-                              <SelectItem key={idx} value={String(idx)}>
-                                {preset.label}
-                              </SelectItem>
-                            )
-                          })}
-                        </SelectGroup>
-                      )
-                    })}
-                  </SelectContent>
-                </Select>
-              </div>
+            <div className="space-y-1">
+              <Label className="text-xs text-muted-foreground">Type</Label>
+              <Select value={String(selectedPresetIndex)} onValueChange={handlePresetChange}>
+                <SelectTrigger className="w-full text-sm h-9">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {PRESET_GROUP_ORDER.map(group => {
+                    const presets = PRESET_GROUPS.get(group)
+                    if (!presets) return null
+                    return (
+                      <SelectGroup key={group}>
+                        <SelectLabel className="text-xs text-muted-foreground font-medium">{group}</SelectLabel>
+                        {presets.map(preset => {
+                          const idx = BADGE_PRESETS.indexOf(preset)
+                          return (
+                            <SelectItem key={idx} value={String(idx)}>
+                              {preset.label}
+                            </SelectItem>
+                          )
+                        })}
+                      </SelectGroup>
+                    )
+                  })}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className={cn("grid gap-3 pt-3", selectedPreset.params.length >= 2 ? "grid-cols-2" : "grid-cols-1")}>
               {selectedPreset.params.map(param => (
-                <div key={param.key} className="space-y-1">
+                <div key={param.key} className="space-y-1 animate-in fade-in-0 duration-200">
                   <Label className="text-xs text-muted-foreground">
                     {param.label}
                     {param.optional && <span className="text-muted-foreground/50 ml-1">(opt)</span>}

--- a/packages/web/components/badge-builder-core.tsx
+++ b/packages/web/components/badge-builder-core.tsx
@@ -3,8 +3,8 @@
  * components/badge-builder-core
  *
  * Shared badge builder UI used by both the landing page builder
- * and the showcase submit dialog. Renders preview + controls.
- * Does NOT render copy output — the parent handles that.
+ * and the showcase submit dialog. Single card with split layout:
+ * preview (left) + controls panel (right) on desktop, stacked on mobile.
  *
  * UX flow:
  * 1. Pick a badge type from preset dropdown (grouped by category)
@@ -16,9 +16,9 @@
 "use client"
 
 import { useState, useCallback, useEffect, useRef, useMemo } from "react"
-import { ChevronDown, RotateCcw, Code2 } from "lucide-react"
+import { RotateCcw, Code2 } from "lucide-react"
 import { LogoPicker } from "@/components/logo-picker"
-import { ColorInput } from "@/components/color-input"
+import { ColorSwatch } from "@/components/color-input"
 import { SvgIconUpload } from "@/components/svg-icon-upload"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -69,7 +69,6 @@ const PRESET_GROUP_ORDER = ["Package", "GitHub", "Social", "Custom"]
 /** Find a preset that matches a given path */
 function findMatchingPreset(path: string): { preset: BadgePreset; values: Record<string, string> } | null {
   for (const preset of BADGE_PRESETS) {
-    // Build a regex from the template: /npm/{package}.svg → /npm/([^/]+)\.svg
     let pattern = preset.template
       .replace(/\./g, "\\.")
       .replace(/\{([^}]+)\}/g, "([^/]+)")
@@ -87,6 +86,19 @@ function findMatchingPreset(path: string): { preset: BadgePreset; values: Record
 }
 
 // ---------------------------------------------------------------------------
+// Variant display
+// ---------------------------------------------------------------------------
+
+const VARIANT_DISPLAY: Record<string, { label: string }> = {
+  default: { label: "Default" },
+  secondary: { label: "Secondary" },
+  outline: { label: "Outline" },
+  ghost: { label: "Ghost" },
+  destructive: { label: "Destructive" },
+  branded: { label: "Branded" },
+}
+
+// ---------------------------------------------------------------------------
 // Props
 // ---------------------------------------------------------------------------
 
@@ -101,7 +113,7 @@ interface BadgeBuilderCoreProps {
   showHeader?: boolean
   /** Whether to show format (SVG/PNG) selector. Default: true */
   showFormat?: boolean
-  /** Additional content rendered after the controls. */
+  /** Additional content rendered below the preview area. */
   children?: React.ReactNode
 }
 
@@ -117,7 +129,6 @@ export function BadgeBuilderCore({
   showFormat = true,
   children,
 }: BadgeBuilderCoreProps) {
-  const [showAdvanced, setShowAdvanced] = useState(false)
   const [showRawPath, setShowRawPath] = useState(false)
   const [imgError, setImgError] = useState(false)
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(null)
@@ -143,7 +154,6 @@ export function BadgeBuilderCore({
     setImgError(false)
   }, [s, onChange])
 
-  // --- When preset or param values change, update the path ---
   const updatePath = useCallback((preset: BadgePreset, values: Record<string, string>) => {
     const path = resolveTemplate(preset, values)
     onChange({ ...s, path })
@@ -155,7 +165,6 @@ export function BadgeBuilderCore({
     if (isNaN(idx) || idx < 0 || idx >= BADGE_PRESETS.length) return
     const preset = BADGE_PRESETS[idx]
     setSelectedPresetIndex(idx)
-    // Reset param values to defaults for the new preset
     const defaults: Record<string, string> = {}
     for (const p of preset.params) defaults[p.key] = p.default
     setParamValues(defaults)
@@ -165,7 +174,6 @@ export function BadgeBuilderCore({
   const handleParamChange = useCallback((key: string, value: string) => {
     const next = { ...paramValues, [key]: value }
     setParamValues(next)
-    // Debounce path update for typing
     if (debounceRef.current) clearTimeout(debounceRef.current)
     debounceRef.current = setTimeout(() => {
       updatePath(selectedPreset, next)
@@ -183,7 +191,6 @@ export function BadgeBuilderCore({
     }, 400)
   }, [s, onChange])
 
-  // Sync rawPathInput when path changes from preset/params
   const prevPath = useRef(s.path)
   useEffect(() => {
     if (s.path !== prevPath.current) {
@@ -194,38 +201,61 @@ export function BadgeBuilderCore({
 
   const isDefault = JSON.stringify(s) === JSON.stringify(BUILDER_DEFAULTS)
 
+  // Map provider to its SimpleIcons slug for branded preview
+  const PROVIDER_ICON: Record<string, string> = {
+    npm: "npm", pypi: "pypi", crates: "rust", docker: "docker",
+    jsr: "jsr", discord: "discord", reddit: "reddit",
+    youtube: "youtube", twitch: "twitch", github: "github",
+    gitlab: "gitlab", bluesky: "bluesky",
+  }
+
+  const currentProvider = useMemo(() => s.path.split("/").filter(Boolean)[0] || "", [s.path])
+  const brandedIcon = PROVIDER_ICON[currentProvider] || ""
+  const hasBranded = brandedIcon !== "" && !s.path.startsWith("/badge/")
+
+  // Build variant preview URLs — static badges showing variant name in that variant's style
+  const variantPreviewUrls = useMemo(() => {
+    if (!badgeUrl) return {} as Record<string, string>
+    const map: Record<string, string> = {}
+    try {
+      const base = new URL(badgeUrl).origin
+      for (const v of VARIANTS) {
+        if (v === "branded" && !hasBranded) continue
+        const label = VARIANT_DISPLAY[v]?.label ?? v
+        const p = new URLSearchParams()
+        if (v !== "default") p.set("variant", v)
+        p.set("size", "default")
+        if (v === "branded") p.set("logo", brandedIcon)
+        else p.set("logo", "false")
+        if (s.mode !== "dark") p.set("mode", s.mode)
+        const q = p.toString()
+        map[v] = `${base}/badge/${encodeURIComponent(label)}.svg${q ? `?${q}` : ""}`
+      }
+    } catch { /* noop */ }
+    return map
+  }, [badgeUrl, s.mode, brandedIcon, hasBranded])
+
+  const handleReset = useCallback(() => {
+    onChange(BUILDER_DEFAULTS)
+    setSelectedPresetIndex(0)
+    const defaults: Record<string, string> = {}
+    for (const p of BADGE_PRESETS[0].params) defaults[p.key] = p.default
+    setParamValues(defaults)
+    setShowRawPath(false)
+  }, [onChange])
+
   return (
     <div className="rounded-xl border border-border bg-card overflow-hidden">
-      {/* ── Header ── */}
-      {showHeader && (
-        <div className="flex items-center justify-between px-5 py-3 border-b border-border bg-muted/30">
-          <h3 className="text-sm font-semibold tracking-tight">Badge Builder</h3>
-          {!isDefault && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                onChange(BUILDER_DEFAULTS)
-                setSelectedPresetIndex(0)
-                const defaults: Record<string, string> = {}
-                for (const p of BADGE_PRESETS[0].params) defaults[p.key] = p.default
-                setParamValues(defaults)
-                setShowAdvanced(false)
-                setShowRawPath(false)
-              }}
-              className="text-muted-foreground text-xs gap-1.5 h-7"
-            >
-              <RotateCcw className="size-3" />
-              Reset
-            </Button>
-          )}
-        </div>
-      )}
-
-      {/* ── Preview ── */}
+      {/* ─── Top: Preview ─── */}
       <div
-        className="flex items-center justify-center border-b border-border py-10 px-6 transition-colors"
-        style={{ backgroundColor: s.mode === "light" ? "#f4f4f5" : "#0c0c0e" }}
+        className="relative flex h-[140px] items-center justify-center transition-colors"
+        style={{
+          backgroundColor: s.mode === "light" ? "#f4f4f5" : "#0c0c0e",
+          backgroundImage: s.mode === "light"
+            ? "radial-gradient(circle, #d4d4d8 1px, transparent 1px)"
+            : "radial-gradient(circle, #27272a 1px, transparent 1px)",
+          backgroundSize: "20px 20px",
+        }}
       >
         {badgeUrl && !imgError ? (
           // eslint-disable-next-line @next/next/no-img-element
@@ -233,171 +263,215 @@ export function BadgeBuilderCore({
             key={badgeUrl}
             src={badgeUrl}
             alt="badge preview"
-            className="max-h-12 select-none"
+            className="max-h-14 select-none drop-shadow-sm"
             onError={() => setImgError(true)}
           />
         ) : (
           <span className="text-xs text-muted-foreground">
-            {imgError ? "Failed to load — check your badge settings" : "Configure your badge below"}
+            {imgError ? "Failed to load — check your settings" : "Configure your badge below"}
           </span>
         )}
+        <span className="absolute right-3 top-3 rounded-md border border-border/40 bg-background/60 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground backdrop-blur-sm">
+          {s.mode}
+        </span>
       </div>
 
-      <div className="p-5 space-y-5">
-        {/* ── Badge type selector ── */}
-        <div className="space-y-2">
-          <Label className="text-xs text-muted-foreground">Badge type</Label>
-          <Select value={String(selectedPresetIndex)} onValueChange={handlePresetChange}>
-            <SelectTrigger className="w-full text-sm">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {PRESET_GROUP_ORDER.map(group => {
-                const presets = PRESET_GROUPS.get(group)
-                if (!presets) return null
-                return (
-                  <SelectGroup key={group}>
-                    <SelectLabel className="text-xs text-muted-foreground font-medium">{group}</SelectLabel>
-                    {presets.map(preset => {
-                      const idx = BADGE_PRESETS.indexOf(preset)
-                      return (
-                        <SelectItem key={idx} value={String(idx)}>
-                          {preset.label}
-                        </SelectItem>
-                      )
-                    })}
-                  </SelectGroup>
-                )
-              })}
-            </SelectContent>
-          </Select>
+      {/* ─── Copy output (slotted from parent) ─── */}
+      {children && (
+        <div className="border-t border-border px-5 py-4">
+          {children}
         </div>
+      )}
 
-        {/* ── Dynamic parameters ── */}
-        {selectedPreset.params.length > 0 && (
-          <div className={cn("grid gap-3 grid-cols-1", selectedPreset.params.length === 2 && "sm:grid-cols-2", selectedPreset.params.length >= 3 && "sm:grid-cols-3")}>
-            {selectedPreset.params.map(param => (
-              <div key={param.key} className="space-y-1.5">
-                <Label className="text-xs text-muted-foreground">
-                  {param.label}
-                  {param.optional && <span className="text-muted-foreground/50 ml-1">(optional)</span>}
-                </Label>
-                <Input
-                  value={paramValues[param.key] || ""}
-                  onChange={e => handleParamChange(param.key, e.target.value)}
-                  placeholder={param.optional ? `${param.placeholder}` : param.placeholder}
-                  className="text-sm"
-                />
-              </div>
-            ))}
+      {/* ─── Controls ─── */}
+      <div className="border-t border-border">
+        {/* Header */}
+        {showHeader && (
+          <div className="flex h-10 items-center justify-between px-5 border-b border-border bg-muted/20">
+            <div className="flex items-center gap-2">
+              <div className="size-1.5 rounded-full bg-foreground/20" />
+              <span className="text-xs font-medium tracking-tight text-muted-foreground">Controls</span>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleReset}
+              className={cn(
+                "text-muted-foreground text-xs gap-1.5 h-7",
+                isDefault && "invisible",
+              )}
+            >
+              <RotateCcw className="size-3" />
+              Reset
+            </Button>
           </div>
         )}
 
-        {/* ── Core controls: variant + size + mode ── */}
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-          <Ctrl label="Variant" value={s.variant} onChange={v => set("variant", v)} options={[...VARIANTS]} />
-          <Ctrl label="Size" value={s.size} onChange={v => set("size", v)} options={[...SIZES]} />
-          <Ctrl label="Mode" value={s.mode} onChange={v => set("mode", v)} options={[...MODES]} />
-        </div>
+        <div className="p-5 space-y-5">
+          {/* ── Row 1: Badge type + params ── */}
+          <div className="space-y-3">
+            <SectionLabel>Badge type</SectionLabel>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div className="space-y-1">
+                <Label className="text-xs text-muted-foreground">Type</Label>
+                <Select value={String(selectedPresetIndex)} onValueChange={handlePresetChange}>
+                  <SelectTrigger className="w-full text-sm h-9">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {PRESET_GROUP_ORDER.map(group => {
+                      const presets = PRESET_GROUPS.get(group)
+                      if (!presets) return null
+                      return (
+                        <SelectGroup key={group}>
+                          <SelectLabel className="text-xs text-muted-foreground font-medium">{group}</SelectLabel>
+                          {presets.map(preset => {
+                            const idx = BADGE_PRESETS.indexOf(preset)
+                            return (
+                              <SelectItem key={idx} value={String(idx)}>
+                                {preset.label}
+                              </SelectItem>
+                            )
+                          })}
+                        </SelectGroup>
+                      )
+                    })}
+                  </SelectContent>
+                </Select>
+              </div>
+              {selectedPreset.params.map(param => (
+                <div key={param.key} className="space-y-1">
+                  <Label className="text-xs text-muted-foreground">
+                    {param.label}
+                    {param.optional && <span className="text-muted-foreground/50 ml-1">(opt)</span>}
+                  </Label>
+                  <Input
+                    value={paramValues[param.key] || ""}
+                    onChange={e => handleParamChange(param.key, e.target.value)}
+                    placeholder={param.placeholder}
+                    className="text-sm h-9"
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
 
-        {/* ── Advanced customization toggle ── */}
-        <button
-          onClick={() => setShowAdvanced(!showAdvanced)}
-          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors w-full"
-        >
-          <ChevronDown className={cn("size-3 transition-transform", showAdvanced && "rotate-180")} />
-          Customize theme, icon, colors & more
-        </button>
+          <div className="h-px bg-border/50" />
 
-        {showAdvanced && (
-          <div className="space-y-4 rounded-lg border border-border/50 bg-muted/5 p-4">
-            {/* Theme + Font + Format */}
-            <div className={cn("grid gap-3 grid-cols-1 sm:grid-cols-2", showFormat && "sm:grid-cols-3")}>
+          {/* ── Row 2: Style (variant + dropdowns) ── */}
+          <div className="space-y-3">
+            <SectionLabel>Style</SectionLabel>
+            <div className={cn("grid grid-cols-3 gap-1.5", hasBranded ? "sm:grid-cols-6" : "sm:grid-cols-5")}>
+              {VARIANTS.filter(v => v !== "branded" || hasBranded).map(v => (
+                <button
+                  key={v}
+                  onClick={() => set("variant", v)}
+                  className={cn(
+                    "flex items-center justify-center rounded-lg px-1 py-2.5 transition-colors",
+                    s.variant === v
+                      ? "bg-foreground/10 ring-1 ring-foreground/20"
+                      : "hover:bg-muted/60",
+                  )}
+                >
+                  {variantPreviewUrls[v] ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={variantPreviewUrls[v]}
+                      alt={VARIANT_DISPLAY[v]?.label ?? v}
+                      className="h-[26px] select-none"
+                    />
+                  ) : (
+                    <span className="text-[11px] text-muted-foreground">
+                      {VARIANT_DISPLAY[v]?.label ?? v}
+                    </span>
+                  )}
+                </button>
+              ))}
+            </div>
+            <div className={cn("grid gap-3", showFormat ? "grid-cols-3 sm:grid-cols-5" : "grid-cols-2 sm:grid-cols-4")}>
+              <Ctrl label="Size" value={s.size} onChange={v => set("size", v)} options={[...SIZES]} />
+              <Ctrl label="Mode" value={s.mode} onChange={v => set("mode", v)} options={[...MODES]} />
               <Ctrl label="Theme" value={s.theme} onChange={v => set("theme", v)} options={[...THEMES]} displayMap={{ _none: "None" }} />
               <Ctrl label="Font" value={s.font} onChange={v => set("font", v)} options={[...FONTS]} />
               {showFormat && (
                 <Ctrl label="Format" value={s.format} onChange={v => set("format", v)} options={[...FORMATS]} displayMap={{ svg: "SVG", png: "PNG" }} />
               )}
             </div>
+          </div>
 
-            {/* Icon */}
-            <div className="space-y-1.5">
-              <Label className="text-xs text-muted-foreground">Icon</Label>
-              <div className="flex gap-2">
-                <div className="flex-1">
-                  <LogoPicker value={s.logo.startsWith("data:") ? "" : s.logo} onChange={v => set("logo", v)} />
-                </div>
-                <SvgIconUpload value={s.logo} onChange={v => set("logo", v)} className="shrink-0" />
+          <div className="h-px bg-border/50" />
+
+          {/* ── Row 3: Icon ── */}
+          <div className="space-y-2">
+            <SectionLabel>Icon</SectionLabel>
+            <div className="flex gap-2">
+              <div className="flex-1">
+                <LogoPicker value={s.logo.startsWith("data:") ? "" : s.logo} onChange={v => set("logo", v)} />
               </div>
+              <SvgIconUpload value={s.logo} onChange={v => set("logo", v)} className="shrink-0" />
             </div>
+          </div>
 
-            {/* Toggles */}
-            <div className="flex flex-wrap items-center gap-4">
-              <label className="flex items-center gap-2 cursor-pointer">
-                <ShadcnCheckbox checked={s.split} onCheckedChange={v => set("split", v === true)} />
-                <span className="text-xs">Split mode</span>
-              </label>
+          <div className="h-px bg-border/50" />
+
+          {/* ── Row 4: Customize — all swatches + text inputs in one flat section ── */}
+          <div className="space-y-3">
+            <SectionLabel>Customize</SectionLabel>
+            <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
+              <ColorSwatch label="Icon color" value={s.logoColor} onChange={v => set("logoColor", v)} />
+              <ColorSwatch label="Background" value={s.color} onChange={v => set("color", v)} />
+              <ColorSwatch label="Value text" value={s.valueColor} onChange={v => set("valueColor", v)} />
+              <ColorSwatch label="Label text" value={s.labelTextColor} onChange={v => set("labelTextColor", v)} />
+              <Reveal open={s.split}>
+                <ColorSwatch label="Label bg" value={s.labelColor} onChange={v => set("labelColor", v)} />
+              </Reveal>
             </div>
-
-            {/* Colors */}
-            <div className="grid grid-cols-2 gap-3">
-              <ColorField label="Background" value={s.color} onChange={v => set("color", v)} />
-              <ColorField label="Icon color" value={s.logoColor} onChange={v => set("logoColor", v)} />
-              {s.split && (
-                <ColorField label="Label background" value={s.labelColor} onChange={v => set("labelColor", v)} />
-              )}
-            </div>
-
-            {/* Text overrides */}
-            <div className="grid grid-cols-2 gap-3">
-              <div className="space-y-1.5">
-                <Label className="text-xs text-muted-foreground">Custom label</Label>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <div className="space-y-1">
+                <Label className="text-xs text-muted-foreground">Label</Label>
                 <Input value={s.label} onChange={e => set("label", e.target.value)} placeholder="auto" className="h-8 text-xs" />
               </div>
-              <div className="space-y-1.5">
-                <Label className="text-xs text-muted-foreground">Gradient</Label>
-                <Input value={s.gradient} onChange={e => set("gradient", e.target.value)} placeholder="ff6b6b,4ecdc4" className="h-8 text-xs" />
-              </div>
-            </div>
-
-            {/* Fine-grain color overrides */}
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-              <ColorField label="Value text" value={s.valueColor} onChange={v => set("valueColor", v)} />
-              <ColorField label="Label text" value={s.labelTextColor} onChange={v => set("labelTextColor", v)} />
-              <div className="space-y-1.5">
+              <div className="space-y-1">
                 <Label className="text-xs text-muted-foreground">Label opacity</Label>
                 <Input value={s.labelOpacity} onChange={e => set("labelOpacity", e.target.value)} placeholder="0.7" className="h-8 text-xs" />
               </div>
-            </div>
-
-            {/* Raw path (for power users) */}
-            <div className="pt-1 border-t border-border/30">
-              <button
-                onClick={() => setShowRawPath(!showRawPath)}
-                className="flex items-center gap-1.5 text-[11px] text-muted-foreground/70 hover:text-muted-foreground transition-colors"
-              >
-                <Code2 className="size-3" />
-                {showRawPath ? "Hide" : "Edit"} raw badge path
-              </button>
-              {showRawPath && (
-                <div className="mt-2 space-y-1.5">
-                  <Input
-                    value={rawPathInput}
-                    onChange={e => handleRawPathInput(e.target.value)}
-                    placeholder="/npm/react.svg"
-                    className="font-mono text-xs h-8"
-                  />
-                  <p className="text-[10px] text-muted-foreground/50">
-                    Direct URL path — overrides the badge type selector above
-                  </p>
-                </div>
-              )}
+              <div className="space-y-1">
+                <Label className="text-xs text-muted-foreground">Gradient</Label>
+                <Input value={s.gradient} onChange={e => set("gradient", e.target.value)} placeholder="ff6b6b,4ecdc4" className="h-8 text-xs" />
+              </div>
+              <div className="flex items-end h-full pb-1">
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <ShadcnCheckbox checked={s.split} onCheckedChange={v => set("split", v === true)} />
+                  <span className="text-xs">Split mode</span>
+                </label>
+              </div>
             </div>
           </div>
-        )}
 
-        {/* ── Slot for parent-specific content (copy output, submit button, etc.) ── */}
-        {children}
+          {/* ── Raw path ── */}
+          <div className="pt-1">
+            <button
+              onClick={() => setShowRawPath(!showRawPath)}
+              className="flex items-center gap-1.5 text-[11px] text-muted-foreground/60 hover:text-muted-foreground transition-colors"
+            >
+              <Code2 className="size-3" />
+              {showRawPath ? "Hide" : "Edit"} raw path
+            </button>
+            <Reveal open={showRawPath}>
+              <div className="mt-2 space-y-1">
+                <Input
+                  value={rawPathInput}
+                  onChange={e => handleRawPathInput(e.target.value)}
+                  placeholder="/npm/react.svg"
+                  className="font-mono text-xs h-8"
+                />
+                <p className="text-[10px] text-muted-foreground/50">
+                  Overrides the badge type selector
+                </p>
+              </div>
+            </Reveal>
+          </div>
+        </div>
       </div>
     </div>
   )
@@ -406,6 +480,28 @@ export function BadgeBuilderCore({
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
+
+/** Animate height from 0 to auto using the grid-rows trick. */
+function Reveal({ open, children }: { open: boolean; children: React.ReactNode }) {
+  return (
+    <div
+      className={cn(
+        "grid transition-[grid-template-rows,opacity] duration-200 ease-out",
+        open ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0",
+      )}
+    >
+      <div className="overflow-hidden">{children}</div>
+    </div>
+  )
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70">
+      {children}
+    </span>
+  )
+}
 
 function Ctrl({
   label,
@@ -439,19 +535,3 @@ function Ctrl({
   )
 }
 
-function ColorField({
-  label,
-  value,
-  onChange,
-}: {
-  label: string
-  value: string
-  onChange: (v: string) => void
-}) {
-  return (
-    <div className="space-y-1.5">
-      <Label className="text-xs text-muted-foreground">{label}</Label>
-      <ColorInput value={value} onChange={onChange} placeholder="auto" />
-    </div>
-  )
-}

--- a/packages/web/components/badge-builder.tsx
+++ b/packages/web/components/badge-builder.tsx
@@ -3,7 +3,7 @@
  * components/badge-builder
  *
  * Landing page badge builder. Wraps BadgeBuilderCore with
- * copy output (Markdown, HTML, URL, RST).
+ * copy output (Markdown, HTML, URL, RST) slotted into the preview column.
  */
 
 "use client"
@@ -78,7 +78,7 @@ export function BadgeBuilder() {
     <BadgeBuilderCore state={s} onChange={setS} badgeUrl={url}>
       {/* ── Copy output ── */}
       {url && (
-        <div className="space-y-3 pt-2">
+        <div className="space-y-3">
           {/* Format tabs */}
           <div className="flex items-center gap-1">
             {COPY_FORMATS.map(f => (

--- a/packages/web/components/color-input.tsx
+++ b/packages/web/components/color-input.tsx
@@ -107,6 +107,63 @@ export function ColorInput({
 }
 
 // ---------------------------------------------------------------------------
+// ColorSwatch — swatch-only picker (no text input)
+// ---------------------------------------------------------------------------
+
+export function ColorSwatch({
+  value,
+  onChange,
+  label,
+}: {
+  value: string
+  onChange: (v: string) => void
+  label?: string
+}) {
+  const [open, setOpen] = useState(false)
+
+  const displayColor = value && isValidHex(value) ? `#${value}` : undefined
+
+  return (
+    <div className="flex items-center gap-2">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              "size-7 shrink-0 cursor-pointer rounded-md border border-input transition-colors hover:border-ring",
+              !displayColor && "bg-transparent",
+            )}
+            style={displayColor ? { backgroundColor: displayColor } : undefined}
+            aria-label={label ? `Pick ${label} color` : "Pick color"}
+          >
+            {!displayColor && (
+              <span className="flex size-full items-center justify-center text-[9px] text-muted-foreground">
+                —
+              </span>
+            )}
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className="w-64 p-3" align="start">
+          <ColorPicker value={value} onChange={onChange} />
+        </PopoverContent>
+      </Popover>
+      {label && (
+        <span className="text-xs text-muted-foreground">{label}</span>
+      )}
+      {displayColor && (
+        <button
+          type="button"
+          onClick={() => onChange("")}
+          className="text-[10px] text-muted-foreground/50 hover:text-muted-foreground transition-colors"
+        >
+          clear
+        </button>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // ColorPicker — HSL canvas + hue slider + eyedropper + presets
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
<!--begin:badgetizr-shieldcn--> 
![Ready](https://shieldcn.dev/badge/Ready-22C55E.svg?variant=default&mode=dark&size=sm&logo=ri:RiCheckFill&color=22C55E)  [![CI 25527113997](https://shieldcn.dev/badge/Build-25527113997-7C3AED.svg?variant=default&mode=dark&size=sm&logo=github&color=7C3AED)](https://github.com/jal-co/shieldcn/actions/runs/25527113997)
<!--end:badgetizr-shieldcn-->
## What changed

Redesigned the landing page badge builder from scratch.

### Layout
- Single card: preview + copy output on top, controls below (was a split two-card layout)
- Flat controls — no more hidden "Advanced customization" accordion
- Section labels (Badge Type, Style, Icon, Customize) for visual hierarchy

### Variant selector
- Each variant button renders a live badge preview in that variant's style
- Branded variant shows the current provider's icon and brand color
- Branded hides automatically for static badges (no icon)

### Controls
- Color fields use swatch-only pickers (click to open color picker, no text input)
- All color swatches in one horizontal row under "Customize"
- Text overrides (label, opacity, gradient, split mode) in a clean 4-column grid
- Params fade in when switching badge types

### Polish
- `Reveal` animation component for conditional UI (split mode label bg, raw path)
- Fixed header height so Reset button doesn't cause layout shift
- Section heading ("Build your badge") above the builder card