### PR TITLE
feat(group): add badge groups — combine badges like a shadcn ButtonGroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/jal-co/shieldcn/stargazers"><img src="https://shieldcn.dev/github/stars/jal-co/shieldcn.svg?variant=branded" alt="stars" /></a>
-  <a href="https://github.com/jal-co/shieldcn/blob/main/LICENSE"><img src="https://shieldcn.dev/github/license/jal-co/shieldcn.svg?variant=branded" alt="license" /></a>
-  <a href="https://github.com/jal-co/shieldcn/graphs/contributors"><img src="https://shieldcn.dev/github/contributors/jal-co/shieldcn.svg?variant=branded" alt="contributors" /></a>
-  <a href="https://github.com/jal-co/shieldcn/commits/main"><img src="https://shieldcn.dev/github/last-commit/jal-co/shieldcn.svg?variant=branded" alt="last commit" /></a>
+  <img src="https://shieldcn.dev/group/github/stars/jal-co/shieldcn%2Bgithub/license/jal-co/shieldcn%2Bgithub/contributors/jal-co/shieldcn%2Bgithub/last-commit/jal-co/shieldcn.svg?variant=branded" alt="shieldcn stats" />
+</p>
+
+<p align="center">
   <a href="https://shieldcn.dev/docs/self-hosting"><img src="https://shieldcn.dev/badge/host%20with-docker-2496ED.svg?variant=branded&logo=docker" alt="host with docker" /></a>
   <a href="https://openpanel.dev?ref=justinlevine.me"><img src="https://shieldcn.dev/badge/analytics%20by-openpanel.svg?variant=branded&logo=openpanel" alt="analytics by openpanel" /></a>
   <a href="https://shadcncraft.com?utm_source=shieldcn.dev"><img src="https://shieldcn.dev/badge/built%20with-shadcncraft-171717.svg?logo=shadcncraft&logoColor=fff&variant=branded" alt="built with shadcncraft" /></a>
@@ -61,6 +61,20 @@ See the [CLI docs](https://shieldcn.dev/docs/cli) for full usage.
 ![license](https://shieldcn.dev/github/license/vercel/next.js.svg)
 ![discord](https://shieldcn.dev/discord/1316199667142496307.svg)
 ```
+
+### Badge groups
+
+Combine multiple badges into a single joined image — like a [shadcn ButtonGroup](https://ui.shadcn.com/docs/components/radix/button-group):
+
+<p>
+  <img src="https://shieldcn.dev/group/npm/react%2Bgithub/stars/vercel/next.js%2Bgithub/license/vercel/next.js.svg?variant=branded" alt="badge group" />
+</p>
+
+```md
+![group](https://shieldcn.dev/group/npm/react+github/stars/vercel/next.js+github/license/vercel/next.js.svg?variant=branded)
+```
+
+Join any badge paths with `+` under `/group/`. Query params apply to all segments. See the [Badge Group docs](https://shieldcn.dev/docs/badges/group).
 
 ## Supported providers
 
@@ -141,6 +155,7 @@ See the [docs](https://shieldcn.dev/docs) for full endpoint details, interactive
 
 | Type | Description | Endpoint |
 |------|-------------|----------|
+| **Badge Group** | Multiple badges joined in one image | `/group/{badge1}+{badge2}+{badge3}` |
 | **Static** | Custom label/message/color | `/badge/{label}-{message}-{color}` |
 | **Dynamic JSON** | Fetch any JSON API | `/badge/dynamic/json?url=...&query=...` |
 | **HTTPS Endpoint** | Proxy any JSON endpoint | `/https/{hostname}/{path}` |

--- a/packages/core/src/badges/render-group.tsx
+++ b/packages/core/src/badges/render-group.tsx
@@ -1,0 +1,407 @@
+/**
+ * shieldcn
+ * lib/badges/render-group
+ *
+ * Renders multiple badges joined together in a single SVG — like a shadcn
+ * ButtonGroup. Left badge gets rounded-l, right badge gets rounded-r,
+ * middle badges have flat edges. A 1px separator line divides each segment.
+ *
+ * Uses the same resolve() pipeline as single badges to guarantee visual
+ * consistency. The only difference is border radius and layout.
+ */
+
+import satori from "satori"
+import { optimize } from "svgo"
+import { readFileSync, existsSync } from "node:fs"
+import { join, dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+import type { BadgeConfig } from "./types"
+import {
+  darkMode,
+  lightMode,
+  getButtonStyle,
+  getButtonSize,
+  type ModeColors,
+} from "./button-tokens"
+
+// ---------------------------------------------------------------------------
+// Font loading (same as render.tsx)
+// ---------------------------------------------------------------------------
+
+function findFontsDir(): string {
+  const candidates = [
+    join(dirname(fileURLToPath(import.meta.url)), "..", "fonts"),
+    join(process.cwd(), "packages", "core", "src", "fonts"),
+    join(process.cwd(), "..", "core", "src", "fonts"),
+    join(process.cwd(), "lib", "fonts"),
+  ]
+  for (const dir of candidates) {
+    if (existsSync(join(dir, "inter-medium.ttf"))) return dir
+  }
+  throw new Error(`Could not find font files. Searched: ${candidates.join(", ")}`)
+}
+
+const fontsDir = findFontsDir()
+const interData = readFileSync(join(fontsDir, "inter-medium.ttf"))
+const geistData = readFileSync(join(fontsDir, "geist-medium.ttf"))
+const geistMonoData = readFileSync(join(fontsDir, "geist-mono-medium.ttf"))
+
+type BadgeFont = "inter" | "geist" | "geist-mono"
+
+const FONT_CONFIG: Record<BadgeFont, { name: string; data: Buffer }> = {
+  inter: { name: "Inter", data: interData },
+  geist: { name: "Geist", data: geistData },
+  "geist-mono": { name: "Geist Mono", data: geistMonoData },
+}
+
+function getFonts(font: BadgeFont = "inter") {
+  const f = FONT_CONFIG[font] ?? FONT_CONFIG.inter
+  return [{ name: f.name, data: f.data, weight: 500 as const, style: "normal" as const }]
+}
+
+// ---------------------------------------------------------------------------
+// Color utilities (same as render.tsx)
+// ---------------------------------------------------------------------------
+
+function luminance(hex: string): number {
+  const h = hex.replace("#", "")
+  const r = parseInt(h.substring(0, 2), 16)
+  const g = parseInt(h.substring(2, 4), 16)
+  const b = parseInt(h.substring(4, 6), 16)
+  if (isNaN(r) || isNaN(g) || isNaN(b)) return 0
+  return (0.299 * r + 0.587 * g + 0.114 * b) / 255
+}
+
+function rgba(hex: string, opacity: number): string {
+  if (opacity >= 1) return hex
+  if (hex === "transparent") return "transparent"
+  const h = hex.replace("#", "")
+  const r = parseInt(h.substring(0, 2), 16)
+  const g = parseInt(h.substring(2, 4), 16)
+  const b = parseInt(h.substring(4, 6), 16)
+  if (isNaN(r) || isNaN(g) || isNaN(b)) return hex
+  return `rgba(${r},${g},${b},${opacity})`
+}
+
+// ---------------------------------------------------------------------------
+// Segment — one badge cell in the group
+// ---------------------------------------------------------------------------
+
+export interface GroupSegment {
+  label: string
+  value: string
+  icon?: string
+  iconPaths?: string[]
+  iconViewBox?: string
+  iconFillRule?: string
+  iconFill?: string
+  iconIsStroke?: boolean
+  iconStrokeWidth?: number
+  iconStrokeLinecap?: string
+  iconStrokeLinejoin?: string
+  iconRotation?: number
+  /** Override brand color for this segment (hex without #). */
+  brandColor?: string
+  /** Override status color for this segment. */
+  statusColor?: string
+  /** Show status dot. */
+  statusDot?: boolean
+}
+
+export interface GroupConfig {
+  segments: GroupSegment[]
+  style: BadgeConfig["style"]
+  size?: BadgeConfig["size"]
+  mode?: "light" | "dark"
+  font?: BadgeFont
+  hasThemeOverride?: boolean
+  colors: BadgeConfig["colors"]
+}
+
+// ---------------------------------------------------------------------------
+// Resolve a segment into renderable values
+// ---------------------------------------------------------------------------
+
+interface ResolvedSegment {
+  label: string
+  value: string
+  fontFamily: string
+  height: number
+  paddingX: number
+  fontSize: number
+  gap: number
+  iconSize: number
+  labelGap: number
+  bg: string | undefined
+  fg: string
+  labelFg: string
+  iconColor: string
+  border: string | undefined
+  dotColor: string | undefined
+  dotSize: number
+  icon?: string
+  iconPaths?: string[]
+  iconViewBox?: string
+  iconFillRule?: string
+  iconFill?: string
+  iconIsStroke: boolean
+  iconStrokeWidth: number
+  iconStrokeLinecap?: string
+  iconStrokeLinejoin?: string
+  iconRotation?: number
+}
+
+function resolveSegment(
+  seg: GroupSegment,
+  config: GroupConfig,
+): ResolvedSegment {
+  const modeColors = config.mode === "light" ? lightMode : darkMode
+  const bs = getButtonStyle(config.style ?? "default", modeColors, seg.brandColor)
+  const bz = getButtonSize(config.size ?? "sm")
+  const font = config.font ?? "inter"
+  const fontFamily = FONT_CONFIG[font]?.name ?? FONT_CONFIG.inter.name
+  const labelOpacity = 0.7
+
+  const isFilled = bs.bg !== "transparent"
+  const hasTheme = !!config.hasThemeOverride
+
+  let bg: string | undefined
+  let fg: string
+  let labelFgBase: string
+  let border: string | undefined = bs.border
+
+  if (isFilled && hasTheme) {
+    bg = config.colors.labelBg
+    fg = config.colors.valueFg
+    labelFgBase = config.colors.labelFg
+  } else if (isFilled) {
+    bg = bs.bg
+    fg = bs.fg
+    labelFgBase = bs.fg
+  } else {
+    bg = undefined
+    fg = bs.fg
+    labelFgBase = bs.fg
+  }
+
+  const finalValueColor = seg.statusDot && seg.statusColor ? seg.statusColor : fg
+  const finalLabelColor = seg.statusDot ? labelFgBase : rgba(labelFgBase, labelOpacity)
+  const finalIconColor = rgba(labelFgBase, Math.min(labelOpacity + 0.15, 1))
+
+  const dotColor = seg.statusDot && seg.statusColor ? seg.statusColor : undefined
+  const dotSize = Math.round(bz.fontSize * 0.5)
+
+  return {
+    label: seg.label,
+    value: seg.value,
+    fontFamily,
+    height: bz.height,
+    paddingX: bz.paddingX,
+    fontSize: bz.fontSize,
+    gap: bz.gap,
+    iconSize: bz.iconSize,
+    labelGap: bz.gap,
+    bg,
+    fg: finalValueColor,
+    labelFg: finalLabelColor,
+    iconColor: finalIconColor,
+    border,
+    dotColor,
+    dotSize,
+    icon: seg.icon,
+    iconPaths: seg.iconPaths,
+    iconViewBox: seg.iconViewBox,
+    iconFillRule: seg.iconFillRule,
+    iconFill: seg.iconFill,
+    iconIsStroke: !!seg.iconIsStroke,
+    iconStrokeWidth: seg.iconStrokeWidth ?? 2,
+    iconStrokeLinecap: seg.iconStrokeLinecap,
+    iconStrokeLinejoin: seg.iconStrokeLinejoin,
+    iconRotation: seg.iconRotation,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Icon element (same as render.tsx)
+// ---------------------------------------------------------------------------
+
+function SegmentIcon({ s }: { s: ResolvedSegment }) {
+  if (!s.icon) return null
+  const vb = s.iconViewBox || "0 0 16 16"
+  const color = s.iconFill || s.iconColor
+  const [, , vbW, vbH] = vb.split(" ").map(Number)
+  const aspect = vbW && vbH ? vbW / vbH : 1
+  const iconH = s.iconSize
+  const iconW = Math.round(s.iconSize * Math.min(aspect, 2.5))
+
+  const rotTransform = s.iconRotation
+    ? `rotate(${s.iconRotation}, ${vbW / 2}, ${vbH / 2})`
+    : undefined
+
+  if (s.iconIsStroke) {
+    const paths = s.iconPaths && s.iconPaths.length > 0 ? s.iconPaths : [s.icon]
+    const pathEls = paths.map((d, i) => (
+      <path
+        key={i}
+        d={d}
+        fill="none"
+        stroke={color}
+        strokeWidth={s.iconStrokeWidth}
+        strokeLinecap={s.iconStrokeLinecap as "round" | "butt" | "square" | undefined}
+        strokeLinejoin={s.iconStrokeLinejoin as "round" | "miter" | "bevel" | undefined}
+      />
+    ))
+    return (
+      <svg viewBox={vb} width={iconW} height={iconH} style={{ flexShrink: 0 }}>
+        {rotTransform ? <g transform={rotTransform}>{pathEls}</g> : pathEls}
+      </svg>
+    )
+  }
+
+  const fr = s.iconFillRule as "nonzero" | "evenodd" | undefined
+  const hasPaths = s.iconPaths && s.iconPaths.length > 0
+  const pathEls = hasPaths
+    ? s.iconPaths!.map((d, i) => <path key={i} fill={color} d={d} fillRule={fr} />)
+    : <path fill={color} d={s.icon} fillRule={fr} />
+
+  return (
+    <svg viewBox={vb} width={iconW} height={iconH} style={{ flexShrink: 0 }}>
+      {rotTransform
+        ? <g transform={rotTransform}>{pathEls}</g>
+        : pathEls
+      }
+    </svg>
+  )
+}
+
+const textStyle = { lineHeight: 1 } as const
+
+// ---------------------------------------------------------------------------
+// Status dot
+// ---------------------------------------------------------------------------
+
+function DotEl({ s }: { s: ResolvedSegment }) {
+  if (!s.dotColor) return null
+  return (
+    <>
+      <div style={{
+        width: s.dotSize,
+        height: s.dotSize,
+        borderRadius: "50%",
+        backgroundColor: s.dotColor,
+        flexShrink: 0,
+      }} />
+      <div style={{ width: s.gap }} />
+    </>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Render the group
+// ---------------------------------------------------------------------------
+
+function renderGroup(segments: ResolvedSegment[], borderRadius: number): React.ReactElement {
+  const count = segments.length
+  if (count === 0) return <div />
+
+  const height = segments[0].height
+  const modeColors = segments[0].bg ? undefined : segments[0].border
+  // Separator color: use the border color, or a subtle divider
+  const sepColor = segments[0].border || rgba(segments[0].fg, 0.15)
+
+  return (
+    <div style={{
+      display: "flex",
+      alignItems: "center",
+      height,
+      borderRadius,
+      overflow: "hidden",
+      ...(segments[0].border ? { border: `1px solid ${segments[0].border}` } : {}),
+    }}>
+      {segments.map((s, i) => {
+        const isFirst = i === 0
+        const isLast = i === count - 1
+
+        return (
+          <div key={i} style={{ display: "flex", alignItems: "center" }}>
+            {/* Separator line between segments */}
+            {!isFirst && (
+              <div style={{
+                width: 1,
+                height,
+                backgroundColor: sepColor,
+                flexShrink: 0,
+              }} />
+            )}
+            {/* Segment content */}
+            <div style={{
+              display: "flex",
+              alignItems: "center",
+              height,
+              paddingLeft: s.paddingX,
+              paddingRight: s.paddingX,
+              fontFamily: s.fontFamily,
+              fontSize: s.fontSize,
+              fontWeight: 500,
+              ...(s.bg ? { backgroundColor: s.bg } : {}),
+            }}>
+              <DotEl s={s} />
+              <SegmentIcon s={s} />
+              {s.icon && <div style={{ width: s.gap }} />}
+              {s.label && (
+                <>
+                  <span style={{ color: s.labelFg, ...textStyle }}>{s.label}</span>
+                  <div style={{ width: s.labelGap }} />
+                </>
+              )}
+              <span style={{ color: s.fg, ...textStyle }}>{s.value}</span>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function renderBadgeGroup(config: GroupConfig): Promise<string> {
+  const resolved = config.segments.map(seg => resolveSegment(seg, config))
+  if (resolved.length === 0) {
+    return "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"0\" height=\"0\"/>"
+  }
+
+  const borderRadius = 6
+  const height = resolved[0].height
+  const el = renderGroup(resolved, borderRadius)
+  const fonts = getFonts(config.font)
+  const raw = await satori(el, { height, fonts })
+
+  // Optimize
+  try {
+    const result = optimize(raw, {
+      multipass: true,
+      plugins: [
+        {
+          name: "preset-default",
+          params: {
+            overrides: {
+              cleanupIds: false,
+              mergePaths: false,
+              collapseGroups: false,
+            },
+          },
+        },
+        {
+          name: "convertPathData",
+          params: { floatPrecision: 1, forceAbsolutePath: true },
+        },
+      ],
+    })
+    return result.data
+  } catch {
+    return raw
+  }
+}

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -7,6 +7,7 @@
  */
 
 import { renderBadge, renderErrorBadge } from "./badges/render"
+import { renderBadgeGroup, type GroupSegment, type GroupConfig } from "./badges/render-group"
 import { resolveTheme, applyColorOverrides, statusColors } from "./badges/themes"
 import { getSimpleIcon } from "./badges/simple-icons"
 import { getProviderBrandColor } from "./badges/brand-colors"
@@ -1346,6 +1347,212 @@ function getDefaultLogoSlug(segments: string[]): { simpleIcon?: string; reactIco
 }
 
 /**
+ * Handle a badge group request.
+ *
+ * URL format: /group/{badge1}+{badge2}+{badge3}.svg
+ * Each badge path is a normal badge endpoint (e.g. npm/react, github/stars/vercel/next.js).
+ * The + delimiter separates badge paths within the group.
+ * Query params apply globally to all segments.
+ */
+async function handleBadgeGroup(
+  cleanSegments: string[],
+  searchParams: URLSearchParams,
+  format: Format,
+  options?: BadgeRequestOptions,
+): Promise<Response> {
+  // Reconstruct the raw path after "group/" and split on "+"
+  const rawPath = cleanSegments.slice(1).join("/")
+  const badgePaths = rawPath.split("+").map(p => p.trim()).filter(Boolean)
+
+  if (badgePaths.length === 0) {
+    if (format === "svg") {
+      return new Response(await renderErrorBadge("group", "no badges specified"), {
+        headers: { "Content-Type": "image/svg+xml", ...CACHE_HEADERS },
+      })
+    }
+    return Response.json({ error: "no badges specified" }, { status: 400 })
+  }
+
+  // JSON: return array of badge data
+  if (format === "json") {
+    const results = await Promise.all(
+      badgePaths.map(async (bp) => {
+        const segs = bp.split("/").filter(Boolean)
+        const data = await fetchBadgeData(segs, searchParams)
+        return data || { label: segs[0] || "error", value: "not found" }
+      })
+    )
+    return Response.json(results, { headers: CACHE_HEADERS })
+  }
+
+  // SVG/PNG: resolve each segment
+  const style = (searchParams.get("style") || searchParams.get("variant") || "default") as BadgeStyle
+  const size = (searchParams.get("size") || undefined) as BadgeSize | undefined
+  const mode = (searchParams.get("mode") === "light" ? "light" : "dark") as "light" | "dark"
+  const theme = searchParams.get("theme") ?? undefined
+  const fontParam = searchParams.get("font") ?? undefined
+  const font = (fontParam && ["inter", "geist", "geist-mono"].includes(fontParam) ? fontParam : undefined) as GroupConfig["font"]
+  const logoColor = searchParams.get("logoColor") ?? undefined
+
+  const hasThemeOverride = !!(theme || searchParams.get("color") || searchParams.get("labelColor"))
+  let colors = resolveTheme(theme)
+  const colorOverride = searchParams.get("color") ?? undefined
+  const labelColorOverride = searchParams.get("labelColor") ?? undefined
+  colors = applyColorOverrides(colors, { color: colorOverride, labelColor: labelColorOverride })
+
+  // Fetch all badge data in parallel
+  const allData = await Promise.all(
+    badgePaths.map(async (bp) => {
+      const segs = bp.split("/").filter(Boolean)
+      const data = await fetchBadgeData(segs, searchParams)
+      return { segs, data }
+    })
+  )
+
+  // Resolve each segment with its icon
+  const segments: GroupSegment[] = await Promise.all(
+    allData.map(async ({ segs, data }) => {
+      const badgeData = data || { label: segs[0] || "error", value: "not found" }
+
+      // Resolve icon for this segment
+      let iconPath: string | undefined
+      let iconPaths: string[] | undefined
+      let iconViewBox: string | undefined
+      let iconFillRule: string | undefined
+      let iconFill: string | undefined
+      let iconIsStroke: boolean | undefined
+      let iconStrokeWidth: number | undefined
+      let iconStrokeLinecap: string | undefined
+      let iconStrokeLinejoin: string | undefined
+      let iconRotation: number | undefined
+      let brandColor: string | undefined
+
+      const provider = segs[0]
+      const providerBrand = provider ? getProviderBrandColor(provider) : undefined
+
+      // Use default provider icon
+      const defaultLogo = getDefaultLogoSlug(segs)
+      if (defaultLogo) {
+        const sources = [
+          defaultLogo.simpleIcon,
+          defaultLogo.reactIcon ? `ri:${defaultLogo.reactIcon}` : null,
+        ].filter(Boolean) as string[]
+
+        for (const source of sources) {
+          const si = await getSimpleIcon(source, logoColor)
+          if (si) {
+            iconPath = si.icon.path
+            iconPaths = si.icon.paths
+            iconViewBox = si.icon.viewBox
+            iconFillRule = si.icon.fillRule
+            iconIsStroke = si.icon.isStroke
+            iconStrokeWidth = si.icon.strokeWidth
+            iconStrokeLinecap = si.icon.strokeLinecap
+            iconStrokeLinejoin = si.icon.strokeLinejoin
+            iconRotation = si.icon.rotation
+            if (si.defaultColor && si.defaultColor !== "currentColor") {
+              brandColor = si.defaultColor
+            }
+            break
+          }
+        }
+      }
+
+      if (!brandColor && providerBrand) brandColor = providerBrand
+
+      // For branded variant, pick contrast-aware icon color
+      if (style === "branded" && !logoColor) {
+        iconFill = brandedFg(brandColor)
+      }
+
+      const statusColor = badgeData.color && statusColors[badgeData.color]
+        ? statusColors[badgeData.color]
+        : undefined
+
+      return {
+        label: searchParams.get("label") || badgeData.label,
+        value: badgeData.value,
+        icon: iconPath,
+        iconPaths,
+        iconViewBox,
+        iconFillRule,
+        iconFill,
+        iconIsStroke,
+        iconStrokeWidth,
+        iconStrokeLinecap,
+        iconStrokeLinejoin,
+        iconRotation,
+        brandColor,
+        statusColor,
+        statusDot: !!statusColor,
+      } satisfies GroupSegment
+    })
+  )
+
+  const groupConfig: GroupConfig = {
+    segments,
+    style,
+    size,
+    mode,
+    font,
+    hasThemeOverride,
+    colors,
+  }
+
+  const svg = await renderBadgeGroup(groupConfig)
+
+  if (options?.onTrack) {
+    void options.onTrack({
+      name: "badge_group_rendered",
+      data: {
+        count: segments.length,
+        format,
+        style,
+        size: size ?? "sm",
+        mode,
+        font: font ?? "inter",
+      },
+    })
+  }
+
+  // PNG response
+  if (format === "png") {
+    const { Resvg, initWasm } = await import("@resvg/resvg-wasm")
+    try {
+      let wasmLoaded = false
+      if (typeof process !== "undefined" && process.env.NODE_ENV === "production") {
+        try {
+          const fs = await import("node:fs")
+          const path = await import("node:path")
+          const candidates = [
+            path.join(process.cwd(), "node_modules", "@resvg", "resvg-wasm", "index_bg.wasm"),
+          ]
+          for (const p of candidates) {
+            if (fs.existsSync(p)) {
+              await initWasm(fs.readFileSync(p))
+              wasmLoaded = true
+              break
+            }
+          }
+        } catch { /* fs not available or file not found */ }
+      }
+      if (!wasmLoaded) {
+        await initWasm(fetch("https://unpkg.com/@resvg/resvg-wasm/index_bg.wasm"))
+      }
+    } catch { /* already initialized */ }
+    const resvg = new Resvg(svg)
+    const png = resvg.render().asPng()
+    return new Response(Buffer.from(png), {
+      headers: { "Content-Type": "image/png", ...CACHE_HEADERS },
+    })
+  }
+
+  return new Response(svg, {
+    headers: { "Content-Type": "image/svg+xml", ...CACHE_HEADERS },
+  })
+}
+
+/**
  * Handle a badge GET request.
  *
  * @param request - The incoming request
@@ -1370,6 +1577,14 @@ export async function handleBadgeGET(
       })
     }
     return Response.json({ error: "invalid url" }, { status: 400 })
+  }
+
+  // ---------------------------------------------------------------------------
+  // Badge group: /group/{badge1}+{badge2}+{badge3}.svg
+  // Renders multiple badges joined in a single SVG like a shadcn ButtonGroup.
+  // ---------------------------------------------------------------------------
+  if (cleanSegments[0] === "group") {
+    return handleBadgeGroup(cleanSegments, searchParams, format, options)
   }
 
   // Fetch badge data from provider

--- a/packages/web/app/showcase/showcase-client.tsx
+++ b/packages/web/app/showcase/showcase-client.tsx
@@ -7,7 +7,8 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
 import { ShowcaseSubmitDialog } from "@/components/showcase-submit-dialog"
-import { featuredBadges, categories } from "@/lib/showcase-data"
+import { featuredBadges, categories, groupShowcaseItems } from "@/lib/showcase-data"
+import { GroupShowcase } from "@/components/group-showcase"
 
 const ALL_CATEGORY_NAMES = ["All", ...categories.map((c) => c.name)]
 const totalIconCount = categories.reduce((sum, c) => sum + c.icons.length, 0)
@@ -62,6 +63,15 @@ export default function ShowcasePage() {
               <BadgeCard key={`featured-${badge.badgePath}-${badge.title}`} badge={badge} />
             ))}
           </div>
+        </div>
+
+        {/* Badge Groups — bento grid */}
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-semibold tracking-wide text-muted-foreground uppercase">Badge Groups</h2>
+            <a href="/docs/badges/group" className="text-xs text-muted-foreground hover:text-foreground transition-colors">docs →</a>
+          </div>
+          <GroupShowcase items={groupShowcaseItems} />
         </div>
 
         <div className="relative">

--- a/packages/web/components/badge-group-modal.tsx
+++ b/packages/web/components/badge-group-modal.tsx
@@ -1,0 +1,347 @@
+"use client"
+
+import { useState, useCallback, useEffect, useMemo } from "react"
+import { Copy, Check, ExternalLink, Plus, Trash2, GripVertical } from "lucide-react"
+import { useBadgeMode } from "@/lib/use-badge-mode"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+interface BadgeGroupModalProps {
+  title: string
+  description?: string
+  badgePath: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const VARIANTS = ["default", "secondary", "outline", "ghost", "destructive", "branded"]
+const SIZES = ["xs", "sm", "default", "lg"]
+const THEMES = ["_none", "zinc", "slate", "blue", "green", "rose", "orange", "violet", "purple", "cyan", "emerald"]
+const MODES = ["dark", "light"]
+
+type OutputFormat = "markdown" | "url" | "html" | "rst" | "asciidoc"
+
+/** Parse a group badge path into individual segment paths. */
+function parseGroupPath(badgePath: string): { segments: string[]; variant: string; size: string; theme: string; mode: string } {
+  // Remove /group/ prefix, strip extension, extract query
+  let path = badgePath
+  const qIdx = path.indexOf("?")
+  let query = ""
+  if (qIdx !== -1) {
+    query = path.slice(qIdx)
+    path = path.slice(0, qIdx)
+  }
+
+  // Strip /group/ and .svg/.png
+  path = path.replace(/^\/group\//, "").replace(/\.(svg|png|json)$/, "")
+
+  const segments = path.split("+").filter(Boolean)
+
+  // Parse query params
+  const params = new URLSearchParams(query)
+
+  return {
+    segments,
+    variant: params.get("variant") ?? "default",
+    size: params.get("size") ?? "sm",
+    theme: params.get("theme") ?? "_none",
+    mode: params.get("mode") ?? "dark",
+  }
+}
+
+/** Build a group badge path from segments and options. */
+function buildGroupPath(
+  segments: string[],
+  opts: { variant: string; size: string; theme: string; mode: string },
+): string {
+  if (segments.length === 0) return "/group/badge/empty.svg"
+
+  const joined = segments.join("+")
+  const params = new URLSearchParams()
+  if (opts.variant !== "default") params.set("variant", opts.variant)
+  if (opts.size !== "sm") params.set("size", opts.size)
+  if (opts.theme !== "_none") params.set("theme", opts.theme)
+  if (opts.mode !== "dark") params.set("mode", opts.mode)
+
+  const qs = params.toString()
+  return `/group/${joined}.svg${qs ? `?${qs}` : ""}`
+}
+
+export function BadgeGroupModal({
+  title,
+  description,
+  badgePath,
+  open,
+  onOpenChange,
+}: BadgeGroupModalProps) {
+  const parsed = useMemo(() => parseGroupPath(badgePath), [badgePath])
+
+  const [segments, setSegments] = useState<string[]>(parsed.segments)
+  const [variant, setVariant] = useState(parsed.variant)
+  const [size, setSize] = useState(parsed.size)
+  const [theme, setTheme] = useState(parsed.theme)
+  const { mode: siteMode } = useBadgeMode()
+  const [mode, setMode] = useState(parsed.mode || siteMode)
+  const [baseUrl, setBaseUrl] = useState("https://shieldcn.dev")
+  const [outputFormat, setOutputFormat] = useState<OutputFormat>("markdown")
+  const [copied, setCopied] = useState(false)
+  const [newSegment, setNewSegment] = useState("")
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => { setMounted(true) }, [])
+
+  useEffect(() => {
+    setBaseUrl(window.location.origin)
+  }, [])
+
+  // Reset when opening with a different badge
+  useEffect(() => {
+    if (open) {
+      const p = parseGroupPath(badgePath)
+      setSegments(p.segments)
+      setVariant(p.variant)
+      setSize(p.size)
+      setTheme(p.theme)
+      setMode(p.mode || siteMode)
+    }
+  }, [badgePath, open, siteMode])
+
+  const resolvedPath = useMemo(
+    () => buildGroupPath(segments, { variant, size, theme, mode }),
+    [segments, variant, size, theme, mode],
+  )
+
+  // For <img src>, encode + as %2B so the browser doesn't treat it as a space
+  const resolvedPathEncoded = resolvedPath.replace(/\+/g, "%2B")
+
+  const fullUrl = `${baseUrl}${resolvedPath}`
+
+  const formattedOutput = useMemo(() => {
+    switch (outputFormat) {
+      case "markdown": return `![${title}](${fullUrl})`
+      case "url": return fullUrl
+      case "html": return `<img alt="${title}" src="${fullUrl}">`
+      case "rst": return `.. image:: ${fullUrl}\n   :alt: ${title}`
+      case "asciidoc": return `image:${fullUrl}[${title}]`
+    }
+  }, [outputFormat, fullUrl, title])
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(formattedOutput)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }, [formattedOutput])
+
+  const addSegment = useCallback(() => {
+    const trimmed = newSegment.trim().replace(/^\//, "").replace(/\.(svg|png|json)$/, "")
+    if (!trimmed) return
+    setSegments(prev => [...prev, trimmed])
+    setNewSegment("")
+  }, [newSegment])
+
+  const removeSegment = useCallback((index: number) => {
+    setSegments(prev => prev.filter((_, i) => i !== index))
+  }, [])
+
+  const moveSegment = useCallback((from: number, to: number) => {
+    setSegments(prev => {
+      const next = [...prev]
+      const [item] = next.splice(from, 1)
+      next.splice(to, 0, item)
+      return next
+    })
+  }, [])
+
+  const sizeHeight = { xs: "h-6", sm: "h-8", default: "h-9", lg: "h-10" }[size] || "h-8"
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-full max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
+            {description ?? "Customize this badge group — add, remove, or reorder segments."}
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Preview */}
+        <div
+          className="flex justify-center overflow-x-auto rounded-lg py-6"
+          style={{ backgroundColor: mode === "light" ? "#f4f4f5" : "#101012" }}
+        >
+          {mounted && segments.length > 0 ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              key={resolvedPath}
+              src={resolvedPathEncoded}
+              alt={title}
+              className={`max-w-full ${sizeHeight}`}
+            />
+          ) : (
+            <p className="text-xs text-muted-foreground">Add segments to preview</p>
+          )}
+        </div>
+
+        {/* Segments list */}
+        <div className="space-y-2">
+          <Label className="text-xs font-medium">Segments</Label>
+          <div className="space-y-1.5">
+            {segments.map((seg, i) => (
+              <div key={`${i}-${seg}`} className="flex items-center gap-2">
+                <div className="flex gap-0.5">
+                  <button
+                    type="button"
+                    onClick={() => i > 0 && moveSegment(i, i - 1)}
+                    disabled={i === 0}
+                    className="rounded p-0.5 text-muted-foreground transition-colors hover:text-foreground disabled:opacity-30"
+                    aria-label="Move up"
+                  >
+                    <GripVertical className="size-3" />
+                  </button>
+                </div>
+                <code className="flex-1 truncate rounded border border-border bg-muted/50 px-2 py-1.5 font-mono text-[11px]">
+                  /{seg}
+                </code>
+                <button
+                  type="button"
+                  onClick={() => removeSegment(i)}
+                  className="rounded p-1 text-muted-foreground transition-colors hover:text-destructive"
+                  aria-label="Remove segment"
+                >
+                  <Trash2 className="size-3.5" />
+                </button>
+              </div>
+            ))}
+          </div>
+
+          {/* Add segment */}
+          <div className="flex items-center gap-2">
+            <Input
+              value={newSegment}
+              onChange={(e) => setNewSegment(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && addSegment()}
+              placeholder="npm/react or github/stars/owner/repo"
+              className="h-8 flex-1 font-mono text-xs"
+            />
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8 gap-1 px-2.5"
+              onClick={addSegment}
+              disabled={!newSegment.trim()}
+            >
+              <Plus className="size-3.5" />
+              Add
+            </Button>
+          </div>
+        </div>
+
+        {/* Style controls */}
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Control label="Variant" value={variant} onValueChange={setVariant} options={VARIANTS} />
+          <Control label="Size" value={size} onValueChange={setSize} options={SIZES} />
+          <Control label="Theme" value={theme} onValueChange={setTheme} options={THEMES} />
+          <Control label="Mode" value={mode} onValueChange={setMode} options={MODES} />
+        </div>
+
+        {/* Copy output */}
+        <div className="space-y-2">
+          <Label className="text-xs font-medium">Copy badge group</Label>
+          <div className="flex flex-wrap gap-1.5">
+            {(["markdown", "url", "html", "rst", "asciidoc"] as OutputFormat[]).map((format) => (
+              <button
+                key={format}
+                onClick={() => setOutputFormat(format)}
+                className={`rounded-md border px-3 py-1.5 text-xs transition-colors ${
+                  outputFormat === format
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-border bg-background text-muted-foreground hover:bg-muted hover:text-foreground"
+                }`}
+              >
+                {format}
+              </button>
+            ))}
+          </div>
+
+          <div className="group relative">
+            <pre className="break-all whitespace-pre-wrap rounded-md border border-border bg-muted/50 p-3 pr-10 font-mono text-xs">
+              {formattedOutput}
+            </pre>
+            <Button
+              variant="outline"
+              size="icon-xs"
+              onClick={handleCopy}
+              className="absolute right-2 top-2 opacity-0 transition-opacity group-hover:opacity-100"
+            >
+              {copied ? <Check className="size-3 text-green-500" /> : <Copy className="size-3" />}
+            </Button>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between border-t pt-3">
+          <p className="text-[11px] text-muted-foreground">badge group · {segments.length} segment{segments.length !== 1 ? "s" : ""}</p>
+          <div className="flex items-center gap-2">
+            <Button variant="ghost" size="sm" className="h-7 gap-1 text-xs" asChild>
+              <a href="/docs/badges/group">
+                <ExternalLink className="size-3" />
+                Docs
+              </a>
+            </Button>
+            <Button variant="ghost" size="sm" className="h-7 gap-1 text-xs" asChild>
+              <a href={resolvedPath} target="_blank" rel="noopener noreferrer">
+                <ExternalLink className="size-3" />
+                Open
+              </a>
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function Control({
+  label,
+  value,
+  onValueChange,
+  options,
+}: {
+  label: string
+  value: string
+  onValueChange: (value: string) => void
+  options: string[]
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-[11px] text-muted-foreground">{label}</Label>
+      <Select value={value} onValueChange={onValueChange}>
+        <SelectTrigger className="h-8 w-full text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((option) => (
+            <SelectItem key={option} value={option}>
+              {option === "_none" ? "auto" : option}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}

--- a/packages/web/components/group-showcase.tsx
+++ b/packages/web/components/group-showcase.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { BadgeGroupModal } from "@/components/badge-group-modal"
+import { useBadgeMode } from "@/lib/use-badge-mode"
+import { cn } from "@/lib/utils"
+import type { GroupShowcaseItem } from "@/lib/showcase-data"
+import { Copy } from "lucide-react"
+
+interface GroupShowcaseProps {
+  items: GroupShowcaseItem[]
+}
+
+export function GroupShowcase({ items }: GroupShowcaseProps) {
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      {items.map((item) => (
+        <GroupCard key={item.badgePath} item={item} />
+      ))}
+    </div>
+  )
+}
+
+function GroupCard({ item }: { item: GroupShowcaseItem }) {
+  const [modalOpen, setModalOpen] = useState(false)
+  const [mounted, setMounted] = useState(false)
+  const { adaptUrl } = useBadgeMode()
+
+  useEffect(() => { setMounted(true) }, [])
+
+  return (
+    <>
+      <button
+        onClick={() => setModalOpen(true)}
+        className={cn(
+          "group relative flex cursor-pointer flex-col items-center justify-center gap-3 rounded-lg border border-border bg-card p-5 text-left transition-all duration-200 hover:border-primary/40 hover:shadow-md hover:shadow-primary/5 active:scale-[0.99]",
+          item.span === 2 ? "sm:col-span-2" : "",
+        )}
+        aria-label={`${item.title} badge group`}
+      >
+        {/* Badge image */}
+        <div className="flex w-full items-center justify-center overflow-x-auto py-1">
+          {mounted ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={adaptUrl(item.badgePath)}
+              alt={item.title}
+              className="inline-block h-8 max-w-full"
+              loading="lazy"
+            />
+          ) : (
+            <div className="h-8" />
+          )}
+        </div>
+
+        {/* Label */}
+        <div className="w-full text-center">
+          <p className="text-xs font-medium">{item.title}</p>
+          <p className="mt-0.5 text-[10px] text-muted-foreground">{item.description}</p>
+        </div>
+
+        {/* Hover overlay */}
+        <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-1 rounded-lg bg-background/95 opacity-0 backdrop-blur-sm transition-opacity duration-150 group-hover:pointer-events-auto group-hover:opacity-100">
+          <Copy className="size-4 text-primary" />
+          <span className="text-xs font-semibold text-primary">Customize group</span>
+          <span className="text-[10px] text-muted-foreground">Click to edit &amp; copy</span>
+        </div>
+      </button>
+
+      <BadgeGroupModal
+        title={item.title}
+        description={item.description}
+        badgePath={item.badgePath}
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+      />
+    </>
+  )
+}

--- a/packages/web/components/sidebar.tsx
+++ b/packages/web/components/sidebar.tsx
@@ -56,6 +56,7 @@ const docsNav: NavGroup[] = [
     title: "Badges",
     alwaysOpen: true,
     items: [
+      { title: "Badge Group", href: "/docs/badges/group" },
       { title: "Static Badge", href: "/docs/badges/static" },
       { title: "Dynamic JSON", href: "/docs/badges/dynamic-json" },
       { title: "HTTPS Endpoint", href: "/docs/badges/https-endpoint" },

--- a/packages/web/components/site-announcement.tsx
+++ b/packages/web/components/site-announcement.tsx
@@ -11,8 +11,8 @@ export function SiteAnnouncement() {
     <Announcement>
       <AnnouncementBadge>New</AnnouncementBadge>
       <AnnouncementContent asChild>
-        <Link href="/docs/badges/x" className="hover:underline underline-offset-4">
-          Now featuring X as a provider
+        <Link href="/docs/badges/group" className="hover:underline underline-offset-4">
+          New: Badge Groups — combine badges like a ButtonGroup
           <ArrowRight className="size-3" />
         </Link>
       </AnnouncementContent>

--- a/packages/web/content/docs/api-reference.mdx
+++ b/packages/web/content/docs/api-reference.mdx
@@ -79,6 +79,14 @@ Static badges — no API token required.
 | `/tokscale/active-days/{username}.svg` | Days with AI activity |
 | `/tokscale/stats.svg` | Global user count |
 
+### Badge Group
+
+| Endpoint | Description |
+|----------|-------------|
+| `/group/{badge1}+{badge2}+{badge3}.svg` | Multiple badges joined in one image |
+
+Join any badge paths with `+`. Query params apply to all segments. See [Badge Group docs](/docs/badges/group).
+
 ### Static
 
 | Endpoint | Description |

--- a/packages/web/content/docs/badges/group.mdx
+++ b/packages/web/content/docs/badges/group.mdx
@@ -1,0 +1,71 @@
+---
+title: Badge Group
+description: Combine multiple badges into a single joined image — like a shadcn ButtonGroup.
+badge: "/group/npm/react+github/stars/vercel/next.js.svg?variant=secondary"
+---
+
+Combine multiple badges into a single image with shared rounded edges and separator lines between segments — styled like a shadcn [ButtonGroup](https://ui.shadcn.com/docs/components/radix/button-group).
+
+<BadgePreviewGroup>
+  <BadgePreviewCard src="/group/npm/react+github/stars/vercel/next.js.svg?variant=branded" alt="badge group branded" description="Branded" />
+  <BadgePreviewCard src="/group/npm/react+github/stars/vercel/next.js.svg?variant=secondary" alt="badge group secondary" description="Secondary" />
+  <BadgePreviewCard src="/group/npm/react+github/stars/vercel/next.js.svg?variant=outline" alt="badge group outline" description="Outline" />
+  <BadgePreviewCard src="/group/npm/react+github/stars/vercel/next.js.svg" alt="badge group default" description="Default" />
+</BadgePreviewGroup>
+
+## URL format
+
+Join multiple badge paths with `+` under the `/group/` prefix:
+
+```
+/group/{badge1}+{badge2}+{badge3}.svg
+```
+
+Each segment is a normal badge endpoint path — `npm/react`, `github/stars/vercel/next.js`, etc. Query parameters apply to all segments.
+
+## Quick examples
+
+```md
+![group](https://shieldcn.dev/group/npm/react+github/stars/vercel/next.js.svg)
+
+![group](https://shieldcn.dev/group/npm/react+github/stars/vercel/next.js+github/license/vercel/next.js.svg?variant=branded)
+
+![group](https://shieldcn.dev/group/github/stars/vercel/next.js+github/forks/vercel/next.js+github/license/vercel/next.js.svg?variant=outline)
+```
+
+<BadgePreview
+  src="/group/npm/react+github/stars/vercel/next.js+github/license/vercel/next.js.svg?variant=branded"
+  alt="3-badge group"
+  description="Three badges joined — npm version, GitHub stars, and license"
+/>
+
+<BadgePreview
+  src="/group/github/stars/vercel/next.js+github/forks/vercel/next.js+github/license/vercel/next.js.svg?variant=outline"
+  alt="github group"
+  description="GitHub-only group in outline variant"
+/>
+
+<BadgePreview
+  src="/group/npm/react+github/ci/vercel/next.js.svg?variant=secondary"
+  alt="npm + ci group"
+  description="npm version paired with CI status"
+/>
+
+## How it works
+
+- Each segment fetches data from its provider independently (in parallel)
+- Icons are resolved per-segment using the provider's default icon
+- For **branded** variant, each segment uses its own provider brand color
+- The outer corners are rounded; inner edges are flat with a 1px separator line
+- All query parameters (`variant`, `size`, `mode`, `theme`, `font`) apply to every segment
+
+## Limitations
+
+- Per-segment query overrides (different variant per segment) are not supported — use query params for the whole group
+- Maximum recommended: 5 segments (beyond that the badge gets very wide)
+- `split` mode is not supported inside groups
+- `gradient` is not supported on groups
+
+## Data source
+
+Each segment fetches from its respective provider. No additional API calls.

--- a/packages/web/content/docs/badges/meta.json
+++ b/packages/web/content/docs/badges/meta.json
@@ -46,6 +46,7 @@
     "weblate",
     "modrinth",
     "tokscale",
+    "group",
     "static",
     "dynamic-json",
     "https-endpoint"

--- a/packages/web/lib/badge-builder-shared.ts
+++ b/packages/web/lib/badge-builder-shared.ts
@@ -66,6 +66,10 @@ export const BADGE_PRESETS: BadgePreset[] = [
   { label: "YouTube — subscribers", template: "/youtube/{channelId}/subscribers.svg", params: [{ key: "channelId", label: "Channel ID", placeholder: "UCsBjURrPoezykLs9EqgamOA", default: "UCsBjURrPoezykLs9EqgamOA" }], group: "Social" },
   { label: "Twitch — status", template: "/twitch/{channel}.svg", params: [{ key: "channel", label: "Channel", placeholder: "shroud", default: "shroud" }], group: "Social" },
 
+  // Groups
+  { label: "Group — npm + stars", template: "/group/npm/{package}+github/stars/{owner}/{repo}.svg", params: [{ key: "package", label: "Package", placeholder: "react", default: "react" }, { key: "owner", label: "Owner", placeholder: "vercel", default: "vercel" }, { key: "repo", label: "Repo", placeholder: "next.js", default: "next.js" }], group: "Group" },
+  { label: "Group — GitHub trio", template: "/group/github/stars/{owner}/{repo}+github/forks/{owner}/{repo}+github/license/{owner}/{repo}.svg", params: [{ key: "owner", label: "Owner", placeholder: "vercel", default: "vercel" }, { key: "repo", label: "Repo", placeholder: "next.js", default: "next.js" }], group: "Group" },
+
   // Custom
   { label: "Static badge", template: "/badge/{content}.svg", params: [{ key: "label", label: "Label", placeholder: "build", default: "build", optional: true }, { key: "value", label: "Value", placeholder: "passing", default: "passing" }, { key: "color", label: "Color (hex)", placeholder: "22c55e", default: "22c55e", optional: true }], group: "Custom", customResolver: "static" },
 ]

--- a/packages/web/lib/showcase-data.ts
+++ b/packages/web/lib/showcase-data.ts
@@ -343,6 +343,7 @@ export const categories: Category[] = [
       makeLogoBadge("langchain", "LangChain", "7FC8FF", "&variant=secondary"),
     ],
   },
+
   {
     name: "Gradients",
     description: "Gradient background badges — use ?gradient=color1,color2 or add a third value for the angle.",
@@ -414,6 +415,74 @@ export const categories: Category[] = [
     
       dynamicBadge("Kotlin", "by @itzzjustmateo", "/badge/Kotlin-7f52ff.svg?logo=kotlin", "A badge for Kotlin :D"),
     ],
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Badge Group showcase — bento grid items
+// ---------------------------------------------------------------------------
+
+export interface GroupShowcaseItem {
+  title: string
+  description: string
+  badgePath: string
+  /** Grid span: 1 = normal, 2 = wide */
+  span: 1 | 2
+}
+
+export const groupShowcaseItems: GroupShowcaseItem[] = [
+  // Wide — hero examples
+  {
+    title: "Project Overview",
+    description: "npm version + stars + license in one badge",
+    badgePath: "/group/npm/react+github/stars/vercel/next.js+github/license/vercel/next.js.svg?variant=branded",
+    span: 2,
+  },
+  {
+    title: "GitHub Health",
+    description: "Stars, forks, and open issues at a glance",
+    badgePath: "/group/github/stars/vercel/next.js+github/forks/vercel/next.js+github/open-issues/vercel/next.js.svg?variant=secondary",
+    span: 2,
+  },
+  // Normal
+  {
+    title: "Version + CI",
+    description: "Package version paired with build status",
+    badgePath: "/group/npm/react+github/ci/vercel/next.js.svg?variant=outline",
+    span: 1,
+  },
+  {
+    title: "Stars + License",
+    description: "Social proof + legal clarity",
+    badgePath: "/group/github/stars/vercel/next.js+github/license/vercel/next.js.svg?variant=branded",
+    span: 1,
+  },
+  // Wide
+  {
+    title: "Full README Row",
+    description: "Everything you'd want in a top-of-README badge bar",
+    badgePath: "/group/npm/react+github/stars/vercel/next.js+github/ci/vercel/next.js+github/license/vercel/next.js.svg?variant=secondary",
+    span: 2,
+  },
+  // Normal
+  {
+    title: "Release + Downloads",
+    description: "Latest release with download count",
+    badgePath: "/group/github/release/vercel/next.js+github/dt/vercel/next.js.svg?variant=branded",
+    span: 1,
+  },
+  {
+    title: "Outline Trio",
+    description: "Clean outline group for light READMEs",
+    badgePath: "/group/github/stars/vercel/next.js+github/forks/vercel/next.js+github/license/vercel/next.js.svg?variant=outline",
+    span: 1,
+  },
+  // Wide
+  {
+    title: "PyPI Stack",
+    description: "Python package version + downloads + license",
+    badgePath: "/group/pypi/v/requests+pypi/dm/requests+pypi/license/requests.svg?variant=branded",
+    span: 2,
   },
 ]
 

--- a/packages/web/lib/use-badge-mode.ts
+++ b/packages/web/lib/use-badge-mode.ts
@@ -26,7 +26,16 @@ export function withBadgeMode(badgePath: string, mode: "dark" | "light"): string
   // Without this, dark mode URLs are identical to the default (no param),
   // and the browser serves cached dark SVGs when switching to light.
   const separator = badgePath.includes("?") ? "&" : "?"
-  return `${badgePath}${separator}mode=${mode}`
+  let url = `${badgePath}${separator}mode=${mode}`
+
+  // Encode + as %2B in group badge paths so browsers don't treat it as a space
+  // in <img src>. The server decodes %2B back to + via URL decoding.
+  if (url.includes("/group/")) {
+    const [path, qs] = url.split("?")
+    url = path.replace(/\+/g, "%2B") + (qs ? `?${qs}` : "")
+  }
+
+  return url
 }
 
 /**


### PR DESCRIPTION
## What

Combine multiple badges into a single joined SVG image — like a [shadcn ButtonGroup](https://ui.shadcn.com/docs/components/radix/button-group). Rounded outer edges, flat inner edges, 1px separator lines.

### URL format

```
/group/{badge1}+{badge2}+{badge3}.svg
```

Each segment is a normal badge endpoint path. Query params apply to all segments.

### Screenshots

**Branded (3 segments):**

![branded](https://shieldcn.dev/group/npm/react%2Bgithub/stars/vercel/next.js%2Bgithub/license/vercel/next.js.svg?variant=branded)

**Secondary (3 segments):**

![secondary](https://shieldcn.dev/group/github/stars/vercel/next.js%2Bgithub/forks/vercel/next.js%2Bgithub/open-issues/vercel/next.js.svg?variant=secondary)

**Outline (2 segments):**

![outline](https://shieldcn.dev/group/github/stars/vercel/next.js%2Bgithub/license/vercel/next.js.svg?variant=outline)

**Full README row (4 segments):**

![full](https://shieldcn.dev/group/npm/react%2Bgithub/stars/vercel/next.js%2Bgithub/ci/vercel/next.js%2Bgithub/license/vercel/next.js.svg?variant=branded)

## Why

Users asked for a way to visually group related badges — version + stars + license as one unit. Styled after the shadcn ButtonGroup pattern.

## How

- `packages/core/src/badges/render-group.tsx` — new Satori-based renderer that lays out N badge segments in a single rounded rect
- `packages/core/src/route-handler.ts` — `handleBadgeGroup()` intercepts `/group/` prefix, fetches data for each segment in parallel, resolves icons per-segment, renders as one SVG
- `packages/web/components/badge-group-modal.tsx` — dedicated modal with segment editor (add/remove/reorder) instead of the single-badge modal
- `packages/web/components/group-showcase.tsx` — bento grid with wide/narrow cards
- `packages/web/lib/use-badge-mode.ts` — fixed `+` encoding (`%2B`) for `/group/` paths in `<img src>`
- Docs, sidebar, API reference, showcase, badge builder, README all updated

## Testing

- All three packages build clean (CLI, web, engine)
- Tested 2/3/4 segment groups across all variants
- Tested SVG, PNG, JSON output formats
- Tested `+` → `%2B` encoding for browser img rendering
- Tested group modal: add/remove/reorder segments, variant/size/mode/theme controls, copy output