### PR TITLE
feat(x): add static X / Twitter follow and mention badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ See the [docs](https://shieldcn.dev/docs) for full endpoint details, interactive
 | **Discord** | online count, members | `/discord/{serverId}` |
 | **Reddit** | karma, subscribers | `/reddit/subscribers/r/{subreddit}` |
 | **Bluesky** | followers, following, posts | `/bluesky/{handle}` |
+| **X / Twitter** | follow CTA, mention CTA | `/x/follow/{username}` |
 | **YouTube** | subscribers, channel views, video views, likes, comments | `/youtube/subscribers/{channelId}` |
 | **Mastodon** | followers, following, posts | `/mastodon/followers/{instance}/{acct}` |
 | **Lemmy** | subscribers, posts, comments | `/lemmy/subscribers/{instance}/{community}` |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -125,7 +125,7 @@ npx shieldcn-cli migrate --write
 | **Tooling** | Package manager (pnpm/yarn/bun/npm), TypeScript, ESLint, Prettier, Biome, Vite, Next.js, Nuxt, Astro, Svelte, Tailwind, Turborepo, Docker, Vitest, Playwright, Jest, Storybook, Vercel, Netlify, Cloudflare |
 | **Stack** | 100+ npm packages mapped to branded badges (React, Prisma, Drizzle, tRPC, Supabase, Stripe, OpenAI, etc.) |
 | **Modern** | ESM-only, tree-shakeable, dual package, monorepo, CLI tool, AGENTS.md, llms.txt, Claude/Cursor ready, MCP |
-| **Community** | Discord invite (from README), GitHub Sponsors, Open Collective, Patreon, Ko-fi (from FUNDING.yml), homepage |
+| **Community** | Discord invite and X/Twitter profile links (from README), GitHub Sponsors, Open Collective, Patreon, Ko-fi (from FUNDING.yml), homepage |
 
 ## Examples
 

--- a/packages/cli/dist/bin.js
+++ b/packages/cli/dist/bin.js
@@ -510,6 +510,15 @@ function extractDiscordInvite(readme) {
   const m = readme.match(re);
   return m ? m[1] : null;
 }
+function extractXUsername(readme) {
+  const re = /(?:https?:\/\/)?(?:www\.)?(?:x\.com|twitter\.com)\/([A-Za-z0-9_]{1,15})(?:[/?#]|\s|\)|"|'|$)/i;
+  const m = readme.match(re);
+  if (!m) return null;
+  const username = m[1];
+  const reserved = /* @__PURE__ */ new Set(["home", "i", "intent", "share", "search", "settings"]);
+  if (reserved.has(username.toLowerCase())) return null;
+  return username;
+}
 function extractShieldsIoUrls(readme) {
   const re = /https?:\/\/img\.shields\.io\/[^\s)"'>]+/g;
   return Array.from(new Set(readme.match(re) ?? []));
@@ -534,6 +543,18 @@ async function communityBadges(owner, repo, pkg, readme, signal) {
         path: `/discord/online-members/${code}.svg`,
         query: { variant: "branded" },
         enabled: true
+      });
+    }
+    const xUsername = extractXUsername(readme);
+    if (xUsername) {
+      out.push({
+        id: "community.x-follow",
+        group: "community",
+        label: "X Follow",
+        path: `/x/follow/${xUsername}.svg`,
+        query: { variant: "branded" },
+        enabled: true,
+        linkUrl: `https://x.com/${xUsername}`
       });
     }
   }
@@ -778,6 +799,53 @@ function formatJson(result, global) {
 }
 
 // src/migrate.ts
+var BRANDED_PROVIDERS = /* @__PURE__ */ new Set([
+  "npm",
+  "github",
+  "discord",
+  "reddit",
+  "pypi",
+  "crates",
+  "docker",
+  "bluesky",
+  "jsr",
+  "youtube",
+  "vscode",
+  "opencollective",
+  "hackernews",
+  "x",
+  "twitter",
+  "mastodon",
+  "lemmy",
+  "packagist",
+  "rubygems",
+  "nuget",
+  "pub",
+  "homebrew",
+  "maven",
+  "cocoapods",
+  "twitch",
+  "codecov",
+  "wakatime",
+  "gitlab",
+  "conda",
+  "chrome",
+  "amo",
+  "coveralls",
+  "sonar",
+  "jsdelivr",
+  "chocolatey",
+  "flathub",
+  "snapcraft",
+  "fdroid",
+  "discourse",
+  "stackexchange",
+  "modrinth",
+  "openvsx",
+  "liberapay",
+  "matrix",
+  "weblate"
+]);
 function convertShieldsUrl(url) {
   try {
     const parsed = new URL(url);
@@ -832,10 +900,28 @@ function convertShieldsUrl(url) {
       shieldcnPath = path;
       if (!shieldcnPath.endsWith(".svg")) shieldcnPath += ".svg";
       provider = "docker";
+    } else if (path.startsWith("twitter/follow/") || path.startsWith("twitter/followers/")) {
+      const username = path.split("/")[2];
+      if (!username) return null;
+      shieldcnPath = `x/follow/${username}.svg`;
+      provider = "x";
+    } else if (path.startsWith("x/follow/")) {
+      shieldcnPath = path;
+      if (!shieldcnPath.endsWith(".svg")) shieldcnPath += ".svg";
+      provider = "x";
     } else {
       shieldcnPath = path;
       if (!shieldcnPath.endsWith(".svg")) shieldcnPath += ".svg";
       provider = path.split("/")[0] || "unknown";
+    }
+    if (!query.has("variant")) {
+      if (provider !== "badge" && BRANDED_PROVIDERS.has(provider)) {
+        query.set("variant", "branded");
+        query.delete("logoColor");
+      } else if (provider === "badge" && logo && BRANDED_PROVIDERS.has(logo)) {
+        query.set("variant", "branded");
+        query.delete("logoColor");
+      }
     }
     const qs = query.toString();
     const converted = `${SHIELDCN_BASE}/${shieldcnPath}${qs ? `?${qs}` : ""}`;

--- a/packages/cli/src/detect.ts
+++ b/packages/cli/src/detect.ts
@@ -394,6 +394,17 @@ function extractDiscordInvite(readme: string): string | null {
   return m ? m[1]! : null
 }
 
+function extractXUsername(readme: string): string | null {
+  const re = /(?:https?:\/\/)?(?:www\.)?(?:x\.com|twitter\.com)\/([A-Za-z0-9_]{1,15})(?:[/?#]|\s|\)|"|'|$)/i
+  const m = readme.match(re)
+  if (!m) return null
+
+  const username = m[1]!
+  const reserved = new Set(["home", "i", "intent", "share", "search", "settings"])
+  if (reserved.has(username.toLowerCase())) return null
+  return username
+}
+
 function extractShieldsIoUrls(readme: string): string[] {
   const re = /https?:\/\/img\.shields\.io\/[^\s)"'>]+/g
   return Array.from(new Set(readme.match(re) ?? []))
@@ -425,6 +436,19 @@ async function communityBadges(
         path: `/discord/online-members/${code}.svg`,
         query: { variant: "branded" },
         enabled: true,
+      })
+    }
+
+    const xUsername = extractXUsername(readme)
+    if (xUsername) {
+      out.push({
+        id: "community.x-follow",
+        group: "community",
+        label: "X Follow",
+        path: `/x/follow/${xUsername}.svg`,
+        query: { variant: "branded" },
+        enabled: true,
+        linkUrl: `https://x.com/${xUsername}`,
       })
     }
   }

--- a/packages/cli/src/migrate.ts
+++ b/packages/cli/src/migrate.ts
@@ -11,7 +11,7 @@ import { SHIELDCN_BASE } from "./constants.js"
 const BRANDED_PROVIDERS = new Set([
   "npm", "github", "discord", "reddit", "pypi", "crates", "docker",
   "bluesky", "jsr", "youtube", "vscode", "opencollective", "hackernews",
-  "mastodon", "lemmy", "packagist", "rubygems", "nuget", "pub", "homebrew",
+  "x", "twitter", "mastodon", "lemmy", "packagist", "rubygems", "nuget", "pub", "homebrew",
   "maven", "cocoapods", "twitch", "codecov", "wakatime", "gitlab", "conda",
   "chrome", "amo", "coveralls", "sonar", "jsdelivr", "chocolatey", "flathub",
   "snapcraft", "fdroid", "discourse", "stackexchange", "modrinth", "openvsx",
@@ -114,6 +114,15 @@ export function convertShieldsUrl(url: string): Migration | null {
       shieldcnPath = path
       if (!shieldcnPath.endsWith(".svg")) shieldcnPath += ".svg"
       provider = "docker"
+    } else if (path.startsWith("twitter/follow/") || path.startsWith("twitter/followers/")) {
+      const username = path.split("/")[2]
+      if (!username) return null
+      shieldcnPath = `x/follow/${username}.svg`
+      provider = "x"
+    } else if (path.startsWith("x/follow/")) {
+      shieldcnPath = path
+      if (!shieldcnPath.endsWith(".svg")) shieldcnPath += ".svg"
+      provider = "x"
     } else {
       // Unknown provider — do a best-effort pass-through
       shieldcnPath = path

--- a/packages/core/src/badges/brand-colors.ts
+++ b/packages/core/src/badges/brand-colors.ts
@@ -19,6 +19,8 @@ export const providerBrandColors: Record<string, string> = {
   crates: "dea584",
   docker: "2496ED",
   bluesky: "0085FF",
+  x: "000000",
+  twitter: "000000",
   jsr: "F7DF1E",
   bundlephobia: "4E4E4E",
   youtube: "FF0000",

--- a/packages/core/src/migrate/transform.ts
+++ b/packages/core/src/migrate/transform.ts
@@ -256,6 +256,23 @@ const SHIELDS_PATTERNS: Array<[RegExp, PathTransformer]> = [
     description: `Reddit subscribers for r/${m[1]}`,
   })],
 
+  // --- X / Twitter ---
+  [/^\/twitter\/follow\/([A-Za-z0-9_]{1,15})$/, (m) => ({
+    path: `/x/follow/${m[1]}`,
+    query: new URLSearchParams(),
+    description: `X follow for @${m[1]}`,
+  })],
+  [/^\/twitter\/followers\/([A-Za-z0-9_]{1,15})$/, (m) => ({
+    path: `/x/follow/${m[1]}`,
+    query: new URLSearchParams(),
+    description: `X follow for @${m[1]}`,
+  })],
+  [/^\/x\/follow\/([A-Za-z0-9_]{1,15})$/, (m) => ({
+    path: `/x/follow/${m[1]}`,
+    query: new URLSearchParams(),
+    description: `X follow for @${m[1]}`,
+  })],
+
   // --- Codecov ---
   [/^\/codecov\/c\/github\/([^/]+)\/([^/]+)$/, (m) => ({
     path: `/codecov/${m[1]}/${m[2]}`,

--- a/packages/core/src/providers/x.ts
+++ b/packages/core/src/providers/x.ts
@@ -1,0 +1,44 @@
+/**
+ * shieldcn
+ * lib/providers/x
+ *
+ * Static X / Twitter badge provider.
+ * Generates follow and mention CTA badges that link to X profiles.
+ * No API token required — these are static badges with the X icon.
+ */
+
+import type { BadgeData } from "../badges/types"
+
+function normalizeUsername(username: string): string {
+  return username.replace(/^@/, "")
+}
+
+function profileLink(username: string): string {
+  return `https://x.com/${normalizeUsername(username)}`
+}
+
+// ---------------------------------------------------------------------------
+// Follow — "follow @username"
+// ---------------------------------------------------------------------------
+
+export function getXFollow(username: string): BadgeData {
+  const normalized = normalizeUsername(username)
+  return {
+    label: "follow",
+    value: `@${normalized}`,
+    link: profileLink(normalized),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mention — "@username"
+// ---------------------------------------------------------------------------
+
+export function getXMention(username: string): BadgeData {
+  const normalized = normalizeUsername(username)
+  return {
+    label: "x",
+    value: `@${normalized}`,
+    link: `https://x.com/intent/tweet?text=${encodeURIComponent(`@${normalized} `)}`,
+  }
+}

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -80,6 +80,7 @@ import { getPyPIVersion, getPyPIDownloads, getPyPILicense, getPyPIPythonVersion 
 import { getCratesVersion, getCratesDownloads, getCratesLicense } from "./providers/crates"
 import { getDockerPulls, getDockerStars, getDockerVersion, getDockerSize } from "./providers/docker"
 import { getBlueskyFollowers, getBlueskyFollowing, getBlueskyPosts } from "./providers/bluesky"
+import { getXFollow, getXMention } from "./providers/x"
 import { getJSRVersion, getJSRScore } from "./providers/jsr"
 import { getBundleMin, getBundleMinGzip, getBundleTreeShaking } from "./providers/bundlephobia"
 import { getYouTubeSubscribers, getYouTubeChannelViews, getYouTubeVideoViews, getYouTubeLikes, getYouTubeComments } from "./providers/youtube"
@@ -547,6 +548,26 @@ async function fetchBadgeData(
 
       // Default: /bluesky/{handle} → followers
       return getBlueskyFollowers(rest[0])
+    }
+
+    // /x/{topic}/{username} or /x/{username}
+    // Static CTA badges — no API token required
+    case "x":
+    case "twitter": {
+      const rest = segments.slice(1)
+      if (rest.length < 1) return null
+
+      const xTopics = new Set(["follow", "mention"])
+      if (xTopics.has(rest[0]) && rest[1]) {
+        switch (rest[0]) {
+          case "follow": return getXFollow(rest[1])
+          case "mention": return getXMention(rest[1])
+          default: return null
+        }
+      }
+
+      // Default: /x/{username} → follow
+      return getXFollow(rest[0])
     }
 
     // /jsr/{topic}/{@scope}/{name}
@@ -1257,6 +1278,7 @@ function getDefaultLogoSlug(segments: string[]): { simpleIcon?: string; reactIco
   if (provider === "crates") return { simpleIcon: "rust" }
   if (provider === "docker") return { simpleIcon: "docker" }
   if (provider === "bluesky") return { simpleIcon: "bluesky" }
+  if (provider === "x" || provider === "twitter") return { simpleIcon: "x", reactIcon: "BsTwitterX" }
   if (provider === "jsr") return { simpleIcon: "jsr" }
   if (provider === "bundlephobia") return { reactIcon: "GoPackage" }
   if (provider === "youtube") return { simpleIcon: "youtube" }

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -85,6 +85,7 @@ services:
 
 Create a token at [github.com/settings/tokens](https://github.com/settings/tokens) — no scopes needed (public data only).
 
+
 ## Environment Variables
 
 | Variable | Required | Default | Description |

--- a/packages/web/components/badge-builder-core.tsx
+++ b/packages/web/components/badge-builder-core.tsx
@@ -206,7 +206,7 @@ export function BadgeBuilderCore({
     npm: "npm", pypi: "pypi", crates: "rust", docker: "docker",
     jsr: "jsr", discord: "discord", reddit: "reddit",
     youtube: "youtube", twitch: "twitch", github: "github",
-    gitlab: "gitlab", bluesky: "bluesky",
+    gitlab: "gitlab", bluesky: "bluesky", x: "x", twitter: "x",
   }
 
   const currentProvider = useMemo(() => s.path.split("/").filter(Boolean)[0] || "", [s.path])

--- a/packages/web/components/sidebar.tsx
+++ b/packages/web/components/sidebar.tsx
@@ -151,6 +151,7 @@ const docsNav: NavGroup[] = [
     title: "Social & Community",
     items: [
       { title: "Bluesky", href: "/docs/badges/bluesky" },
+      { title: "X / Twitter", href: "/docs/badges/x" },
       { title: "YouTube", href: "/docs/badges/youtube" },
       { title: "Mastodon", href: "/docs/badges/mastodon" },
       { title: "Lemmy", href: "/docs/badges/lemmy" },

--- a/packages/web/components/site-announcement.tsx
+++ b/packages/web/components/site-announcement.tsx
@@ -11,8 +11,8 @@ export function SiteAnnouncement() {
     <Announcement>
       <AnnouncementBadge>New</AnnouncementBadge>
       <AnnouncementContent asChild>
-        <Link href="/docs/cli" className="hover:underline underline-offset-4">
-          Introducing shieldcn-cli — generate badges from the terminal
+        <Link href="/docs/badges/x" className="hover:underline underline-offset-4">
+          Now featuring X as a provider
           <ArrowRight className="size-3" />
         </Link>
       </AnnouncementContent>

--- a/packages/web/content/docs/api-reference.mdx
+++ b/packages/web/content/docs/api-reference.mdx
@@ -45,6 +45,16 @@ description: Complete URL specification, query parameters, and response formats.
 | `/discord/members/{inviteCode}.svg` | Approximate member count from invite |
 | `/discord/online-members/{inviteCode}.svg` | Approximate online member count from invite |
 
+### X / Twitter
+
+| Endpoint | Description |
+|----------|-------------|
+| `/x/{username}.svg` | Follow CTA (default) |
+| `/x/follow/{username}.svg` | "follow @username" CTA |
+| `/x/mention/{username}.svg` | "@username" mention CTA |
+
+Static badges — no API token required.
+
 ### Homebrew
 
 | Endpoint | Description |

--- a/packages/web/content/docs/badges/meta.json
+++ b/packages/web/content/docs/badges/meta.json
@@ -26,6 +26,7 @@
     "flathub",
     "fdroid",
     "bluesky",
+    "x",
     "youtube",
     "mastodon",
     "lemmy",

--- a/packages/web/content/docs/badges/x/index.mdx
+++ b/packages/web/content/docs/badges/x/index.mdx
@@ -1,0 +1,49 @@
+---
+title: X / Twitter
+description: Badges for X profiles — follow and mention CTA badges with the X icon.
+badge: "/x/follow/x.svg?variant=branded"
+---
+
+Static CTA badges for X profiles. No API token required.
+
+<BadgePreviewGroup>
+  <BadgePreviewCard src="/x/follow/x.svg?variant=branded" alt="x follow" description="Follow (branded)" />
+  <BadgePreviewCard src="/x/follow/jal_co.svg?variant=secondary" alt="x follow" description="Follow (secondary)" />
+  <BadgePreviewCard src="/x/mention/jal_co.svg?variant=outline" alt="x mention" description="Mention (outline)" />
+  <BadgePreviewCard src="/x/jal_co.svg" alt="x default" description="Default (follow)" />
+</BadgePreviewGroup>
+
+## Available badges
+
+| Badge | Endpoint | Description |
+|-------|----------|-------------|
+| Follow | `/x/follow/{username}` | "follow @username" CTA linking to profile |
+| Mention | `/x/mention/{username}` | "@username" CTA linking to tweet intent |
+| Default | `/x/{username}` | Same as follow |
+
+<BadgeSandbox
+  endpoint="/x/follow/:username.svg"
+  pathParams={[
+    { name: "username", label: "username", placeholder: "jal_co", required: true, description: "X username without @." },
+  ]}
+  defaults={{ username: "jal_co" }}
+  extraParams={[
+    { name: "variant", label: "variant", defaultValue: "branded", options: ["branded", "default", "secondary", "outline", "ghost"] },
+  ]}
+/>
+
+## Quick examples
+
+```md
+![follow](https://shieldcn.dev/x/follow/jal_co.svg?variant=branded)
+![mention](https://shieldcn.dev/x/mention/jal_co.svg?variant=outline)
+![follow](https://shieldcn.dev/x/jal_co.svg?variant=secondary)
+```
+
+## Why static?
+
+X's API requires a $200/mo Basic plan for any read access — even public profile data like follower counts. These badges skip the API entirely and render as static follow/mention CTAs with the X icon. No token, no cost, no rate limits.
+
+## Data source
+
+No external API calls. Badges are rendered statically using the username from the URL path.

--- a/packages/web/content/docs/badges/x/meta.json
+++ b/packages/web/content/docs/badges/x/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "X / Twitter",
+  "pages": ["index"]
+}

--- a/packages/web/content/docs/cli.mdx
+++ b/packages/web/content/docs/cli.mdx
@@ -50,6 +50,16 @@ npx shieldcn-cli https://github.com/shadcn-ui/ui
 
 Remote scanning uses `raw.githubusercontent.com` HEAD requests to detect config files — no GitHub token required.
 
+### X / Twitter badges
+
+The CLI detects `x.com/{username}` and `twitter.com/{username}` links in your README and generates an X follow CTA badge:
+
+```md
+![X Follow](https://shieldcn.dev/x/follow/username.svg?variant=branded)
+```
+
+These are static badges — no API token required. They render as follow CTAs with the X icon and link to the profile.
+
 ### Customize style
 
 Override the default variant, size, theme, or mode:
@@ -287,6 +297,7 @@ Detects modern project signals:
 ### Community
 
 - **Discord** — extracted from `discord.gg` or `discord.com/invite` links in README
+- **X / Twitter** — extracted from `x.com/{username}` or `twitter.com/{username}` links in README
 - **Sponsors** — parsed from `.github/FUNDING.yml` (GitHub Sponsors, Open Collective, Patreon, Ko-fi)
 - **Homepage** — from `"homepage"` in package.json
 

--- a/packages/web/lib/badge-builder-shared.ts
+++ b/packages/web/lib/badge-builder-shared.ts
@@ -61,6 +61,8 @@ export const BADGE_PRESETS: BadgePreset[] = [
   // Social
   { label: "Discord — online", template: "/discord/{serverId}.svg", params: [{ key: "serverId", label: "Server ID", placeholder: "1316199667142496307", default: "1316199667142496307" }], group: "Social" },
   { label: "Reddit — subscribers", template: "/reddit/{subreddit}.svg", params: [{ key: "subreddit", label: "Subreddit", placeholder: "typescript", default: "typescript" }], group: "Social" },
+  { label: "X — follow", template: "/x/follow/{username}.svg", params: [{ key: "username", label: "Username", placeholder: "jal_co", default: "jal_co" }], group: "Social" },
+  { label: "X — mention", template: "/x/mention/{username}.svg", params: [{ key: "username", label: "Username", placeholder: "jal_co", default: "jal_co" }], group: "Social" },
   { label: "YouTube — subscribers", template: "/youtube/{channelId}/subscribers.svg", params: [{ key: "channelId", label: "Channel ID", placeholder: "UCsBjURrPoezykLs9EqgamOA", default: "UCsBjURrPoezykLs9EqgamOA" }], group: "Social" },
   { label: "Twitch — status", template: "/twitch/{channel}.svg", params: [{ key: "channel", label: "Channel", placeholder: "shroud", default: "shroud" }], group: "Social" },
 

--- a/packages/web/lib/gen/detect-profile.ts
+++ b/packages/web/lib/gen/detect-profile.ts
@@ -395,14 +395,14 @@ function socialBadges(
   )
   seen.add("github")
 
-  // Twitter from API
+  // Twitter / X
   if (user.twitter_username) {
     badges.push(
       mk(
         "social.twitter",
-        "Twitter / X",
-        staticBadgePath("Follow", `@${user.twitter_username}`, "000000"),
-        { logo: "x", variant: "branded" },
+        "X Follow",
+        `/x/follow/${user.twitter_username}.svg`,
+        { variant: "branded" },
         `https://x.com/${user.twitter_username}`,
       ),
     )
@@ -437,12 +437,18 @@ function socialBadges(
       const display = link.username
         ? `@${link.username}`
         : link.platform
+      const path = link.slug === "x" && link.username
+        ? `/x/follow/${link.username}.svg`
+        : staticBadgePath(link.platform, display, link.color)
+      const query: Record<string, string> = link.slug === "x"
+        ? { variant: "branded" }
+        : { logo: link.slug, variant: "branded" }
       badges.push(
         mk(
           `social.${link.slug}`,
           link.platform,
-          staticBadgePath(link.platform, display, link.color),
-          { logo: link.slug, variant: "branded" },
+          path,
+          query,
           link.url,
         ),
       )

--- a/packages/web/lib/gen/detect.ts
+++ b/packages/web/lib/gen/detect.ts
@@ -187,6 +187,17 @@ function extractDiscordInvite(readme: string): string | null {
   return m ? m[1]! : null;
 }
 
+function extractXUsername(readme: string): string | null {
+  const re = /(?:https?:\/\/)?(?:www\.)?(?:x\.com|twitter\.com)\/([A-Za-z0-9_]{1,15})(?:[/?#]|\s|\)|"|'|$)/i;
+  const m = readme.match(re);
+  if (!m) return null;
+
+  const username = m[1]!;
+  const reserved = new Set(['home', 'i', 'intent', 'share', 'search', 'settings']);
+  if (reserved.has(username.toLowerCase())) return null;
+  return username;
+}
+
 function extractShieldsIoUrls(readme: string): string[] {
   const re = /https?:\/\/img\.shields\.io\/[^\s)"'>]+/g;
   return Array.from(new Set(readme.match(re) ?? []));
@@ -491,6 +502,20 @@ async function communityBadges(
         query: { variant: 'branded' },
         overrides: {},
         enabled: true,
+      });
+    }
+
+    const xUsername = extractXUsername(readme);
+    if (xUsername) {
+      out.push({
+        id: 'community.x-follow',
+        group: 'community',
+        label: 'X Follow',
+        path: `/x/follow/${xUsername}.svg`,
+        query: { variant: 'branded' },
+        overrides: {},
+        enabled: true,
+        linkUrl: `https://x.com/${xUsername}`,
       });
     }
   }

--- a/packages/web/lib/showcase-data.ts
+++ b/packages/web/lib/showcase-data.ts
@@ -131,8 +131,10 @@ export const categories: Category[] = [
   },
   {
     name: "Social",
-    description: "Badges for social platforms — Bluesky, Mastodon, Hacker News, Lemmy, and Reddit.",
+    description: "Badges for social platforms — X, Bluesky, Mastodon, Hacker News, Lemmy, and Reddit.",
     icons: [
+      dynamicBadge("X Follow", "social cta", "/x/follow/jal_co.svg?variant=branded", "Follow CTA badge linking to an X profile.", "/docs/badges/x"),
+      dynamicBadge("X Mention", "social cta", "/x/mention/jal_co.svg?variant=outline", "Mention CTA badge linking to tweet intent.", "/docs/badges/x"),
       dynamicBadge("Bluesky Followers", "social proof", "/bluesky/jay.bsky.team.svg?variant=branded", "Bluesky follower count.", "/docs/badges/bluesky"),
       dynamicBadge("Bluesky Posts", "activity", "/bluesky/posts/jay.bsky.team.svg?variant=outline", "Bluesky post count.", "/docs/badges/bluesky"),
       dynamicBadge("Mastodon Followers", "fediverse", "/mastodon/followers/mastodon.social/Gargron.svg?variant=branded", "Mastodon follower count from any instance.", "/docs/badges/mastodon"),


### PR DESCRIPTION
## What

Add X / Twitter as a badge provider with static follow and mention CTA badges. No API token required.

### Endpoints

| Endpoint | Renders | Links to |
|----------|---------|----------|
| `/x/follow/{username}.svg` | `follow \| @username` | `x.com/{username}` |
| `/x/mention/{username}.svg` | `x \| @username` | tweet intent |
| `/x/{username}.svg` | same as follow | `x.com/{username}` |
| `/twitter/...` | alias for `/x/...` | — |

## Why

X's API now requires a $200/mo Basic plan for any read access (even public profile data like follower counts). Instead of API-backed live badges, these render as static follow/mention CTAs with the X icon — free, no token, no rate limits.

## How

- `packages/core/src/providers/x.ts` — static provider returning label/value/link (no fetch)
- Route handler maps `/x` and `/twitter` to the provider
- Brand color `000000` registered for branded variant
- Docs, sidebar, showcase, badge builder, API reference all updated
- CLI + web generators detect `x.com/` and `twitter.com/` links in READMEs
- Profile generator uses GitHub's `twitter_username` API field
- CLI migrate + core migrate map `shields.io/twitter/follow/{user}` → `/x/follow/{user}`
- Site announcement banner updated

## Testing

- All three packages build clean (`shieldcn-cli`, `@shieldcn/web`, `@shieldcn/engine`)
- Tested badge rendering locally — SVG, JSON, branded/outline/secondary variants
- Tested CLI migrate transform for shields.io twitter URLs
- Tested core migrate transform