### PR TITLE
fix(agent): correct Content-Signal values and markdown negotiation

### DIFF
--- a/packages/web/app/api/markdown/route.ts
+++ b/packages/web/app/api/markdown/route.ts
@@ -1,0 +1,35 @@
+/**
+ * shieldcn
+ * app/api/markdown/route.ts
+ *
+ * Serves llms.txt / llms-full.txt as text/markdown for agent content negotiation.
+ * The middleware rewrites to this route when Accept: text/markdown is detected.
+ *
+ * Query params:
+ *   ?full=1 — serve llms-full.txt instead of llms.txt
+ */
+
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+export function GET(request: Request) {
+  const url = new URL(request.url)
+  const full = url.searchParams.get("full") === "1"
+  const filename = full ? "llms-full.txt" : "llms.txt"
+
+  try {
+    const content = readFileSync(join(process.cwd(), "public", filename), "utf-8")
+
+    return new Response(content, {
+      headers: {
+        "Content-Type": "text/markdown; charset=utf-8",
+        "Cache-Control": "public, max-age=3600, s-maxage=3600",
+      },
+    })
+  } catch {
+    return new Response("# shieldcn\n\nMarkdown content not available.", {
+      status: 404,
+      headers: { "Content-Type": "text/markdown; charset=utf-8" },
+    })
+  }
+}

--- a/packages/web/app/robots.txt/route.ts
+++ b/packages/web/app/robots.txt/route.ts
@@ -21,7 +21,7 @@ Disallow: /dev/
 # Content Signals (draft-romm-aipref-contentsignals)
 # Badge images and docs are free to index and use as AI input.
 # Training on shieldcn source/content is not preferred.
-Content-Signal: ai-train=disallow, search=allow, ai-input=allow
+Content-Signal: ai-train=no, search=yes, ai-input=yes
 
 Sitemap: https://shieldcn.dev/sitemap.xml
 `

--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -26,7 +26,8 @@ export function middleware(request: NextRequest) {
   const accept = request.headers.get("accept") || ""
 
   // Markdown content negotiation:
-  // When an agent requests text/markdown on HTML pages, serve the LLM-friendly version.
+  // When an agent requests text/markdown on HTML pages, serve the LLM-friendly version
+  // via a local API route that returns proper Content-Type: text/markdown.
   // Only apply to page routes, not API/asset/badge routes.
   if (
     accept.includes("text/markdown") &&
@@ -40,13 +41,13 @@ export function middleware(request: NextRequest) {
     !pathname.endsWith(".txt") &&
     !pathname.endsWith(".xml")
   ) {
-    // Serve /llms.txt for the homepage, /llms-full.txt for any subpage
-    const markdownUrl = pathname === "/" || pathname === ""
-      ? `${SITE}/llms.txt`
-      : `${SITE}/llms-full.txt`
+    // Rewrite to local API route that serves markdown with correct Content-Type
+    const full = pathname !== "/" && pathname !== "" ? "1" : "0"
+    const rewriteUrl = request.nextUrl.clone()
+    rewriteUrl.pathname = "/api/markdown"
+    rewriteUrl.searchParams.set("full", full)
 
-    const response = NextResponse.rewrite(markdownUrl)
-    response.headers.set("Content-Type", "text/markdown")
+    const response = NextResponse.rewrite(rewriteUrl)
     response.headers.set("Link", LINK_HEADER)
     return response
   }


### PR DESCRIPTION
## What

Two fixes for the agent discovery endpoints from PR #98.

## Why

1. **Content Signals** — the draft spec uses `yes`/`no` values, not `allow`/`disallow`
2. **Markdown negotiation** — `NextResponse.rewrite()` to an external URL can't override `Content-Type`. The response was returning `text/plain` instead of `text/markdown`.

## How

- `robots.txt`: Changed `ai-train=disallow, search=allow, ai-input=allow` → `ai-train=no, search=yes, ai-input=yes`
- Added `/api/markdown` route handler that reads `llms.txt`/`llms-full.txt` and returns it with `Content-Type: text/markdown; charset=utf-8`
- Middleware now rewrites to the local `/api/markdown?full=0|1` route instead of the external URL

## Testing

```bash
# Content Signals
curl -s http://localhost:3000/robots.txt | grep Content-Signal
# → Content-Signal: ai-train=no, search=yes, ai-input=yes

# Markdown negotiation  
curl -sI -H 'Accept: text/markdown' http://localhost:3000/ | grep content-type
# → content-type: text/markdown; charset=utf-8
```