### PR TITLE
fix(badges): render animated GIF at 1x to match other badges

### DIFF
--- a/packages/core/src/badges/gif.ts
+++ b/packages/core/src/badges/gif.ts
@@ -52,14 +52,19 @@ async function ensureResvg(initWasm: (input: unknown) => Promise<void>): Promise
  * @param baseSvg   The static base badge SVG (rendered once, no animation).
  * @param mode      The animation mode ("pulse" | "glow" | "shimmer").
  * @param dotColor  Resolved status-dot color (required for pulse/glow).
- * @param scale     Pixel scale factor for crisper raster output (default 2).
+ * @param scale     Pixel scale factor. Defaults to 1 so the GIF's pixel size
+ *                  matches the badge's logical size (and the PNG/SVG output) —
+ *                  in a bare `![](url)` the GIF displays at its intrinsic size,
+ *                  so anything above 1 makes it render larger than other
+ *                  badges. Raise only when the caller controls the `<img>`
+ *                  display size.
  * @returns         GIF bytes, or null if the badge can't be animated as a GIF.
  */
 export async function renderGif(
   baseSvg: string,
   mode: AnimateMode,
   dotColor: string | undefined,
-  scale = 2,
+  scale = 1,
 ): Promise<Uint8Array | null> {
   if (mode === "none") return null
 


### PR DESCRIPTION
## What

Renders animated `.gif` badges at **1x** instead of 2x, so they match the size of every other badge.

## Why

The GIF output was rendered at `scale = 2`, producing e.g. a 506×80 GIF for a badge whose SVG/PNG is 253×40. A GIF has no separate display size — in a bare `![](url)` (READMEs, npm, etc.) it shows at its **intrinsic pixel size**, so animated badges appeared **twice as large** as the SVG/PNG badges next to them.

The 2x was meant as supersampling for crispness, but since callers can't set the `<img>` display size in markdown, it just made every animated badge oversized.

## How

- Default `renderGif`'s `scale` to `1` (matches PNG output, which uses the SVG's intrinsic size).
- Bonus: file size drops too (~57KB → ~25KB for the hero badge), since there are 4x fewer pixels per frame.
- `scale` remains a parameter for callers that *do* control display size.

## Testing

- Confirmed the GIF now renders at 253×40 — identical to the SVG and PNG output for the same badge.
- Verified it still looks clean at 1x (legible text, clean inset corners, visible shimmer).
- `tsc --noEmit` passes for `@shieldcn/core`.

## Notes

Follow-up to the animated badges feature (#103). Pairs with #104 (which points the README hero at the live `.gif` endpoint) — once both land, the hero renders at the correct size.
