### PR TITLE
chore(lint): fix web eslint flat config and pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "turbo": "^2"
   },
   "lint-staged": {
-    "packages/web/**/*.{ts,tsx}": "eslint --no-warn-ignored --max-warnings 0 --config packages/web/eslint.config.mjs"
+    "packages/web/**/*.{ts,tsx}": "pnpm --filter @shieldcn/web exec eslint --no-warn-ignored --max-warnings 0"
   }
 }

--- a/packages/web/app/dev/social/page.tsx
+++ b/packages/web/app/dev/social/page.tsx
@@ -109,16 +109,6 @@ function loadSvg(svg: string): Promise<HTMLImageElement> {
   })
 }
 
-/** Read intrinsic width/height from an SVG root. */
-function svgSize(svg: string): { w: number; h: number } {
-  const w = svg.match(/<svg[^>]*\bwidth="([\d.]+)"/)?.[1]
-  const h = svg.match(/<svg[^>]*\bheight="([\d.]+)"/)?.[1]
-  if (w && h) return { w: parseFloat(w), h: parseFloat(h) }
-  const vb = svg.match(/viewBox="([\d.\s-]+)"/)?.[1]?.trim().split(/\s+/).map(Number)
-  if (vb && vb.length === 4) return { w: vb[2], h: vb[3] }
-  return { w: 0, h: 0 }
-}
-
 async function downloadGif(item: BadgeItem, mode: Bg): Promise<void> {
   try {
     const res = await fetch(buildGifUrl(item, mode))

--- a/packages/web/eslint.config.mjs
+++ b/packages/web/eslint.config.mjs
@@ -1,13 +1,5 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-});
+import nextCoreWebVitals from "eslint-config-next/core-web-vitals"
+import nextTypescript from "eslint-config-next/typescript"
 
 const eslintConfig = [
   {
@@ -17,7 +9,8 @@ const eslintConfig = [
       "next-env.d.ts",
     ],
   },
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
-];
+  ...nextCoreWebVitals,
+  ...nextTypescript,
+]
 
-export default eslintConfig;
+export default eslintConfig


### PR DESCRIPTION
## What

Fixes the web package's ESLint setup so `lint` and the pre-commit hook actually run.

## Why

Two independent breakages meant ESLint never ran:

1. **Config**: `packages/web/eslint.config.mjs` imported `FlatCompat` from `@eslint/eslintrc`, which was never a declared dependency — ESLint failed to load on every file. Even with the package present, `FlatCompat` + `next/core-web-vitals` hits a circular-structure validation error under ESLint 9 / Next 16.
2. **Hook**: `lint-staged` spawned a bare `eslint` from the repo root, where it isn't installed → `ENOENT`. The pre-commit hook silently failed on every commit touching web `.ts/.tsx`.

## How

- Import `eslint-config-next/core-web-vitals` and `eslint-config-next/typescript` directly (Next 16 ships native flat configs) and drop the `FlatCompat`/`@eslint/eslintrc` shim.
- Run lint-staged's eslint via `pnpm --filter @shieldcn/web exec` with auto-discovered config so it resolves the binary and config correctly.
- Remove an unused helper (`svgSize`) in the social composer that the now-working lint surfaced.

## Testing

- `eslint` now loads and lints (verified clean file → exit 0, file with errors → exit 1).
- Pre-commit hook ran successfully on this commit's staged files.
- Typecheck clean.

## Note (scope)

Enabling lint reveals **~74 pre-existing violations (44 errors, 30 warnings)** across the web package that the broken config was hiding (e.g. `tour.tsx`, various components). These are **intentionally left untouched** here — fixing them is a separate, larger effort (some are `react-hooks/exhaustive-deps` and React Compiler memoization errors needing real judgment).

Because lint-staged only runs on **staged** files, this does not block unrelated commits — only commits that touch an offending file. Recommend a follow-up to burn down the backlog before wiring `turbo lint` into required CI.
