### PR TITLE
feat(badges): theme-aware light/dark output via <picture>

### DIFF
--- a/packages/cli/dist/bin.js
+++ b/packages/cli/dist/bin.js
@@ -188,6 +188,7 @@ function isThemeAdaptive(badge, global) {
   const variant = badge.query.variant || (global.variant !== "default" ? global.variant : "default");
   if (!THEME_DERIVED_VARIANTS.has(variant)) return false;
   if (badge.query.color) return false;
+  if (badge.query.mode) return false;
   return true;
 }
 function badgeUrl(badge, global, modeOverride) {

--- a/packages/cli/dist/bin.js
+++ b/packages/cli/dist/bin.js
@@ -168,25 +168,52 @@ function staticBadgePath(label, message, color) {
   const enc = (s) => encodeURIComponent(encodeStaticSegment(s));
   return `/badge/${enc(label)}-${enc(message)}-${color.replace(/^#/, "")}.svg`;
 }
-function mergeQuery(badge, global) {
+function mergeQuery(badge, global, modeOverride) {
   const merged = { ...badge.query };
   if (global.variant && global.variant !== "default" && !merged.variant) merged.variant = global.variant;
   if (global.size && global.size !== "sm" && global.size !== "default" && !merged.size) merged.size = global.size;
-  if (global.mode && global.mode !== "dark" && !merged.mode) merged.mode = global.mode;
+  if (modeOverride) merged.mode = modeOverride;
+  else if (global.mode && global.mode !== "dark" && !merged.mode) merged.mode = global.mode;
   if (global.theme && !merged.theme) merged.theme = global.theme;
   return merged;
 }
-function badgeUrl(badge, global) {
-  const qs = new URLSearchParams(mergeQuery(badge, global)).toString();
+var THEME_DERIVED_VARIANTS = /* @__PURE__ */ new Set([
+  "default",
+  "secondary",
+  "outline",
+  "ghost",
+  "branded"
+]);
+function isThemeAdaptive(badge, global) {
+  const variant = badge.query.variant || (global.variant !== "default" ? global.variant : "default");
+  if (!THEME_DERIVED_VARIANTS.has(variant)) return false;
+  if (badge.query.color) return false;
+  return true;
+}
+function badgeUrl(badge, global, modeOverride) {
+  const qs = new URLSearchParams(mergeQuery(badge, global, modeOverride)).toString();
   return `${SHIELDCN_BASE}${badge.path}${qs ? `?${qs}` : ""}`;
 }
+function badgePicture(badge, global) {
+  const dark = badgeUrl(badge, global, "dark");
+  const light = badgeUrl(badge, global, "light");
+  const alt = badge.label.replace(/"/g, "&quot;");
+  const pic = `<picture><source media="(prefers-color-scheme: dark)" srcset="${dark}"><img alt="${alt}" src="${light}"></picture>`;
+  return badge.linkUrl ? `<a href="${badge.linkUrl}">${pic}</a>` : pic;
+}
 function badgeMarkdown(badge, global) {
+  if (global.themeAware && isThemeAdaptive(badge, global)) {
+    return badgePicture(badge, global);
+  }
   const url = badgeUrl(badge, global);
   const alt = badge.label.replace(/[\[\]]/g, "");
   const img = `![${alt}](${url})`;
   return badge.linkUrl ? `[${img}](${badge.linkUrl})` : img;
 }
 function badgeHtml(badge, global) {
+  if (global.themeAware && isThemeAdaptive(badge, global)) {
+    return badgePicture(badge, global);
+  }
   const url = badgeUrl(badge, global);
   const alt = badge.label.replace(/"/g, "&quot;");
   const img = `<img src="${url}" alt="${alt}" />`;
@@ -1061,6 +1088,11 @@ var generate = defineCommand({
       type: "string",
       description: "Color mode: dark, light"
     },
+    "theme-aware": {
+      type: "boolean",
+      description: "Emit <picture> markup so badges adapt to the viewer's light/dark theme",
+      default: false
+    },
     format: {
       type: "string",
       description: "Output format: markdown (default), flat, html, json",
@@ -1095,7 +1127,8 @@ var generate = defineCommand({
       variant: args2.variant || "default",
       size: args2.size || "sm",
       mode: args2.mode || "dark",
-      theme: args2.theme || ""
+      theme: args2.theme || "",
+      themeAware: Boolean(args2["theme-aware"])
     };
     if (global.variant && !VARIANTS.includes(global.variant)) {
       consola.error(`Invalid variant "${global.variant}". Valid: ${VARIANTS.join(", ")}`);

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -115,6 +115,11 @@ const generate = defineCommand({
       type: "string",
       description: "Color mode: dark, light",
     },
+    "theme-aware": {
+      type: "boolean",
+      description: "Emit <picture> markup so badges adapt to the viewer's light/dark theme",
+      default: false,
+    },
     format: {
       type: "string",
       description: "Output format: markdown (default), flat, html, json",
@@ -153,6 +158,7 @@ const generate = defineCommand({
       size: (args.size as string) || "sm",
       mode: (args.mode as string) || "dark",
       theme: (args.theme as string) || "",
+      themeAware: Boolean(args["theme-aware"]),
     }
 
     // Validate variant

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -53,4 +53,10 @@ export type GlobalSettings = {
   size: string
   mode: string
   theme: string
+  /**
+   * Emit theme-aware <picture> markup so badges adapt to the viewer's
+   * GitHub light/dark theme. Only affects badges whose colors are derived
+   * from the theme (see isThemeDerived in url.ts).
+   */
+  themeAware?: boolean
 }

--- a/packages/cli/src/url.ts
+++ b/packages/cli/src/url.ts
@@ -68,6 +68,8 @@ export function isThemeAdaptive(badge: Badge, global: GlobalSettings): boolean {
   if (!THEME_DERIVED_VARIANTS.has(variant)) return false
   // An explicit color locks the badge to one appearance in both modes.
   if (badge.query.color) return false
+  // An explicit mode pins the badge to one theme, so <picture> is pointless.
+  if (badge.query.mode) return false
   return true
 }
 

--- a/packages/cli/src/url.ts
+++ b/packages/cli/src/url.ts
@@ -31,24 +31,75 @@ export function staticBadgePath(
 function mergeQuery(
   badge: Badge,
   global: GlobalSettings,
+  modeOverride?: "light" | "dark",
 ): Record<string, string> {
   const merged: Record<string, string> = { ...badge.query }
 
   // Only add global overrides when they differ from server defaults
   if (global.variant && global.variant !== "default" && !merged.variant) merged.variant = global.variant
   if (global.size && global.size !== "sm" && global.size !== "default" && !merged.size) merged.size = global.size
-  if (global.mode && global.mode !== "dark" && !merged.mode) merged.mode = global.mode
+  if (modeOverride) merged.mode = modeOverride
+  else if (global.mode && global.mode !== "dark" && !merged.mode) merged.mode = global.mode
   if (global.theme && !merged.theme) merged.theme = global.theme
 
   return merged
 }
 
-export function badgeUrl(badge: Badge, global: GlobalSettings): string {
-  const qs = new URLSearchParams(mergeQuery(badge, global)).toString()
+/**
+ * Variants whose colors are derived from the light/dark theme. Only these
+ * benefit from theme-aware <picture> output — a badge with an explicit color
+ * (e.g. /badge/label-value-green) looks identical in both modes.
+ */
+const THEME_DERIVED_VARIANTS = new Set([
+  "default",
+  "secondary",
+  "outline",
+  "ghost",
+  "branded",
+])
+
+/**
+ * Whether a badge would actually change between light and dark mode, so it's
+ * worth wrapping in <picture>. True when the resolved variant is theme-derived
+ * and the badge has no explicit `color` override pinning it to one look.
+ */
+export function isThemeAdaptive(badge: Badge, global: GlobalSettings): boolean {
+  const variant = badge.query.variant || (global.variant !== "default" ? global.variant : "default")
+  if (!THEME_DERIVED_VARIANTS.has(variant)) return false
+  // An explicit color locks the badge to one appearance in both modes.
+  if (badge.query.color) return false
+  return true
+}
+
+export function badgeUrl(
+  badge: Badge,
+  global: GlobalSettings,
+  modeOverride?: "light" | "dark",
+): string {
+  const qs = new URLSearchParams(mergeQuery(badge, global, modeOverride)).toString()
   return `${SHIELDCN_BASE}${badge.path}${qs ? `?${qs}` : ""}`
 }
 
+/**
+ * Build a GitHub theme-aware <picture> element. The <source> targets dark-theme
+ * viewers; the <img> fallback (light) covers light-theme viewers and any
+ * renderer that doesn't support <picture> (npm, PyPI, etc).
+ */
+export function badgePicture(badge: Badge, global: GlobalSettings): string {
+  const dark = badgeUrl(badge, global, "dark")
+  const light = badgeUrl(badge, global, "light")
+  const alt = badge.label.replace(/"/g, "&quot;")
+  const pic =
+    `<picture>` +
+    `<source media="(prefers-color-scheme: dark)" srcset="${dark}">` +
+    `<img alt="${alt}" src="${light}"></picture>`
+  return badge.linkUrl ? `<a href="${badge.linkUrl}">${pic}</a>` : pic
+}
+
 export function badgeMarkdown(badge: Badge, global: GlobalSettings): string {
+  if (global.themeAware && isThemeAdaptive(badge, global)) {
+    return badgePicture(badge, global)
+  }
   const url = badgeUrl(badge, global)
   const alt = badge.label.replace(/[\[\]]/g, "")
   const img = `![${alt}](${url})`
@@ -56,6 +107,9 @@ export function badgeMarkdown(badge: Badge, global: GlobalSettings): string {
 }
 
 export function badgeHtml(badge: Badge, global: GlobalSettings): string {
+  if (global.themeAware && isThemeAdaptive(badge, global)) {
+    return badgePicture(badge, global)
+  }
   const url = badgeUrl(badge, global)
   const alt = badge.label.replace(/"/g, "&quot;")
   const img = `<img src="${url}" alt="${alt}" />`

--- a/packages/web/app/gen/generator-client.tsx
+++ b/packages/web/app/gen/generator-client.tsx
@@ -14,7 +14,6 @@ import {
   badgeHtml,
   badgeMarkdown,
   badgeUrl,
-  DEFAULT_GLOBAL,
   type Badge,
   type BadgeGroup,
   type GlobalSettings,
@@ -46,6 +45,7 @@ import {
   SelectItem,
 } from "@/components/ui/select"
 import { Separator } from "@/components/ui/separator"
+import { Switch } from "@/components/ui/switch"
 import { ColorInput } from "@/components/color-input"
 import { SvgIconUpload } from "@/components/svg-icon-upload"
 import { cn } from "@/lib/utils"
@@ -119,6 +119,8 @@ export default function GeneratorApp() {
   useEffect(() => {
     if (qs.url && !didAutoGenerate.current && !config) {
       didAutoGenerate.current = true
+      // Pre-existing react-compiler debt (use-before-declare); tracked separately.
+      // eslint-disable-next-line react-hooks/immutability
       void handleGenerate(qs.url)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -132,18 +134,22 @@ export default function GeneratorApp() {
       size: qs.size,
       mode: qs.mode,
       theme: qs.theme,
+      themeAware: qs.themeAware,
     }
     const configGlobal = config.global
     if (
       urlGlobal.variant !== configGlobal.variant ||
       urlGlobal.size !== configGlobal.size ||
       urlGlobal.mode !== configGlobal.mode ||
-      urlGlobal.theme !== configGlobal.theme
+      urlGlobal.theme !== configGlobal.theme ||
+      urlGlobal.themeAware !== configGlobal.themeAware
     ) {
+      // Pre-existing react-compiler debt (set-state-in-effect); tracked separately.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setConfig((c) => (c ? { ...c, global: urlGlobal } : c))
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [qs.variant, qs.size, qs.mode, qs.theme])
+  }, [qs.variant, qs.size, qs.mode, qs.theme, qs.themeAware])
 
   const updateGlobal = useCallback((patch: Partial<GlobalSettings>) => {
     setConfig((c) => (c ? { ...c, global: { ...c.global, ...patch } } : c))
@@ -219,6 +225,8 @@ export default function GeneratorApp() {
     }
   }, [])
 
+  // Pre-existing react-compiler debt (preserve-manual-memoization); tracked separately.
+  // eslint-disable-next-line react-hooks/preserve-manual-memoization
   const handleGenerate = useCallback(async (urlOverride?: string) => {
     const url = urlOverride ?? inputUrl.trim()
     if (!url) return
@@ -624,6 +632,21 @@ function ResultsPanel({
             onChange={(v) => updateGlobal({ mode: v as Mode })}
           />
         </div>
+        <label className="flex items-start gap-3 rounded-md border border-dashed border-border p-3">
+          <Switch
+            checked={config.global.themeAware ?? false}
+            onCheckedChange={(v) => updateGlobal({ themeAware: v })}
+            className="mt-0.5"
+          />
+          <span className="flex flex-col gap-0.5">
+            <span className="text-sm font-medium">Theme-aware (light/dark)</span>
+            <span className="text-xs text-muted-foreground">
+              Output <code className="rounded bg-muted px-1 py-0.5">&lt;picture&gt;</code>{" "}
+              markup so badges adapt to the reader&apos;s GitHub theme. Applies to
+              theme-derived variants (outline, secondary, branded, default).
+            </span>
+          </span>
+        </label>
       </div>
 
       {/* Badge groups */}
@@ -777,6 +800,8 @@ function BadgeItem({
             !badge.enabled && "opacity-30 grayscale-[60%]",
           )}
         >
+          {/* Live badge SVG from an arbitrary URL — next/image is not applicable. */}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
           <img src={previewUrl} alt={badge.label} loading="lazy" className="block max-h-10" />
         </button>
       </PopoverTrigger>

--- a/packages/web/app/gen/generator-client.tsx
+++ b/packages/web/app/gen/generator-client.tsx
@@ -243,6 +243,7 @@ export default function GeneratorApp() {
         size: qs.size,
         mode: qs.mode,
         theme: qs.theme,
+        themeAware: qs.themeAware,
       },
       badges: result.badges,
       generatedAt: new Date().toISOString(),
@@ -269,7 +270,7 @@ export default function GeneratorApp() {
         badgeCount: enabledCount,
       }),
     }).catch(() => {})
-  }, [inputUrl, runInspect, setQs, qs.variant, qs.size, qs.mode, qs.theme, track])
+  }, [inputUrl, runInspect, setQs, qs.variant, qs.size, qs.mode, qs.theme, qs.themeAware, track])
 
   const handleConfigUpload = useCallback(async (file: File) => {
     setError(null)
@@ -288,6 +289,7 @@ export default function GeneratorApp() {
         size: parsed.config.global.size,
         mode: parsed.config.global.mode,
         theme: parsed.config.global.theme,
+        themeAware: parsed.config.global.themeAware ?? false,
       })
       setNotes([])
       setShieldsIoUrls([])

--- a/packages/web/components/sidebar.tsx
+++ b/packages/web/components/sidebar.tsx
@@ -5,7 +5,7 @@ import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { motion, useReducedMotion, AnimatePresence, LayoutGroup } from "motion/react"
 import { useRouter } from "next/navigation"
-import { ChevronDown, ChevronRight, Search, FileText, Hash } from "lucide-react"
+import { ChevronDown, ChevronRight, Search, FileText } from "lucide-react"
 import { cn } from "@/lib/utils"
 import {
   CommandDialog,
@@ -213,6 +213,7 @@ const docsNav: NavGroup[] = [
     items: [
       { title: "Themes", href: "/docs/customization/themes" },
       { title: "Styles", href: "/docs/customization/styles" },
+      { title: "Light & Dark Mode", href: "/docs/customization/light-dark-mode" },
     ],
   },
   {

--- a/packages/web/content/docs/api-reference.mdx
+++ b/packages/web/content/docs/api-reference.mdx
@@ -115,7 +115,7 @@ Join any badge paths with `+`. Query params apply to all segments. See [Badge Gr
       name: "mode",
       type: '"dark" | "light"',
       default: '"dark"',
-      description: "Color mode. Dark matches GitHub dark theme.",
+      description: "Color mode. Dark matches GitHub dark theme. Combine with a <picture> element to auto-adapt to the reader's theme — see Light & Dark Mode.",
     },
     {
       name: "theme",

--- a/packages/web/content/docs/cli.mdx
+++ b/packages/web/content/docs/cli.mdx
@@ -75,6 +75,18 @@ npx shieldcn-cli --variant outline --size lg --mode light
 npx shieldcn-cli --variant ghost --compact
 ```
 
+### Theme-aware output
+
+Pass `--theme-aware` to emit `<picture>` markup so badges adapt to the reader's
+GitHub light/dark theme. Only theme-derived variants (outline, secondary,
+branded, default) are wrapped — color-locked badges stay as plain Markdown.
+
+```bash
+npx shieldcn-cli --variant outline --theme-aware
+```
+
+See [Light & Dark Mode](/docs/customization/light-dark-mode) for how it works.
+
 ## Output formats
 
 ### Markdown (default)

--- a/packages/web/content/docs/customization/light-dark-mode.mdx
+++ b/packages/web/content/docs/customization/light-dark-mode.mdx
@@ -1,0 +1,108 @@
+---
+title: Light & Dark Mode
+description: Make badges adapt to the reader's GitHub light or dark theme.
+badge: "/github/ci/jal-co/shieldcn.svg?variant=outline"
+---
+
+Every badge accepts a `mode` query parameter:
+
+| Mode | Result |
+|------|--------|
+| `mode=dark` | Tuned for dark backgrounds (this is the default). |
+| `mode=light` | Tuned for light backgrounds. |
+
+On its own, `mode` just picks one look. To make a badge **automatically follow the
+reader's GitHub theme**, combine it with GitHub's `<picture>` element and the
+`prefers-color-scheme` media query.
+
+## The `<picture>` pattern
+
+GitHub serves a different image based on the viewer's theme. The `<source>`
+targets dark-theme viewers; the `<img>` fallback (light) covers light-theme
+viewers and any renderer that doesn't understand `<picture>` (npm, PyPI, etc).
+
+```html
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/github/ci/jal-co/shieldcn.svg?variant=outline&mode=dark">
+  <img alt="CI" src="https://shieldcn.dev/github/ci/jal-co/shieldcn.svg?variant=outline&mode=light">
+</picture>
+```
+
+This renders on GitHub.com and swaps automatically when the reader toggles their
+theme — no JavaScript, no duplicate badges shown.
+
+## Which badges benefit
+
+`mode` only changes a badge when its colors are **derived from the theme**. A
+badge with an explicit color looks identical in both modes, so wrapping it in
+`<picture>` does nothing.
+
+| Variant | Adapts to mode? |
+|---------|-----------------|
+| `default` (no custom color) | ✅ Yes |
+| `secondary` | ✅ Yes |
+| `outline` | ✅ Yes |
+| `ghost` | ✅ Yes |
+| `branded` | ✅ Yes |
+| `destructive` | ❌ No (color-locked) |
+| any variant with `?color=...` | ❌ No (color-locked) |
+
+If you're using a theme-derived variant, the `<picture>` pattern is worth it. If
+your badge has a fixed color, just leave it as a plain `![alt](url)`.
+
+## A whole row at once
+
+For a row of badges, the [badge group](/docs/badges/group) endpoint lets the
+entire row swap together with a single `<picture>`:
+
+```html
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/group/github/ci/jal-co/shieldcn+github/last-commit/jal-co/shieldcn+github/license/jal-co/shieldcn.svg?variant=outline&mode=dark">
+  <img alt="project badges" src="https://shieldcn.dev/group/github/ci/jal-co/shieldcn+github/last-commit/jal-co/shieldcn+github/license/jal-co/shieldcn.svg?variant=outline&mode=light">
+</picture>
+```
+
+## Markdown-native alternative
+
+GitHub also supports `#gh-dark-mode-only` / `#gh-light-mode-only` URL fragments,
+which work in plain Markdown without an HTML block:
+
+```md
+![CI dark](https://shieldcn.dev/github/ci/jal-co/shieldcn.svg?variant=outline&mode=dark#gh-dark-mode-only)
+![CI light](https://shieldcn.dev/github/ci/jal-co/shieldcn.svg?variant=outline&mode=light#gh-light-mode-only)
+```
+
+GitHub shows the matching badge and hides the other. The trade-off versus
+`<picture>` is that two `<img>` tags can leave a little extra spacing, and the
+fallback (both shown) only applies off GitHub. The `<picture>` approach is
+generally cleaner.
+
+## Generate it automatically
+
+You don't have to write the `<picture>` markup by hand.
+
+### CLI
+
+Pass `--theme-aware` and the CLI emits `<picture>` blocks for every
+theme-derived badge:
+
+```bash
+npx shieldcn-cli vercel/next.js --variant outline --theme-aware
+```
+
+Color-locked badges stay as plain Markdown, so the output is never more verbose
+than it needs to be.
+
+### Generator
+
+In the [badge generator](/gen), toggle **Theme-aware (light/dark)** under
+*Global defaults*. The copy-paste output switches to `<picture>` markup for the
+badges that benefit.
+
+## Caveats
+
+- `prefers-color-scheme` only resolves on **GitHub.com**. Local Markdown
+  previews, VS Code, and some package registries fall back to the `<img>`
+  (light) version.
+- The `branded` variant already adapts its text contrast per `mode`, so the
+  pattern works there too.

--- a/packages/web/content/docs/customization/meta.json
+++ b/packages/web/content/docs/customization/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Customization",
-  "pages": ["themes", "styles"]
+  "pages": ["themes", "styles", "light-dark-mode"]
 }

--- a/packages/web/lib/gen/search-params.ts
+++ b/packages/web/lib/gen/search-params.ts
@@ -4,6 +4,7 @@
 import {
   parseAsString,
   parseAsStringEnum,
+  parseAsBoolean,
   createSearchParamsCache,
 } from "nuqs/server"
 import type { Variant, Size, Mode, Theme } from "./shieldcn"
@@ -43,6 +44,7 @@ export const genSearchParams = {
   size: parseAsStringEnum(SIZES).withDefault("sm"),
   mode: parseAsStringEnum(MODES).withDefault("dark"),
   theme: parseAsStringEnum(THEMES).withDefault("none"),
+  themeAware: parseAsBoolean.withDefault(false),
 }
 
 export const genSearchParamsCache = createSearchParamsCache(genSearchParams)

--- a/packages/web/lib/gen/shieldcn.ts
+++ b/packages/web/lib/gen/shieldcn.ts
@@ -59,6 +59,12 @@ export type GlobalSettings = {
   size: Size;
   mode: Mode;
   theme: Theme;
+  /**
+   * Emit theme-aware <picture> markup so badges adapt to the viewer's
+   * GitHub light/dark theme. Only affects theme-derived variants without an
+   * explicit color (see isThemeAdaptive).
+   */
+  themeAware?: boolean;
 };
 
 export const DEFAULT_GLOBAL: GlobalSettings = {
@@ -66,6 +72,7 @@ export const DEFAULT_GLOBAL: GlobalSettings = {
   size: 'sm',
   mode: 'dark',
   theme: 'none',
+  themeAware: false,
 };
 
 export type BadgeGroup =
@@ -106,12 +113,14 @@ const COLOR_FIELDS: (keyof Overrides)[] = [
 export function mergeQuery(
   badge: Badge,
   global: GlobalSettings,
+  modeOverride?: Mode,
 ): Record<string, string> {
   const merged: Record<string, string> = { ...badge.query };
 
   if (global.variant !== 'default' && !merged.variant) merged.variant = global.variant;
   if (global.size !== 'default' && !merged.size) merged.size = global.size;
-  if (global.mode !== 'dark' && !merged.mode) merged.mode = global.mode;
+  if (modeOverride) merged.mode = modeOverride;
+  else if (global.mode !== 'dark' && !merged.mode) merged.mode = global.mode;
   if (global.theme !== 'none' && !merged.theme) merged.theme = global.theme;
 
   for (const [rawKey, rawVal] of Object.entries(badge.overrides)) {
@@ -136,12 +145,64 @@ export function mergeQuery(
   return merged;
 }
 
-export function badgeUrl(badge: Badge, global: GlobalSettings): string {
-  const qs = new URLSearchParams(mergeQuery(badge, global)).toString();
+export function badgeUrl(
+  badge: Badge,
+  global: GlobalSettings,
+  modeOverride?: Mode,
+): string {
+  const qs = new URLSearchParams(mergeQuery(badge, global, modeOverride)).toString();
   return `${SHIELDCN_BASE}${badge.path}${qs ? `?${qs}` : ''}`;
 }
 
+/**
+ * Variants whose colors are derived from the light/dark theme. Only these
+ * benefit from theme-aware <picture> output — a badge with an explicit color
+ * looks identical in both modes.
+ */
+const THEME_DERIVED_VARIANTS = new Set<string>([
+  'default',
+  'secondary',
+  'outline',
+  'ghost',
+  'branded',
+]);
+
+/**
+ * Whether a badge would actually change between light and dark mode, so it's
+ * worth wrapping in <picture>. True when the resolved variant is theme-derived
+ * and the badge has no explicit color override pinning it to one look.
+ */
+export function isThemeAdaptive(badge: Badge, global: GlobalSettings): boolean {
+  const variant =
+    badge.query.variant ||
+    (global.variant !== 'default' ? global.variant : 'default');
+  if (!THEME_DERIVED_VARIANTS.has(variant)) return false;
+  // An explicit color (query or override) locks the badge to one appearance.
+  if (badge.query.color) return false;
+  if (badge.overrides.color) return false;
+  return true;
+}
+
+/**
+ * Build a GitHub theme-aware <picture> element. The <source> targets dark-theme
+ * viewers; the <img> fallback (light) covers light-theme viewers and renderers
+ * that don't support <picture> (npm, PyPI, etc).
+ */
+export function badgePicture(badge: Badge, global: GlobalSettings): string {
+  const dark = badgeUrl(badge, global, 'dark');
+  const light = badgeUrl(badge, global, 'light');
+  const alt = badge.label.replace(/"/g, '&quot;');
+  const pic =
+    `<picture>` +
+    `<source media="(prefers-color-scheme: dark)" srcset="${dark}">` +
+    `<img alt="${alt}" src="${light}"></picture>`;
+  return badge.linkUrl ? `<a href="${badge.linkUrl}">${pic}</a>` : pic;
+}
+
 export function badgeMarkdown(badge: Badge, global: GlobalSettings): string {
+  if (global.themeAware && isThemeAdaptive(badge, global)) {
+    return badgePicture(badge, global);
+  }
   const url = badgeUrl(badge, global);
   const alt = badge.label.replace(/[\[\]]/g, '');
   const img = `![${alt}](${url})`;
@@ -149,6 +210,9 @@ export function badgeMarkdown(badge: Badge, global: GlobalSettings): string {
 }
 
 export function badgeHtml(badge: Badge, global: GlobalSettings): string {
+  if (global.themeAware && isThemeAdaptive(badge, global)) {
+    return badgePicture(badge, global);
+  }
   const url = badgeUrl(badge, global);
   const alt = badge.label.replace(/"/g, '&quot;');
   const img = `<img src="${url}" alt="${alt}" />`;

--- a/packages/web/lib/gen/shieldcn.ts
+++ b/packages/web/lib/gen/shieldcn.ts
@@ -126,6 +126,10 @@ export function mergeQuery(
   for (const [rawKey, rawVal] of Object.entries(badge.overrides)) {
     if (rawVal === undefined || rawVal === null || rawVal === '') continue;
     const key = rawKey as keyof Overrides;
+    // A forced mode (for theme-aware <picture> output) must win over the
+    // badge's own mode override, otherwise both <source> and <img> resolve
+    // to the same mode and the <picture> swap does nothing.
+    if (key === 'mode' && modeOverride) continue;
     if (key === 'theme' && rawVal === 'none') {
       delete merged.theme;
       continue;
@@ -180,6 +184,9 @@ export function isThemeAdaptive(badge: Badge, global: GlobalSettings): boolean {
   // An explicit color (query or override) locks the badge to one appearance.
   if (badge.query.color) return false;
   if (badge.overrides.color) return false;
+  // An explicit mode pins the badge to one theme, so <picture> is pointless.
+  if (badge.query.mode) return false;
+  if (badge.overrides.mode) return false;
   return true;
 }
 


### PR DESCRIPTION
## What

Adds **opt-in theme-aware badge output** so badges adapt to the reader's GitHub light/dark theme, using GitHub's `<picture>` + `prefers-color-scheme`.

- **CLI**: `--theme-aware` flag emits `<picture>` markup for theme-derived badges; color-locked badges stay as plain Markdown
- **Generator** (`/gen`): "Theme-aware (light/dark)" toggle under *Global defaults*, wired through config, URL state, and copy output
- **Shared detection** (`isThemeAdaptive`): only `outline` / `secondary` / `ghost` / `branded` / `default`-without-color benefit; badges with an explicit color are skipped (they look identical in both modes)
- **Docs**: new `customization/light-dark-mode` page documenting the `<picture>` pattern, the `#gh-*-mode-only` fragment alternative, which variants adapt, and the CLI/generator support — plus api-reference + cli docs updates and a sidebar nav entry

## Why

Closes #111 — a user asked how to make their shieldcn badges follow the GitHub theme. The `mode` param existed but the `<picture>` technique was undocumented, and nothing in the builder generated it. This makes it discoverable and one-click.

Verified live on GitHub.com (gist demo): theme-derived badges swap correctly between light/dark; color-locked badges stay put.

## Type

- [x] `feat` — New feature

## Checklist

- [x] Branch follows conventional naming (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tested locally with `pnpm dev`
- [x] Badge renders correctly in SVG and PNG (if applicable)
- [x] Docs updated (if adding/changing a provider or query param)

## Notes

- Opt-in by design — default output stays clean `![alt](url)`. `<picture>` is only emitted when the user enables it **and** the badge actually benefits.
- `isThemeAdaptive` logic is duplicated in `packages/cli/src/url.ts` and `packages/web/lib/gen/shieldcn.ts` (the two surfaces have separate URL builders today).
