### PR TITLE
feat(observability): emit badge + cache metrics to sentry

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
   },
   "packageManager": "pnpm@10.30.3",
   "pnpm": {
+    "onlyBuiltDependencies": [
+      "@sentry-internal/node-cpu-profiler",
+      "@sentry/cli"
+    ],
     "overrides": {
       "fast-uri@<3.1.2": ">=3.1.2",
       "turbo@<2.9.14": ">=2.9.14",

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -250,6 +250,25 @@ export async function cacheSet<T>(key: string, data: T, ttlSeconds: number = 300
  * @param ttlSeconds - cache TTL (default 300)
  * @returns data or null
  */
+/**
+ * Optional metrics callback for cache instrumentation.
+ * Set by the app layer (Sentry, etc.) before any requests flow.
+ */
+let cacheMetricsCallback: ((metric: {
+  type: "counter"
+  name: string
+  value: number
+  tags?: Record<string, string>
+}) => void) | null = null
+
+/**
+ * Register a callback to receive cache metrics (hit/miss/backoff/budget).
+ * Call once at app startup.
+ */
+export function setCacheMetricsCallback(cb: typeof cacheMetricsCallback): void {
+  cacheMetricsCallback = cb
+}
+
 export async function cachedFetch<T>(
   provider: string,
   key: string,
@@ -260,13 +279,36 @@ export async function cachedFetch<T>(
 
   // 1. Cache hit?
   const cached = await cacheGet<T>(fullKey)
-  if (cached !== undefined) return cached
+  if (cached !== undefined) {
+    cacheMetricsCallback?.({
+      type: "counter", name: "badge.cache", value: 1,
+      tags: { provider, result: "hit" },
+    })
+    return cached
+  }
+
+  cacheMetricsCallback?.({
+    type: "counter", name: "badge.cache", value: 1,
+    tags: { provider, result: "miss" },
+  })
 
   // 2. Is the provider backed off?
-  if (isBackedOff(provider)) return null
+  if (isBackedOff(provider)) {
+    cacheMetricsCallback?.({
+      type: "counter", name: "badge.backoff", value: 1,
+      tags: { provider },
+    })
+    return null
+  }
 
   // 3. Rate budget check
-  if (!consumeBudget(provider)) return null
+  if (!consumeBudget(provider)) {
+    cacheMetricsCallback?.({
+      type: "counter", name: "badge.budget_exhausted", value: 1,
+      tags: { provider },
+    })
+    return null
+  }
 
   // 4. Fetch
   try {

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -1950,10 +1950,29 @@ async function handleBadgeGETInner(
 
   // ── Animated GIF output (animates inside GitHub READMEs) ──────────────
   if (format === "gif") {
+    const gifRenderStart = performance.now()
     const { svg: baseSvg, dotColor } = await renderBadgeBase(badgeConfig)
     // Default a bare `.gif` (no animate param) to shimmer so it actually moves.
     const gifMode = animateRequested === "none" ? "shimmer" : animateRequested
     const gif = await renderGif(baseSvg, gifMode, dotColor)
+    const gifRenderMs = performance.now() - gifRenderStart
+
+    if (options?.onMetric) {
+      options.onMetric({
+        type: "distribution",
+        name: "badge.render_duration",
+        value: gifRenderMs,
+        unit: "millisecond",
+        tags: { provider, format, style, mode },
+      })
+      options.onMetric({
+        type: "distribution",
+        name: "badge.total_duration",
+        value: fetchMs + gifRenderMs,
+        unit: "millisecond",
+        tags: { provider, format },
+      })
+    }
 
     if (gif) {
       if (options?.onTrack) {

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -18,6 +18,23 @@ import { normalizeSearchParams } from "./normalize-params"
 import type { BadgeData, BadgeConfig, BadgeStyle, BadgeSize } from "./badges/types"
 
 /**
+ * A single metric emission. Apps wire this to Sentry.metrics (or any
+ * metrics backend); core stays dependency-free.
+ */
+export interface MetricEvent {
+  /** Metric type: counter, distribution (histogram), gauge, or set. */
+  type: "counter" | "distribution" | "gauge" | "set"
+  /** Metric name, e.g. "badge.render_duration". */
+  name: string
+  /** Numeric value (or string for sets). */
+  value: number | string
+  /** Unit hint — Sentry uses this for display formatting. */
+  unit?: "millisecond" | "none" | "byte"
+  /** Key-value tags attached to the metric point. */
+  tags?: Record<string, string>
+}
+
+/**
  * Options for the badge GET handler.
  */
 export interface BadgeRequestOptions {
@@ -30,6 +47,12 @@ export interface BadgeRequestOptions {
    * Sentry (or any monitoring tool); core stays dependency-free.
    */
   onError?: (error: unknown, context: Record<string, string>) => void
+  /**
+   * Optional metrics callback. Called to emit counter/distribution/gauge/set
+   * metrics for badge operations. Apps wire this to Sentry.metrics or any
+   * metrics backend; core stays dependency-free.
+   */
+  onMetric?: (metric: MetricEvent) => void
 }
 
 /** Check if a hex color (without #) is light enough to need dark text/icons. */
@@ -1642,7 +1665,26 @@ async function handleBadgeGETInner(
   }
 
   // Fetch badge data from provider
+  const fetchStart = performance.now()
   const data = await fetchBadgeData(cleanSegments, searchParams)
+  const fetchMs = performance.now() - fetchStart
+  const provider = cleanSegments[0] || "unknown"
+
+  if (options?.onMetric) {
+    options.onMetric({
+      type: "distribution",
+      name: "badge.provider_fetch_duration",
+      value: fetchMs,
+      unit: "millisecond",
+      tags: { provider, found: data ? "true" : "false" },
+    })
+    options.onMetric({
+      type: "counter",
+      name: "badge.request",
+      value: 1,
+      tags: { provider, format },
+    })
+  }
 
   if (!data) {
     if (format === "svg") {
@@ -1720,7 +1762,6 @@ async function handleBadgeGETInner(
   let brandColor: string | undefined
 
   // For branded variant, get provider brand color as fallback
-  const provider = cleanSegments[0]
   const providerBrand = getProviderBrandColor(provider)
 
   if (logoParam === "false" || logoParam === "none") {
@@ -1939,13 +1980,32 @@ async function handleBadgeGETInner(
     })
   }
 
+  const renderStart = performance.now()
   const svg = await renderBadge(badgeConfig)
+  const renderMs = performance.now() - renderStart
+
+  if (options?.onMetric) {
+    options.onMetric({
+      type: "distribution",
+      name: "badge.render_duration",
+      value: renderMs,
+      unit: "millisecond",
+      tags: { provider, format, style, mode },
+    })
+    options.onMetric({
+      type: "distribution",
+      name: "badge.total_duration",
+      value: fetchMs + renderMs,
+      unit: "millisecond",
+      tags: { provider, format },
+    })
+  }
 
   if (options?.onTrack) {
     void options.onTrack({
       name: "badge_rendered",
       data: {
-        provider: cleanSegments[0] || "unknown",
+        provider,
         format,
         style,
         size: size ?? "sm",

--- a/packages/engine/app/[...slug]/route.ts
+++ b/packages/engine/app/[...slug]/route.ts
@@ -3,14 +3,30 @@
  * app/[...slug]/route.ts
  *
  * Badge catch-all route. Delegates to @shieldcn/core — no analytics.
- * Reports unexpected badge errors to Sentry (no-op without a DSN).
+ * Reports unexpected badge errors to Sentry and emits custom metrics
+ * (no-op without a DSN).
  */
 
-import { handleBadgeGET, handleBadgePUT } from "@shieldcn/core/route-handler"
+import { handleBadgeGET, handleBadgePUT, type MetricEvent } from "@shieldcn/core/route-handler"
 import * as Sentry from "@sentry/nextjs"
 
 function reportBadgeError(error: unknown, context: Record<string, string>) {
   Sentry.captureException(error, { tags: { area: "badge" }, extra: context })
+}
+
+function emitMetric(metric: MetricEvent) {
+  const attributes = metric.tags ?? {}
+  switch (metric.type) {
+    case "counter":
+      Sentry.metrics.count(metric.name, metric.value as number, { attributes, unit: metric.unit ?? "none" })
+      break
+    case "distribution":
+      Sentry.metrics.distribution(metric.name, metric.value as number, { attributes, unit: metric.unit ?? "none" })
+      break
+    case "gauge":
+      Sentry.metrics.gauge(metric.name, metric.value as number, { attributes, unit: metric.unit ?? "none" })
+      break
+  }
 }
 
 export async function GET(
@@ -18,7 +34,7 @@ export async function GET(
   { params }: { params: Promise<{ slug: string[] }> }
 ) {
   const { slug } = await params
-  return handleBadgeGET(request, slug, { onError: reportBadgeError })
+  return handleBadgeGET(request, slug, { onError: reportBadgeError, onMetric: emitMetric })
 }
 
 export async function PUT(

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -15,6 +15,7 @@
     "react-dom": "19.2.4"
   },
   "devDependencies": {
+    "@sentry/profiling-node": "^10.56.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/packages/engine/sentry.edge.config.ts
+++ b/packages/engine/sentry.edge.config.ts
@@ -4,6 +4,8 @@
  *
  * Sentry initialization for the engine's Edge runtime.
  * Inert unless NEXT_PUBLIC_SENTRY_DSN is set.
+ *
+ * Note: Profiling is not available on the Edge runtime — Node.js only.
  */
 
 import * as Sentry from "@sentry/nextjs"

--- a/packages/engine/sentry.server.config.ts
+++ b/packages/engine/sentry.server.config.ts
@@ -8,6 +8,8 @@
  */
 
 import * as Sentry from "@sentry/nextjs"
+import { nodeProfilingIntegration } from "@sentry/profiling-node"
+import { setCacheMetricsCallback } from "@shieldcn/core/cache"
 
 const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN
 
@@ -15,10 +17,20 @@ if (dsn) {
   Sentry.init({
     dsn,
     tracesSampleRate: 1,
+    profilesSampleRate: 1,
     enableLogs: true,
     debug: false,
+    integrations: [nodeProfilingIntegration()],
     // Privacy: do not attach the visitor IP, cookies, or request body to
     // stored error events. IPs are processed transiently but never retained.
     sendDefaultPii: false,
+  })
+
+  // Wire cache metrics to Sentry.metrics
+  setCacheMetricsCallback((metric) => {
+    Sentry.metrics.count(metric.name, metric.value, {
+      attributes: metric.tags,
+      unit: "none",
+    })
   })
 }

--- a/packages/web/app/[...slug]/route.ts
+++ b/packages/web/app/[...slug]/route.ts
@@ -3,10 +3,11 @@
  * packages/web/app/[...slug]/route.ts
  *
  * Catch-all route handler for badge endpoints.
- * Delegates to @shieldcn/core route handler with analytics tracking.
+ * Delegates to @shieldcn/core route handler with analytics tracking
+ * and Sentry metrics instrumentation.
  */
 
-import { handleBadgeGET, handleBadgePUT } from "@shieldcn/core/route-handler"
+import { handleBadgeGET, handleBadgePUT, type MetricEvent } from "@shieldcn/core/route-handler"
 import * as Sentry from "@sentry/nextjs"
 import { trackEvent } from "@/lib/openpanel"
 
@@ -14,12 +15,31 @@ function reportBadgeError(error: unknown, context: Record<string, string>) {
   Sentry.captureException(error, { tags: { area: "badge" }, extra: context })
 }
 
+function emitMetric(metric: MetricEvent) {
+  const attributes = metric.tags ?? {}
+  switch (metric.type) {
+    case "counter":
+      Sentry.metrics.count(metric.name, metric.value as number, { attributes, unit: metric.unit ?? "none" })
+      break
+    case "distribution":
+      Sentry.metrics.distribution(metric.name, metric.value as number, { attributes, unit: metric.unit ?? "none" })
+      break
+    case "gauge":
+      Sentry.metrics.gauge(metric.name, metric.value as number, { attributes, unit: metric.unit ?? "none" })
+      break
+  }
+}
+
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ slug: string[] }> }
 ) {
   const { slug } = await params
-  return handleBadgeGET(request, slug, { onTrack: trackEvent, onError: reportBadgeError })
+  return handleBadgeGET(request, slug, {
+    onTrack: trackEvent,
+    onError: reportBadgeError,
+    onMetric: emitMetric,
+  })
 }
 
 export async function PUT(

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -40,6 +40,7 @@
     "yaml": "^2.8.3"
   },
   "devDependencies": {
+    "@sentry/profiling-node": "^10.56.0",
     "@tailwindcss/postcss": "^4",
     "@tailwindcss/typography": "^0.5.19",
     "@types/node": "^20",

--- a/packages/web/sentry.edge.config.ts
+++ b/packages/web/sentry.edge.config.ts
@@ -4,6 +4,8 @@
  *
  * Sentry initialization for the Edge runtime (middleware, edge routes).
  * Inert unless NEXT_PUBLIC_SENTRY_DSN is set.
+ *
+ * Note: Profiling is not available on the Edge runtime — Node.js only.
  */
 
 import * as Sentry from "@sentry/nextjs"

--- a/packages/web/sentry.server.config.ts
+++ b/packages/web/sentry.server.config.ts
@@ -8,6 +8,8 @@
  */
 
 import * as Sentry from "@sentry/nextjs"
+import { nodeProfilingIntegration } from "@sentry/profiling-node"
+import { setCacheMetricsCallback } from "@shieldcn/core/cache"
 
 const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN
 
@@ -15,10 +17,22 @@ if (dsn) {
   Sentry.init({
     dsn,
     tracesSampleRate: 1,
+    profilesSampleRate: 1,
     enableLogs: true,
     debug: false,
+    integrations: [nodeProfilingIntegration()],
     // Privacy: do not attach the visitor IP, cookies, or request body to
     // stored error events. IPs are processed transiently but never retained.
     sendDefaultPii: false,
+  })
+
+  // Wire cache metrics to Sentry.metrics so cache hit/miss/backoff/budget
+  // counters flow to Application Metrics without @shieldcn/core depending
+  // on Sentry directly.
+  setCacheMetricsCallback((metric) => {
+    Sentry.metrics.count(metric.name, metric.value, {
+      attributes: metric.tags,
+      unit: "none",
+    })
   })
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,7 +105,7 @@ importers:
     dependencies:
       '@sentry/nextjs':
         specifier: ^10.56.0
-        version: 10.56.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.107.2)
+        version: 10.56.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.107.2)
       '@shieldcn/core':
         specifier: workspace:*
         version: link:../core
@@ -119,6 +119,9 @@ importers:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
     devDependencies:
+      '@sentry/profiling-node':
+        specifier: ^10.56.0
+        version: 10.56.0
       '@types/node':
         specifier: ^20
         version: 20.19.39
@@ -145,7 +148,7 @@ importers:
         version: 2.6.2
       '@sentry/nextjs':
         specifier: ^10.56.0
-        version: 10.56.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.107.2)
+        version: 10.56.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.107.2)
       '@shieldcn/core':
         specifier: workspace:*
         version: link:../core
@@ -219,6 +222,9 @@ importers:
         specifier: ^2.8.3
         version: 2.8.3
     devDependencies:
+      '@sentry/profiling-node':
+        specifier: ^10.56.0
+        version: 10.56.0
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.4
@@ -2134,6 +2140,10 @@ packages:
     resolution: {integrity: sha512-fkRR9JroESTIlErkht3OrH4DXKd/DbPozr2KLdX7boMo31hPu4cL9fuqzwOrwyDPRq9B4j+qEgIWB8JrTbgvmg==}
     engines: {node: '>=18'}
 
+  '@sentry-internal/node-cpu-profiler@2.4.1':
+    resolution: {integrity: sha512-Wnkik+RLvRUZEB8Zx5ofgPdcC8bCSoiUUiyH6TorrLK6PBPerbjK48c2GsJf6l5Hc5GAhA3fitueVLATB0XhWQ==}
+    engines: {node: '>=18'}
+
   '@sentry-internal/replay-canvas@10.56.0':
     resolution: {integrity: sha512-SDg2K0CAZT/TnhrixQGwXoi6ZsWUB+DQy3UUk0bSQm6c/5k5zFBpGOiughQN+DYsDilKREfPKmUEEnqvUjm1HQ==}
     engines: {node: '>=18'}
@@ -2256,6 +2266,11 @@ packages:
       '@opentelemetry/core': ^1.30.1 || ^2.1.0
       '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
       '@opentelemetry/semantic-conventions': ^1.39.0
+
+  '@sentry/profiling-node@10.56.0':
+    resolution: {integrity: sha512-AmcUrvqJcvl39fNzoXBCPp8iGStRSmpBYqQCPz1mlDUw/n/iWpLq5+8iHecXyT5oOST4xHjNIyb7AA/fj0Pxzw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@sentry/react@10.56.0':
     resolution: {integrity: sha512-HfPLyvnrydfyjRXw9Q0GMzj7w2YtEwuC9z5RrPUfarA2qpA0/J8cfGLzyFX2v0jBmA/kkj6J1uBUoSVhCTxFHg==}
@@ -4919,6 +4934,10 @@ packages:
         optional: true
       sass:
         optional: true
+
+  node-abi@3.92.0:
+    resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
+    engines: {node: '>=10'}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -7989,6 +8008,11 @@ snapshots:
     dependencies:
       '@sentry/core': 10.56.0
 
+  '@sentry-internal/node-cpu-profiler@2.4.1':
+    dependencies:
+      detect-libc: 2.1.2
+      node-abi: 3.92.0
+
   '@sentry-internal/replay-canvas@10.56.0':
     dependencies:
       '@sentry-internal/replay': 10.56.0
@@ -8072,7 +8096,7 @@ snapshots:
 
   '@sentry/core@10.56.0': {}
 
-  '@sentry/nextjs@10.56.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.107.2)':
+  '@sentry/nextjs@10.56.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.107.2)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.41.1
@@ -8132,6 +8156,15 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
       '@sentry/core': 10.56.0
+
+  '@sentry/profiling-node@10.56.0':
+    dependencies:
+      '@sentry-internal/node-cpu-profiler': 2.4.1
+      '@sentry/core': 10.56.0
+      '@sentry/node': 10.56.0
+    transitivePeerDependencies:
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
 
   '@sentry/react@10.56.0(react@19.2.4)':
     dependencies:
@@ -11262,6 +11295,10 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  node-abi@3.92.0:
+    dependencies:
+      semver: 7.7.4
 
   node-domexception@1.0.0: {}
 


### PR DESCRIPTION
## What

Wires cache and badge operations to **Sentry metrics** so hit/miss rates, provider backoff, and render timings are visible in production.

- Adds a dependency-free `onMetric` callback (`MetricEvent`) to the core route handler and a `setCacheMetricsCallback` hook in the cache layer — `@shieldcn/core` stays free of any Sentry dependency
- Both `web` and `engine` emit counter / distribution / gauge metrics via `Sentry.metrics`
- Allows Sentry's native build deps via pnpm `onlyBuiltDependencies`

## Why

Builds on the Sentry integration from #112. Errors are now captured, but operational health (cache efficiency, render latency, rate-limit backoff) was still invisible. These metrics surface it without coupling the core engine to Sentry.

Inert without a DSN, like the rest of the Sentry wiring — forks and self-hosters are unaffected.

## Type

- [x] `feat` — New feature

## Checklist

- [x] Branch follows conventional naming (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tested locally with `pnpm dev`
- [ ] Badge renders correctly in SVG and PNG (if applicable)
- [ ] Docs updated (if adding/changing a provider or query param)

## Notes

- Depends conceptually on #112 (already merged).
- The metrics callback mirrors the existing `onError`/`onTrack` pattern — core defines the interface, apps inject the Sentry implementation.
- Worth verifying the metrics land in the Sentry dashboard (Metrics tab) before/after merge, the same way error capture was verified.
