### PR TITLE
feat(builder): add link URL field and improve custom badge UX

### DIFF
--- a/packages/web/components/badge-builder-core.tsx
+++ b/packages/web/components/badge-builder-core.tsx
@@ -16,7 +16,7 @@
 "use client"
 
 import { useState, useCallback, useEffect, useRef, useMemo } from "react"
-import { RotateCcw, Code2 } from "lucide-react"
+import { RotateCcw, Code2, Link } from "lucide-react"
 import { LogoPicker } from "@/components/logo-picker"
 import { ColorSwatch } from "@/components/color-input"
 import { SvgIconUpload } from "@/components/svg-icon-upload"
@@ -37,6 +37,7 @@ import { cn } from "@/lib/utils"
 import {
   BADGE_PRESETS,
   resolveTemplate,
+  resolveDefaultLinkUrl,
   VARIANTS,
   SIZES,
   MODES,
@@ -64,7 +65,7 @@ function groupPresets(): Map<string, BadgePreset[]> {
 }
 
 const PRESET_GROUPS = groupPresets()
-const PRESET_GROUP_ORDER = ["Package", "GitHub", "Social", "Custom"]
+const PRESET_GROUP_ORDER = ["Custom", "Package", "GitHub", "Social", "Group"]
 
 /** Find a preset that matches a given path */
 function findMatchingPreset(path: string): { preset: BadgePreset; values: Record<string, string> } | null {
@@ -154,9 +155,9 @@ export function BadgeBuilderCore({
     setImgError(false)
   }, [s, onChange])
 
-  const updatePath = useCallback((preset: BadgePreset, values: Record<string, string>) => {
+  const updatePath = useCallback((preset: BadgePreset, values: Record<string, string>, extraState?: Partial<BuilderState>) => {
     const path = resolveTemplate(preset, values)
-    onChange({ ...s, path })
+    onChange({ ...s, ...extraState, path })
     setImgError(false)
   }, [s, onChange])
 
@@ -168,7 +169,9 @@ export function BadgeBuilderCore({
     const defaults: Record<string, string> = {}
     for (const p of preset.params) defaults[p.key] = p.default
     setParamValues(defaults)
-    updatePath(preset, defaults)
+    // Auto-fill link URL from preset default
+    const linkUrl = resolveDefaultLinkUrl(preset, defaults)
+    updatePath(preset, defaults, { linkUrl })
   }, [updatePath])  // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleParamChange = useCallback((key: string, value: string) => {
@@ -176,9 +179,13 @@ export function BadgeBuilderCore({
     setParamValues(next)
     if (debounceRef.current) clearTimeout(debounceRef.current)
     debounceRef.current = setTimeout(() => {
-      updatePath(selectedPreset, next)
+      // Update link URL if user hasn't customized it (still matches previous auto-filled value)
+      const prevAutoLink = resolveDefaultLinkUrl(selectedPreset, paramValues)
+      const nextAutoLink = resolveDefaultLinkUrl(selectedPreset, next)
+      const isAutoLink = !s.linkUrl || s.linkUrl === prevAutoLink
+      updatePath(selectedPreset, next, isAutoLink ? { linkUrl: nextAutoLink } : undefined)
     }, 300)
-  }, [paramValues, selectedPreset, updatePath])
+  }, [paramValues, selectedPreset, updatePath, s.linkUrl])
 
   // --- Raw path editing (advanced) ---
   const [rawPathInput, setRawPathInput] = useState(s.path)
@@ -414,7 +421,28 @@ export function BadgeBuilderCore({
 
           <div className="h-px bg-border/50" />
 
-          {/* ── Row 4: Customize — all swatches + text inputs in one flat section ── */}
+          {/* ── Row 4: Link URL ── */}
+          <div className="space-y-2">
+            <SectionLabel>Link</SectionLabel>
+            <div className="relative">
+              <Link className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground/50" />
+              <Input
+                value={s.linkUrl}
+                onChange={e => set("linkUrl", e.target.value)}
+                placeholder="https://… — where the badge links to when clicked"
+                className="h-9 pl-8 text-sm"
+              />
+            </div>
+            {s.linkUrl && (
+              <p className="text-[10px] text-muted-foreground/50">
+                Badge will be wrapped in a clickable link in Markdown/HTML output.
+              </p>
+            )}
+          </div>
+
+          <div className="h-px bg-border/50" />
+
+          {/* ── Row 5: Customize — all swatches + text inputs in one flat section ── */}
           <div className="space-y-3">
             <SectionLabel>Customize</SectionLabel>
             <div className="flex flex-wrap items-center gap-x-5 gap-y-2">

--- a/packages/web/components/badge-builder.tsx
+++ b/packages/web/components/badge-builder.tsx
@@ -26,12 +26,23 @@ import {
 
 type CopyFormat = "markdown" | "html" | "url" | "rst"
 
-function formatOutput(url: string, format: CopyFormat): string {
+function formatOutput(url: string, format: CopyFormat, linkUrl?: string): string {
+  const link = linkUrl?.trim() || ""
   switch (format) {
-    case "markdown": return `![badge](${url})`
-    case "html": return `<img alt="badge" src="${url}">`
-    case "url": return url
-    case "rst": return `.. image:: ${url}\n   :alt: badge`
+    case "markdown":
+      return link
+        ? `[![badge](${url})](${link})`
+        : `![badge](${url})`
+    case "html":
+      return link
+        ? `<a href="${link}"><img alt="badge" src="${url}"></a>`
+        : `<img alt="badge" src="${url}">`
+    case "url":
+      return url
+    case "rst":
+      return link
+        ? `.. image:: ${url}\n   :alt: badge\n   :target: ${link}`
+        : `.. image:: ${url}\n   :alt: badge`
   }
 }
 
@@ -65,7 +76,7 @@ export function BadgeBuilder() {
   }, [resolvedTheme]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const url = useMemo(() => buildBadgeUrl(s, baseUrl), [s, baseUrl])
-  const output = useMemo(() => formatOutput(url, copyFormat), [url, copyFormat])
+  const output = useMemo(() => formatOutput(url, copyFormat, s.linkUrl), [url, copyFormat, s.linkUrl])
 
   const handleCopy = useCallback(() => {
     if (!output) return

--- a/packages/web/lib/badge-builder-shared.ts
+++ b/packages/web/lib/badge-builder-shared.ts
@@ -34,45 +34,58 @@ export interface BadgePreset {
   group: string
   /** Custom path resolver (e.g. "static" for dash-separated format) */
   customResolver?: string
+  /** Default link URL template with {key} placeholders (auto-filled when preset is selected) */
+  defaultLinkUrl?: string
 }
 
 export const BADGE_PRESETS: BadgePreset[] = [
+  // Custom — first so "make a badge" users see it immediately
+  { label: "Custom badge", template: "/badge/{content}.svg", params: [{ key: "label", label: "Label", placeholder: "build", default: "build", optional: true }, { key: "value", label: "Value", placeholder: "passing", default: "passing" }, { key: "color", label: "Color (hex)", placeholder: "22c55e", default: "22c55e", optional: true }], group: "Custom", customResolver: "static" },
+
   // Package
-  { label: "npm — version", template: "/npm/{package}.svg", params: [{ key: "package", label: "Package", placeholder: "react", default: "react" }], group: "Package" },
-  { label: "npm — downloads", template: "/npm/{package}/dm.svg", params: [{ key: "package", label: "Package", placeholder: "react", default: "react" }], group: "Package" },
-  { label: "npm — license", template: "/npm/{package}/license.svg", params: [{ key: "package", label: "Package", placeholder: "react", default: "react" }], group: "Package" },
-  { label: "npm — types", template: "/npm/{package}/types.svg", params: [{ key: "package", label: "Package", placeholder: "react", default: "react" }], group: "Package" },
-  { label: "PyPI — version", template: "/pypi/{package}/v.svg", params: [{ key: "package", label: "Package", placeholder: "django", default: "django" }], group: "Package" },
-  { label: "Crates.io — version", template: "/crates/{crate}/v.svg", params: [{ key: "crate", label: "Crate", placeholder: "serde", default: "serde" }], group: "Package" },
-  { label: "JSR — score", template: "/jsr/{scope}/{package}/score.svg", params: [{ key: "scope", label: "Scope", placeholder: "@std", default: "@std" }, { key: "package", label: "Package", placeholder: "path", default: "path" }], group: "Package" },
-  { label: "Docker — pulls", template: "/docker/{namespace}/{image}/pulls.svg", params: [{ key: "namespace", label: "Namespace", placeholder: "library", default: "library" }, { key: "image", label: "Image", placeholder: "nginx", default: "nginx" }], group: "Package" },
+  { label: "npm — version", template: "/npm/{package}.svg", params: [{ key: "package", label: "Package", placeholder: "react", default: "react" }], group: "Package", defaultLinkUrl: "https://www.npmjs.com/package/{package}" },
+  { label: "npm — downloads", template: "/npm/{package}/dm.svg", params: [{ key: "package", label: "Package", placeholder: "react", default: "react" }], group: "Package", defaultLinkUrl: "https://www.npmjs.com/package/{package}" },
+  { label: "npm — license", template: "/npm/{package}/license.svg", params: [{ key: "package", label: "Package", placeholder: "react", default: "react" }], group: "Package", defaultLinkUrl: "https://www.npmjs.com/package/{package}" },
+  { label: "npm — types", template: "/npm/{package}/types.svg", params: [{ key: "package", label: "Package", placeholder: "react", default: "react" }], group: "Package", defaultLinkUrl: "https://www.npmjs.com/package/{package}" },
+  { label: "PyPI — version", template: "/pypi/{package}/v.svg", params: [{ key: "package", label: "Package", placeholder: "django", default: "django" }], group: "Package", defaultLinkUrl: "https://pypi.org/project/{package}" },
+  { label: "Crates.io — version", template: "/crates/{crate}/v.svg", params: [{ key: "crate", label: "Crate", placeholder: "serde", default: "serde" }], group: "Package", defaultLinkUrl: "https://crates.io/crates/{crate}" },
+  { label: "JSR — score", template: "/jsr/{scope}/{package}/score.svg", params: [{ key: "scope", label: "Scope", placeholder: "@std", default: "@std" }, { key: "package", label: "Package", placeholder: "path", default: "path" }], group: "Package", defaultLinkUrl: "https://jsr.io/{scope}/{package}" },
+  { label: "Docker — pulls", template: "/docker/{namespace}/{image}/pulls.svg", params: [{ key: "namespace", label: "Namespace", placeholder: "library", default: "library" }, { key: "image", label: "Image", placeholder: "nginx", default: "nginx" }], group: "Package", defaultLinkUrl: "https://hub.docker.com/r/{namespace}/{image}" },
 
   // GitHub
-  { label: "GitHub — stars", template: "/github/{owner}/{repo}/stars.svg", params: [{ key: "owner", label: "Owner", placeholder: "vercel", default: "vercel" }, { key: "repo", label: "Repo", placeholder: "next.js", default: "next.js" }], group: "GitHub" },
-  { label: "GitHub — release", template: "/github/{owner}/{repo}/release.svg", params: [{ key: "owner", label: "Owner", placeholder: "vercel", default: "vercel" }, { key: "repo", label: "Repo", placeholder: "next.js", default: "next.js" }], group: "GitHub" },
-  { label: "GitHub — CI", template: "/github/{owner}/{repo}/ci.svg", params: [{ key: "owner", label: "Owner", placeholder: "vercel", default: "vercel" }, { key: "repo", label: "Repo", placeholder: "next.js", default: "next.js" }], group: "GitHub" },
-  { label: "GitHub — license", template: "/github/{owner}/{repo}/license.svg", params: [{ key: "owner", label: "Owner", placeholder: "vercel", default: "vercel" }, { key: "repo", label: "Repo", placeholder: "next.js", default: "next.js" }], group: "GitHub" },
-  { label: "GitHub — forks", template: "/github/{owner}/{repo}/forks.svg", params: [{ key: "owner", label: "Owner", placeholder: "vercel", default: "vercel" }, { key: "repo", label: "Repo", placeholder: "next.js", default: "next.js" }], group: "GitHub" },
-  { label: "GitHub — issues", template: "/github/{owner}/{repo}/issues.svg", params: [{ key: "owner", label: "Owner", placeholder: "vercel", default: "vercel" }, { key: "repo", label: "Repo", placeholder: "next.js", default: "next.js" }], group: "GitHub" },
-  { label: "GitHub — contributors", template: "/github/{owner}/{repo}/contributors.svg", params: [{ key: "owner", label: "Owner", placeholder: "vercel", default: "vercel" }, { key: "repo", label: "Repo", placeholder: "next.js", default: "next.js" }], group: "GitHub" },
-  { label: "GitHub — last commit", template: "/github/{owner}/{repo}/last-commit.svg", params: [{ key: "owner", label: "Owner", placeholder: "vercel", default: "vercel" }, { key: "repo", label: "Repo", placeholder: "next.js", default: "next.js" }], group: "GitHub" },
-  { label: "GitHub — downloads", template: "/github/{owner}/{repo}/downloads.svg", params: [{ key: "owner", label: "Owner", placeholder: "vercel", default: "vercel" }, { key: "repo", label: "Repo", placeholder: "next.js", default: "next.js" }], group: "GitHub" },
+  { label: "GitHub — stars", template: "/github/{owner}/{repo}/stars.svg", params: [{ key: "owner", label: "Owner", placeholder: "vercel", default: "vercel" }, { key: "repo", label: "Repo", placeholder: "next.js", default: "next.js" }], group: "GitHub", defaultLinkUrl: "https://github.com/{owner}/{repo}" },
+  { label: "GitHub — release", template: "/github/{owner}/{repo}/release.svg", params: [{ key: "owner", label: "Owner", placeholder: "vercel", default: "vercel" }, { key: "repo", label: "Repo", placeholder: "next.js", default: "next.js" }], group: "GitHub", defaultLinkUrl: "https://github.com/{owner}/{repo}/releases" },
+  { label: "GitHub — CI", template: "/github/{owner}/{repo}/ci.svg", params: [{ key: "owner", label: "Owner", placeholder: "vercel", default: "vercel" }, { key: "repo", label: "Repo", placeholder: "next.js", default: "next.js" }], group: "GitHub", defaultLinkUrl: "https://github.com/{owner}/{repo}/actions" },
+  { label: "GitHub — license", template: "/github/{owner}/{repo}/license.svg", params: [{ key: "owner", label: "Owner", placeholder: "vercel", default: "vercel" }, { key: "repo", label: "Repo", placeholder: "next.js", default: "next.js" }], group: "GitHub", defaultLinkUrl: "https://github.com/{owner}/{repo}" },
+  { label: "GitHub — forks", template: "/github/{owner}/{repo}/forks.svg", params: [{ key: "owner", label: "Owner", placeholder: "vercel", default: "vercel" }, { key: "repo", label: "Repo", placeholder: "next.js", default: "next.js" }], group: "GitHub", defaultLinkUrl: "https://github.com/{owner}/{repo}/forks" },
+  { label: "GitHub — issues", template: "/github/{owner}/{repo}/issues.svg", params: [{ key: "owner", label: "Owner", placeholder: "vercel", default: "vercel" }, { key: "repo", label: "Repo", placeholder: "next.js", default: "next.js" }], group: "GitHub", defaultLinkUrl: "https://github.com/{owner}/{repo}/issues" },
+  { label: "GitHub — contributors", template: "/github/{owner}/{repo}/contributors.svg", params: [{ key: "owner", label: "Owner", placeholder: "vercel", default: "vercel" }, { key: "repo", label: "Repo", placeholder: "next.js", default: "next.js" }], group: "GitHub", defaultLinkUrl: "https://github.com/{owner}/{repo}/graphs/contributors" },
+  { label: "GitHub — last commit", template: "/github/{owner}/{repo}/last-commit.svg", params: [{ key: "owner", label: "Owner", placeholder: "vercel", default: "vercel" }, { key: "repo", label: "Repo", placeholder: "next.js", default: "next.js" }], group: "GitHub", defaultLinkUrl: "https://github.com/{owner}/{repo}/commits" },
+  { label: "GitHub — downloads", template: "/github/{owner}/{repo}/downloads.svg", params: [{ key: "owner", label: "Owner", placeholder: "vercel", default: "vercel" }, { key: "repo", label: "Repo", placeholder: "next.js", default: "next.js" }], group: "GitHub", defaultLinkUrl: "https://github.com/{owner}/{repo}/releases" },
 
   // Social
   { label: "Discord — online", template: "/discord/{serverId}.svg", params: [{ key: "serverId", label: "Server ID", placeholder: "1316199667142496307", default: "1316199667142496307" }], group: "Social" },
-  { label: "Reddit — subscribers", template: "/reddit/{subreddit}.svg", params: [{ key: "subreddit", label: "Subreddit", placeholder: "typescript", default: "typescript" }], group: "Social" },
-  { label: "X — follow", template: "/x/follow/{username}.svg", params: [{ key: "username", label: "Username", placeholder: "jal_co", default: "jal_co" }], group: "Social" },
-  { label: "X — mention", template: "/x/mention/{username}.svg", params: [{ key: "username", label: "Username", placeholder: "jal_co", default: "jal_co" }], group: "Social" },
-  { label: "YouTube — subscribers", template: "/youtube/{channelId}/subscribers.svg", params: [{ key: "channelId", label: "Channel ID", placeholder: "UCsBjURrPoezykLs9EqgamOA", default: "UCsBjURrPoezykLs9EqgamOA" }], group: "Social" },
-  { label: "Twitch — status", template: "/twitch/{channel}.svg", params: [{ key: "channel", label: "Channel", placeholder: "shroud", default: "shroud" }], group: "Social" },
+  { label: "Reddit — subscribers", template: "/reddit/{subreddit}.svg", params: [{ key: "subreddit", label: "Subreddit", placeholder: "typescript", default: "typescript" }], group: "Social", defaultLinkUrl: "https://www.reddit.com/r/{subreddit}" },
+  { label: "X — follow", template: "/x/follow/{username}.svg", params: [{ key: "username", label: "Username", placeholder: "jal_co", default: "jal_co" }], group: "Social", defaultLinkUrl: "https://x.com/{username}" },
+  { label: "X — mention", template: "/x/mention/{username}.svg", params: [{ key: "username", label: "Username", placeholder: "jal_co", default: "jal_co" }], group: "Social", defaultLinkUrl: "https://x.com/{username}" },
+  { label: "YouTube — subscribers", template: "/youtube/{channelId}/subscribers.svg", params: [{ key: "channelId", label: "Channel ID", placeholder: "UCsBjURrPoezykLs9EqgamOA", default: "UCsBjURrPoezykLs9EqgamOA" }], group: "Social", defaultLinkUrl: "https://www.youtube.com/channel/{channelId}" },
+  { label: "Twitch — status", template: "/twitch/{channel}.svg", params: [{ key: "channel", label: "Channel", placeholder: "shroud", default: "shroud" }], group: "Social", defaultLinkUrl: "https://www.twitch.tv/{channel}" },
 
   // Groups
-  { label: "Group — npm + stars", template: "/group/npm/{package}+github/stars/{owner}/{repo}.svg", params: [{ key: "package", label: "Package", placeholder: "react", default: "react" }, { key: "owner", label: "Owner", placeholder: "vercel", default: "vercel" }, { key: "repo", label: "Repo", placeholder: "next.js", default: "next.js" }], group: "Group" },
-  { label: "Group — GitHub trio", template: "/group/github/stars/{owner}/{repo}+github/forks/{owner}/{repo}+github/license/{owner}/{repo}.svg", params: [{ key: "owner", label: "Owner", placeholder: "vercel", default: "vercel" }, { key: "repo", label: "Repo", placeholder: "next.js", default: "next.js" }], group: "Group" },
-
-  // Custom
-  { label: "Static badge", template: "/badge/{content}.svg", params: [{ key: "label", label: "Label", placeholder: "build", default: "build", optional: true }, { key: "value", label: "Value", placeholder: "passing", default: "passing" }, { key: "color", label: "Color (hex)", placeholder: "22c55e", default: "22c55e", optional: true }], group: "Custom", customResolver: "static" },
+  { label: "Group — npm + stars", template: "/group/npm/{package}+github/stars/{owner}/{repo}.svg", params: [{ key: "package", label: "Package", placeholder: "react", default: "react" }, { key: "owner", label: "Owner", placeholder: "vercel", default: "vercel" }, { key: "repo", label: "Repo", placeholder: "next.js", default: "next.js" }], group: "Group", defaultLinkUrl: "https://github.com/{owner}/{repo}" },
+  { label: "Group — GitHub trio", template: "/group/github/stars/{owner}/{repo}+github/forks/{owner}/{repo}+github/license/{owner}/{repo}.svg", params: [{ key: "owner", label: "Owner", placeholder: "vercel", default: "vercel" }, { key: "repo", label: "Repo", placeholder: "next.js", default: "next.js" }], group: "Group", defaultLinkUrl: "https://github.com/{owner}/{repo}" },
 ]
+
+/** Resolve a preset's defaultLinkUrl template with parameter values */
+export function resolveDefaultLinkUrl(preset: BadgePreset, values: Record<string, string>): string {
+  if (!preset.defaultLinkUrl) return ""
+  let url = preset.defaultLinkUrl
+  for (const param of preset.params) {
+    const val = values[param.key] || param.default
+    url = url.replace(`{${param.key}}`, val)
+  }
+  return url
+}
 
 /** Resolve a preset template with parameter values */
 export function resolveTemplate(preset: BadgePreset, values: Record<string, string>): string {
@@ -136,10 +149,12 @@ export interface BuilderState {
   valueColor: string
   labelTextColor: string
   labelOpacity: string
+  /** Target URL when the badge is clicked (wraps in a link) */
+  linkUrl: string
 }
 
 export const BUILDER_DEFAULTS: BuilderState = {
-  path: "/npm/react.svg",
+  path: "/badge/build-passing-22c55e.svg",
   variant: "default",
   size: "sm",
   theme: "_none",
@@ -156,6 +171,7 @@ export const BUILDER_DEFAULTS: BuilderState = {
   valueColor: "",
   labelTextColor: "",
   labelOpacity: "",
+  linkUrl: "",
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Add a **Link URL** input to the badge builder and improve the custom badge workflow based on community feedback from Bruzzz.

### Link URL field
- New "Link" section in the builder controls with a URL input
- When a link URL is set, copy output wraps the badge in a clickable link:
  - **Markdown**: `[![badge](badge-url)](link-url)`
  - **HTML**: `<a href="link-url"><img alt="badge" src="badge-url"></a>`
  - **RST**: `.. image::` with `:target:` directive
  - **URL**: unchanged (just the badge URL)
- Smart auto-fill: selecting a preset (npm, GitHub, etc.) auto-populates the link URL with the relevant page (e.g. `https://npmjs.com/package/react`). Updates as params change. Custom edits are preserved.

### Custom badge UX improvements
- Reorder preset dropdown: **Custom** group is now first (was last)
- Rename "Static badge" → "Custom badge" for clarity
- Default builder state starts on Custom badge (was npm version)
- Add **Group** presets to dropdown (they were missing from the group order — never showed up)

## Why

Community feedback from Bruzzz:
1. No way to set a target URL when clicking on a badge — users had to manually wrap output in markdown link syntax
2. The custom badge workflow was buried — users who want to make branded badges for their README had to hunt for it
3. Builder defaulted to data badges (npm version) but many users want custom static badges first

## How

- `BuilderState` gains a `linkUrl: string` field
- `BadgePreset` gains an optional `defaultLinkUrl` template (uses same `{key}` syntax as path templates)
- New `resolveDefaultLinkUrl()` helper resolves preset link templates
- `handlePresetChange` auto-fills `linkUrl` from preset defaults
- `handleParamChange` preserves custom link URLs but updates auto-filled ones
- `formatOutput()` wraps badge in link syntax when `linkUrl` is set
- `PRESET_GROUP_ORDER` reordered: Custom, Package, GitHub, Social, Group

## Testing

1. Open landing page → builder defaults to "Custom badge"
2. Switch to npm version → link URL auto-fills to npmjs.com
3. Change package name → link URL updates
4. Manually edit link URL → changing package no longer overwrites it
5. Copy Markdown → confirm `[![badge](...)](#)` format when link is set
6. Copy HTML → confirm `<a href="..."><img ...></a>` format
7. Reset → everything clears including link URL
8. Group presets now appear in the dropdown

## Screenshots

_(UI changes — will add after Vercel preview deploys)_