### PR TITLE
fix(badges): preserve icon detail by not baking scale into path data

### DIFF
--- a/packages/core/src/badges/render.tsx
+++ b/packages/core/src/badges/render.tsx
@@ -373,18 +373,26 @@ function optimizeSvg(svg: string): string {
               // Don't collapse <g> elements — rotation transforms on icon
               // groups must be preserved.
               collapseGroups: false,
+              // Round path coordinates but keep absolute commands, and DO NOT
+              // bake transforms into path data.
+              //
+              // Custom icons are positioned with a tiny scale() transform
+              // (e.g. 14/512 ≈ 0.027). If SVGO bakes that into the path coords
+              // and then rounds to 1 decimal, all curve detail collapses —
+              // detailed icons (shieldcn shield, shipperclub) render as an
+              // unrecognizable "swirl". Keeping applyTransforms:false leaves
+              // the path in its native viewBox space with the scale as a
+              // separate transform, preserving fidelity. floatPrecision:1 still
+              // compacts the large badge geometry.
+              //
+              // Stroke-based icons (Lucide, Feather) also rely on this: they
+              // join subpaths in one `d`, so absolute commands must be kept.
+              convertPathData: {
+                floatPrecision: 1,
+                applyTransforms: false,
+                forceAbsolutePath: true,
+              },
             },
-          },
-        },
-        // Round path coordinates but keep absolute commands.
-        // Stroke-based icons (Lucide, Feather) join multiple subpaths into
-        // one `d` attribute — converting M (absolute move) to m (relative)
-        // breaks them because each subpath needs absolute positioning.
-        {
-          name: "convertPathData",
-          params: {
-            floatPrecision: 1,
-            forceAbsolutePath: true,
           },
         },
       ],


### PR DESCRIPTION
## What

Stop SVGO from baking the icon's `scale()` transform into its path coordinates. `convertPathData` now runs inside the `preset-default` overrides with `applyTransforms: false`, so icon paths stay in their native viewBox space with the scale kept as a separate transform.

## Why

Custom icons are positioned with a tiny `scale()` transform (e.g. `16/512 ≈ 0.03`). SVGO was baking that into the path coordinates and then rounding to 1 decimal (`floatPrecision: 1`), which collapsed detailed icons into an unrecognizable "swirl".

Affected icons: `shieldcn` (shield), `shipperclub`. SimpleIcons and simpler custom icons (e.g. `shadcncraft`, `openpanel`) were unaffected because their geometry survives the rounding.

## How

- Moved `convertPathData` into `preset-default` overrides with `applyTransforms: false`
- Kept `floatPrecision: 1` (still compacts large badge geometry) and `forceAbsolutePath: true` (stroke-based icons like Lucide/Feather need absolute commands)

## Testing

- `pnpm validate:icons` → all 6 custom icons valid
- Typecheck clean
- Verified `shieldcn` and `shipperclub` logos render correctly at the badge `<image>` and PNG output; confirmed `react`, `openpanel`, `shadcncraft` still render correctly (no regression)

> Note: repo `lint` currently fails on `main` due to a missing `@eslint/eslintrc` dep (unrelated to this change) — surfaced separately, not fixed here.
