### PR TITLE
feat(badges): add badge variant registry as single source of truth

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
   "exports": {
     "./badges/*": "./src/badges/*",
     "./providers/*": "./src/providers/*",
@@ -36,7 +40,8 @@
     "@types/pg": "^8.20.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3"
   },
   "peerDependencies": {
     "react": "^19",

--- a/packages/core/src/badges/registry.test.ts
+++ b/packages/core/src/badges/registry.test.ts
@@ -1,0 +1,202 @@
+/**
+ * shieldcn
+ * lib/badges/registry.test
+ *
+ * Proves the registry is the source of truth and that validation enforces it.
+ * Scoped (per rollout plan B) to npm, github, and the static badge provider.
+ */
+
+import { describe, expect, it } from "vitest"
+import { ALL_VARIANTS, REGISTRY, allowedVariants, allowedVariantsForPath, resolveTopic } from "./registry"
+import { resolveVariant, validateBadgeRequest } from "./validate"
+
+describe("registry shape", () => {
+  it("every topic has a non-empty example", () => {
+    for (const provider of REGISTRY) {
+      for (const topic of provider.topics) {
+        expect(topic.example.length, `${provider.provider}/${topic.topic}`).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  it("ALL_VARIANTS matches the documented 6 (no phantom variants)", () => {
+    expect([...ALL_VARIANTS]).toEqual([
+      "default",
+      "secondary",
+      "outline",
+      "ghost",
+      "destructive",
+      "branded",
+    ])
+  })
+
+  it("every declared variant is a real variant", () => {
+    for (const provider of REGISTRY) {
+      for (const topic of provider.topics) {
+        for (const v of topic.variants ?? []) {
+          expect(ALL_VARIANTS, `${provider.provider}/${topic.topic}`).toContain(v)
+        }
+      }
+    }
+  })
+
+  it("topics within a provider are unique", () => {
+    for (const provider of REGISTRY) {
+      const keys = provider.topics.map((t) => t.topic)
+      expect(new Set(keys).size, provider.provider).toBe(keys.length)
+    }
+  })
+
+  it("every topic's example resolves back to that topic (no drift)", () => {
+    for (const provider of REGISTRY) {
+      if (provider.freeform) continue
+      for (const topic of provider.topics) {
+        const resolved = resolveTopic(provider.provider, topic.example)
+        expect(resolved?.topic, `${provider.provider}/${topic.topic} → ${topic.example.join("/")}`).toBe(topic.topic)
+      }
+    }
+  })
+})
+
+describe("resolveTopic", () => {
+  it("resolves a known npm topic", () => {
+    expect(resolveTopic("npm", ["v", "react"])?.topic).toBe("v")
+  })
+
+  it("resolves a github topic from the /{topic}/{owner}/{repo} form", () => {
+    expect(resolveTopic("github", ["stars", "facebook", "react"])?.topic).toBe("stars")
+  })
+
+  it("resolves a github topic from the /{owner}/{repo}/{topic} form", () => {
+    expect(resolveTopic("github", ["facebook", "react", "stars"])?.topic).toBe("stars")
+  })
+
+  it("wildcard provider matches any segments", () => {
+    expect(resolveTopic("badge", ["build-passing-green"])?.topic).toBe("*")
+  })
+
+  it("returns null for an unknown topic on a provider with no default", () => {
+    // reddit has no defaultTopic, so an unrecognized segment is a real error.
+    expect(resolveTopic("reddit", ["bogus"])).toBeNull()
+  })
+
+  it("falls back to defaultTopic when no topic segment is present", () => {
+    // npm treats a bare segment as a package name → default "v" (legacy behavior).
+    expect(resolveTopic("npm", ["react"])?.topic).toBe("v")
+  })
+
+  it("returns null for an unregistered provider", () => {
+    expect(resolveTopic("not-a-real-provider", ["123"])).toBeNull()
+  })
+})
+
+describe("validateBadgeRequest", () => {
+  it("passes a valid npm version + default variant", () => {
+    expect(validateBadgeRequest("npm", ["v", "react"], undefined).ok).toBe(true)
+  })
+
+  it("passes a valid npm version + outline variant", () => {
+    expect(validateBadgeRequest("npm", ["v", "react"], "outline").ok).toBe(true)
+  })
+
+  it("defers (ok) on an unknown topic — data layer handles not-found", () => {
+    // Non-breaking: unknown topics are not rejected here; fetchBadgeData
+    // returns a graceful "not found" badge instead.
+    expect(validateBadgeRequest("reddit", ["bogus"], undefined).ok).toBe(true)
+  })
+
+  it("does not enforce variants on an unknown topic", () => {
+    // Topic unknown → no variant policy → allow anything.
+    expect(validateBadgeRequest("reddit", ["bogus"], "branded").ok).toBe(true)
+  })
+
+  it("rejects an unknown variant string", () => {
+    const r = validateBadgeRequest("npm", ["v", "react"], "sparkly")
+    expect(r.ok).toBe(false)
+    expect(r.code).toBe("unsupported-variant")
+  })
+
+  it("rejects branded on a github CI status badge", () => {
+    const r = validateBadgeRequest("github", ["ci", "facebook", "react"], "branded")
+    expect(r.ok).toBe(false)
+    expect(r.code).toBe("unsupported-variant")
+    expect(r.message).toContain("github/ci")
+  })
+
+  it("allows branded on github stars", () => {
+    expect(validateBadgeRequest("github", ["stars", "facebook", "react"], "branded").ok).toBe(true)
+  })
+
+  it("defers (ok) for unregistered providers — non-breaking rollout", () => {
+    expect(validateBadgeRequest("not-a-real-provider", ["123"], "branded").ok).toBe(true)
+  })
+})
+
+describe("allowedVariantsForPath (drives the builder dropdown)", () => {
+  it("narrows branded out for a github CI path (with .svg + both orderings)", () => {
+    expect(allowedVariantsForPath("/github/vercel/next.js/ci.svg")).not.toContain("branded")
+    expect(allowedVariantsForPath("github/ci/vercel/next.js")).not.toContain("branded")
+  })
+
+  it("allows all variants for github stars", () => {
+    expect(allowedVariantsForPath("/github/vercel/next.js/stars.svg")).toEqual(ALL_VARIANTS)
+  })
+
+  it("allows all variants for a static badge", () => {
+    expect(allowedVariantsForPath("/badge/build-passing-green.svg")).toEqual(ALL_VARIANTS)
+  })
+
+  it("allows all variants for groups", () => {
+    expect(allowedVariantsForPath("/group/npm/react+github/stars/vercel/next.js.svg")).toEqual(ALL_VARIANTS)
+  })
+
+  it("defers to ALL_VARIANTS for unregistered providers", () => {
+    expect(allowedVariantsForPath("/not-a-real-provider/123.svg")).toEqual(ALL_VARIANTS)
+  })
+
+  it("drops branded for the flag provider (no brand identity)", () => {
+    expect(allowedVariantsForPath("/flag/in.svg")).not.toContain("branded")
+  })
+})
+
+describe("resolveVariant (route coercion — non-breaking)", () => {
+  it("keeps a valid variant", () => {
+    expect(resolveVariant("npm", ["v", "react"], "outline")).toBe("outline")
+  })
+
+  it("coerces branded on a state badge to default (not an error)", () => {
+    expect(resolveVariant("github", ["ci", "facebook", "react"], "branded")).toBe("default")
+  })
+
+  it("coerces legacy/unknown variant strings to default (legacy parity)", () => {
+    expect(resolveVariant("npm", ["v", "react"], "flat")).toBe("default")
+    expect(resolveVariant("npm", ["v", "react"], "subtle")).toBe("default")
+    expect(resolveVariant("npm", ["v", "react"], "sparkly")).toBe("default")
+  })
+
+  it("defaults when nothing requested", () => {
+    expect(resolveVariant("npm", ["v", "react"], undefined)).toBe("default")
+  })
+
+  it("coerces branded on a flag badge to default", () => {
+    expect(resolveVariant("flag", ["in"], "branded")).toBe("default")
+  })
+
+  it("keeps a valid variant on unregistered providers", () => {
+    expect(resolveVariant("not-a-real-provider", ["x"], "branded")).toBe("branded")
+  })
+})
+
+describe("allowedVariants", () => {
+  it("falls back to ALL_VARIANTS when a topic doesn't narrow", () => {
+    const npm = REGISTRY.find((p) => p.provider === "npm")!
+    const v = npm.topics.find((t) => t.topic === "v")!
+    expect(allowedVariants(v)).toEqual(ALL_VARIANTS)
+  })
+
+  it("uses the narrowed list when present", () => {
+    const gh = REGISTRY.find((p) => p.provider === "github")!
+    const ci = gh.topics.find((t) => t.topic === "ci")!
+    expect(allowedVariants(ci)).not.toContain("branded")
+  })
+})

--- a/packages/core/src/badges/registry.ts
+++ b/packages/core/src/badges/registry.ts
@@ -1,0 +1,712 @@
+/**
+ * shieldcn
+ * lib/badges/registry
+ *
+ * THE source of truth for what each badge provider supports.
+ *
+ * The route handler accepts anything off the URL and casts it (`as BadgeStyle`),
+ * so invalid variants / unknown topics silently render. This registry declares,
+ * per provider and per topic (endpoint), exactly what is valid:
+ *
+ *   - which topics (endpoints) exist
+ *   - how path segments map to params
+ *   - which variants are allowed (defaults to ALL)
+ *   - a renderable example used by tests + the visual matrix
+ *
+ * Everything else reads from here:
+ *   - `validate.ts` rejects unknown providers/topics and unsupported variants
+ *   - tests assert every registered example renders
+ *   - (later) the docs sandbox + matrix only show real options
+ *
+ * Rollout is incremental. Only providers listed here are validated; unknown
+ * providers fall through to the legacy switch unchanged (see validate.ts).
+ */
+
+import type { BadgeStyle } from "./types"
+
+/**
+ * Every variant the renderer actually understands — one entry per case in
+ * `getButtonStyle` (button-tokens.ts). This is THE list the UI dropdowns,
+ * showcase, and validation all read from. Keep it in lockstep with BadgeStyle.
+ */
+export const ALL_VARIANTS: readonly BadgeStyle[] = [
+  "default",
+  "secondary",
+  "outline",
+  "ghost",
+  "destructive",
+  "branded",
+] as const
+
+/** Display labels for each variant (single source for UI dropdowns). */
+export const VARIANT_LABELS: Record<BadgeStyle, string> = {
+  default: "Default",
+  secondary: "Secondary",
+  outline: "Outline",
+  ghost: "Ghost",
+  destructive: "Destructive",
+  branded: "Branded",
+}
+
+/** A single endpoint within a provider (e.g. npm "v", github "stars"). */
+export interface BadgeTopic {
+  /** Topic key as it appears in the URL (e.g. "v", "stars"). */
+  topic: string
+  /** Human description for docs / matrix. */
+  description: string
+  /**
+   * Variants this topic supports. Omit to allow every variant in ALL_VARIANTS.
+   * Narrow this for badges where some variants make no sense (e.g. a status
+   * badge whose color is data-driven shouldn't offer `branded`).
+   */
+  variants?: readonly BadgeStyle[]
+  /**
+   * A real, renderable example path (segments after the provider), used by
+   * tests and the visual matrix. Should hit a stable, well-known target.
+   */
+  example: string[]
+}
+
+/** A provider and all of its topics. */
+export interface BadgeProvider {
+  /** Provider key — the first URL segment (e.g. "npm", "github"). */
+  provider: string
+  /** Human description. */
+  description: string
+  /** All endpoints this provider exposes. */
+  topics: BadgeTopic[]
+  /**
+   * Topic key used when no topic segment is present in the path
+   * (e.g. `/npm/react` defaults to "v", `/discord/{id}` to "online").
+   */
+  defaultTopic?: string
+  /**
+   * Freeform providers have no fixed topics — any path is valid (e.g. static
+   * `/badge/...`, custom `/https/...`). Variants still respect `variants` below.
+   */
+  freeform?: boolean
+  /**
+   * Variants allowed across this whole provider. Used for freeform providers
+   * (which have no per-topic narrowing) and as the fallback for any topic that
+   * doesn't declare its own `variants`. Omit to allow every variant.
+   */
+  variants?: readonly BadgeStyle[]
+}
+
+/** Synthetic topic returned for freeform providers. */
+const FREEFORM_TOPIC: BadgeTopic = {
+  topic: "*",
+  description: "Freeform badge — any path.",
+  example: [],
+}
+
+/**
+ * Every variant except `branded`. Used where `branded` is meaningless:
+ *   - pass/fail STATE badges (color is data-driven, not a brand identity)
+ *   - badges with no brand at all (e.g. country flags)
+ */
+const NO_BRANDED: readonly BadgeStyle[] = ALL_VARIANTS.filter((v) => v !== "branded")
+
+/** Shorthand for a topic with no special narrowing (all 6 variants). */
+function t(topic: string, description: string, example: string[]): BadgeTopic {
+  return { topic, description, example }
+}
+
+/** Shorthand for a pass/fail STATE topic (drops `branded`). */
+function state(topic: string, description: string, example: string[]): BadgeTopic {
+  return { topic, description, example, variants: NO_BRANDED }
+}
+
+/**
+ * Registry entries — the source of truth for every provider.
+ *
+ * `defaultTopic` = topic used when no topic segment is present.
+ * `freeform`     = any path valid, all variants (custom/static/endpoint badges).
+ * STATE badges (pass/fail/secure) drop `branded`; everything else allows all 6.
+ */
+export const REGISTRY: BadgeProvider[] = [
+  {
+    provider: "npm",
+    description: "npm package version, downloads, license, and metadata.",
+    defaultTopic: "v",
+    topics: [
+      t("v", "Latest published version", ["v", "react"]),
+      t("dw", "Downloads last week", ["dw", "react"]),
+      t("dm", "Downloads last month", ["dm", "react"]),
+      t("dy", "Downloads last year", ["dy", "react"]),
+      t("dt", "Total downloads", ["dt", "react"]),
+      t("license", "Declared license", ["license", "react"]),
+      t("node", "Required Node version", ["node", "react"]),
+      t("types", "TypeScript types availability", ["types", "react"]),
+      t("dependents", "Number of dependents", ["dependents", "react"]),
+    ],
+  },
+  {
+    provider: "github",
+    description: "GitHub repo and user stats, releases, and CI status.",
+    topics: [
+      t("stars", "Repository stars", ["stars", "facebook", "react"]),
+      t("forks", "Repository forks", ["forks", "facebook", "react"]),
+      t("watchers", "Repository watchers", ["watchers", "facebook", "react"]),
+      t("license", "Repository license", ["license", "facebook", "react"]),
+      t("branches", "Branch count", ["branches", "facebook", "react"]),
+      t("releases", "Release count", ["releases", "facebook", "react"]),
+      t("tags", "Tag count", ["tags", "facebook", "react"]),
+      t("tag", "Latest tag", ["tag", "facebook", "react"]),
+      t("release", "Latest release", ["release", "facebook", "react"]),
+      t("contributors", "Contributor count", ["contributors", "facebook", "react"]),
+      t("issues", "Open issues", ["issues", "facebook", "react"]),
+      t("open-issues", "Open issues", ["open-issues", "facebook", "react"]),
+      t("closed-issues", "Closed issues", ["closed-issues", "facebook", "react"]),
+      t("label-issues", "Issues with a label", ["label-issues", "facebook", "react", "bug"]),
+      t("prs", "Open pull requests", ["prs", "facebook", "react"]),
+      t("open-prs", "Open pull requests", ["open-prs", "facebook", "react"]),
+      t("closed-prs", "Closed pull requests", ["closed-prs", "facebook", "react"]),
+      t("merged-prs", "Merged pull requests", ["merged-prs", "facebook", "react"]),
+      t("milestones", "Milestone count", ["milestones", "facebook", "react"]),
+      t("commits", "Commit count", ["commits", "facebook", "react"]),
+      t("last-commit", "Time since last commit", ["last-commit", "facebook", "react"]),
+      t("assets-dl", "Release asset downloads", ["assets-dl", "facebook", "react"]),
+      t("dt", "Total downloads", ["dt", "facebook", "react"]),
+      t("downloads", "Release downloads", ["downloads", "facebook", "react"]),
+      t("downloads-all", "All release downloads", ["downloads-all", "facebook", "react"]),
+      t("downloads-asset", "Specific asset downloads", ["downloads-asset", "facebook", "react"]),
+      t("dependents-repo", "Dependent repositories", ["dependents-repo", "facebook", "react"]),
+      t("dependents-pkg", "Dependent packages", ["dependents-pkg", "facebook", "react"]),
+      // Pass/fail state badges — no `branded`.
+      state("ci", "GitHub Actions CI status", ["ci", "facebook", "react"]),
+      state("checks", "Combined check status", ["checks", "facebook", "react"]),
+      state("dependabot", "Dependabot security state", ["dependabot", "facebook", "react"]),
+      // User-level (2-segment) endpoints.
+      t("followers", "GitHub user followers", ["followers", "torvalds"]),
+      t("user-stars", "Total stars across a user's repos", ["user-stars", "torvalds"]),
+    ],
+  },
+  {
+    provider: "discord",
+    description: "Discord server online members.",
+    defaultTopic: "online",
+    topics: [
+      t("online", "Online members (by server ID)", ["1316199667142496307"]),
+      t("members", "Total members (by invite)", ["members", "abcdef"]),
+      t("online-members", "Online members (by invite)", ["online-members", "abcdef"]),
+    ],
+  },
+  {
+    provider: "reddit",
+    description: "Reddit karma and subreddit subscribers.",
+    topics: [
+      t("karma", "User karma", ["karma", "u", "spez"]),
+      t("subscribers", "Subreddit subscribers", ["subscribers", "r", "typescript"]),
+    ],
+  },
+  {
+    provider: "memo",
+    description: "Persisted custom key/value badges.",
+    freeform: true,
+    topics: [],
+  },
+  {
+    provider: "badge",
+    description: "Static and dynamic custom badges.",
+    freeform: true,
+    topics: [],
+  },
+  {
+    provider: "flag",
+    description: "\u201cBuilt in {country}\u201d badge with a flag inset.",
+    freeform: true,
+    // A flag chip has no brand identity, so `branded` doesn't apply.
+    variants: NO_BRANDED,
+    topics: [],
+  },
+  {
+    provider: "https",
+    description: "Custom badge from an arbitrary HTTPS endpoint.",
+    freeform: true,
+    topics: [],
+  },
+  {
+    provider: "pypi",
+    description: "PyPI package version, downloads, and metadata.",
+    defaultTopic: "v",
+    topics: [
+      t("v", "Latest version", ["v", "django"]),
+      t("dd", "Downloads per day", ["dd", "django"]),
+      t("dw", "Downloads per week", ["dw", "django"]),
+      t("dm", "Downloads per month", ["dm", "django"]),
+      t("license", "Declared license", ["license", "django"]),
+      t("python", "Required Python version", ["python", "django"]),
+    ],
+  },
+  {
+    provider: "crates",
+    description: "Crates.io version, downloads, and license.",
+    defaultTopic: "v",
+    topics: [
+      t("v", "Latest version", ["v", "serde"]),
+      t("d", "Total downloads", ["d", "serde"]),
+      t("dr", "Recent downloads", ["dr", "serde"]),
+      t("license", "Declared license", ["license", "serde"]),
+    ],
+  },
+  {
+    provider: "docker",
+    description: "Docker Hub pulls, stars, version, and image size.",
+    defaultTopic: "pulls",
+    topics: [
+      t("pulls", "Pull count", ["library", "nginx", "pulls"]),
+      t("stars", "Stars", ["library", "nginx", "stars"]),
+      t("v", "Latest version tag", ["library", "nginx", "v"]),
+      t("size", "Image size", ["library", "nginx", "size"]),
+    ],
+  },
+  {
+    provider: "bluesky",
+    description: "Bluesky followers, following, and posts.",
+    topics: [
+      t("followers", "Followers", ["followers", "bsky.app"]),
+      t("following", "Following", ["following", "bsky.app"]),
+      t("posts", "Posts", ["posts", "bsky.app"]),
+    ],
+  },
+  {
+    provider: "x",
+    description: "X (Twitter) follow and mention badges.",
+    topics: [
+      t("follow", "Follow", ["follow", "jal_co"]),
+      t("mention", "Mention", ["mention", "jal_co"]),
+    ],
+  },
+  {
+    provider: "twitter",
+    description: "Alias of the x provider.",
+    topics: [
+      t("follow", "Follow", ["follow", "jal_co"]),
+      t("mention", "Mention", ["mention", "jal_co"]),
+    ],
+  },
+  {
+    provider: "jsr",
+    description: "JSR package version and score.",
+    defaultTopic: "v",
+    topics: [
+      t("v", "Latest version", ["@std", "path", "v"]),
+      t("score", "Package score", ["@std", "path", "score"]),
+    ],
+  },
+  {
+    provider: "bundlephobia",
+    description: "Bundle size from Bundlephobia.",
+    defaultTopic: "minzip",
+    topics: [
+      t("min", "Minified size", ["min", "react"]),
+      t("minzip", "Minified + gzipped size", ["minzip", "react"]),
+      t("tree-shaking", "Tree-shaking support", ["tree-shaking", "react"]),
+    ],
+  },
+  {
+    provider: "youtube",
+    description: "YouTube channel and video stats.",
+    topics: [
+      t("subscribers", "Channel subscribers", ["UCsBjURrPoezykLs9EqgamOA", "subscribers"]),
+      t("channel-views", "Channel views", ["UCsBjURrPoezykLs9EqgamOA", "channel-views"]),
+      t("views", "Video views", ["dQw4w9WgXcQ", "views"]),
+      t("likes", "Video likes", ["dQw4w9WgXcQ", "likes"]),
+      t("comments", "Video comments", ["dQw4w9WgXcQ", "comments"]),
+    ],
+  },
+  {
+    provider: "vscode",
+    description: "VS Code Marketplace installs, rating, and version.",
+    topics: [
+      t("installs", "Install count", ["esbenp", "prettier-vscode", "installs"]),
+      t("rating", "Average rating", ["esbenp", "prettier-vscode", "rating"]),
+      t("v", "Latest version", ["esbenp", "prettier-vscode", "v"]),
+    ],
+  },
+  {
+    provider: "opencollective",
+    description: "Open Collective backers, sponsors, and balance.",
+    topics: [
+      t("backers", "Backers", ["backers", "webpack"]),
+      t("sponsors", "Sponsors", ["sponsors", "webpack"]),
+      t("contributors", "Contributors", ["contributors", "webpack"]),
+      t("balance", "Balance", ["balance", "webpack"]),
+      t("budget", "Annual budget", ["budget", "webpack"]),
+    ],
+  },
+  {
+    provider: "hackernews",
+    description: "Hacker News user karma.",
+    freeform: true,
+    topics: [],
+  },
+  {
+    provider: "mastodon",
+    description: "Mastodon followers, following, and posts.",
+    topics: [
+      t("followers", "Followers", ["mastodon.social", "Gargron", "followers"]),
+      t("following", "Following", ["mastodon.social", "Gargron", "following"]),
+      t("posts", "Posts", ["mastodon.social", "Gargron", "posts"]),
+    ],
+  },
+  {
+    provider: "lemmy",
+    description: "Lemmy community subscribers, posts, and comments.",
+    topics: [
+      t("subscribers", "Subscribers", ["lemmy.ml", "technology", "subscribers"]),
+      t("posts", "Posts", ["lemmy.ml", "technology", "posts"]),
+      t("comments", "Comments", ["lemmy.ml", "technology", "comments"]),
+    ],
+  },
+  {
+    provider: "packagist",
+    description: "Packagist (PHP) version, downloads, and license.",
+    defaultTopic: "v",
+    topics: [
+      t("v", "Latest version", ["v", "laravel", "framework"]),
+      t("dt", "Total downloads", ["dt", "laravel", "framework"]),
+      t("dm", "Monthly downloads", ["dm", "laravel", "framework"]),
+      t("dd", "Daily downloads", ["dd", "laravel", "framework"]),
+      t("license", "Declared license", ["license", "laravel", "framework"]),
+    ],
+  },
+  {
+    provider: "rubygems",
+    description: "RubyGems version, downloads, and license.",
+    defaultTopic: "v",
+    topics: [
+      t("v", "Latest version", ["v", "rails"]),
+      t("dt", "Total downloads", ["dt", "rails"]),
+      t("dv", "Version downloads", ["dv", "rails"]),
+      t("license", "Declared license", ["license", "rails"]),
+    ],
+  },
+  {
+    provider: "nuget",
+    description: "NuGet version and downloads.",
+    defaultTopic: "v",
+    topics: [
+      t("v", "Latest version", ["v", "Newtonsoft.Json"]),
+      t("dt", "Total downloads", ["dt", "Newtonsoft.Json"]),
+    ],
+  },
+  {
+    provider: "pub",
+    description: "Dart/Flutter pub.dev version and scores.",
+    defaultTopic: "v",
+    topics: [
+      t("v", "Latest version", ["v", "provider"]),
+      t("likes", "Likes", ["likes", "provider"]),
+      t("points", "Pub points", ["points", "provider"]),
+      t("popularity", "Popularity", ["popularity", "provider"]),
+    ],
+  },
+  {
+    provider: "homebrew",
+    description: "Homebrew formula/cask version and installs.",
+    defaultTopic: "v",
+    topics: [
+      t("v", "Formula version", ["v", "wget"]),
+      t("cask", "Cask version", ["cask", "firefox"]),
+      t("installs", "Install count", ["installs", "wget"]),
+      t("dm", "Monthly downloads", ["dm", "wget"]),
+      t("dq", "Quarterly downloads", ["dq", "wget"]),
+      t("dy", "Yearly downloads", ["dy", "wget"]),
+      t("cask-dm", "Cask monthly downloads", ["cask-dm", "firefox"]),
+      t("cask-dq", "Cask quarterly downloads", ["cask-dq", "firefox"]),
+      t("cask-dy", "Cask yearly downloads", ["cask-dy", "firefox"]),
+    ],
+  },
+  {
+    provider: "maven",
+    description: "Maven Central latest version.",
+    freeform: true,
+    topics: [],
+  },
+  {
+    provider: "cocoapods",
+    description: "CocoaPods latest version.",
+    freeform: true,
+    topics: [],
+  },
+  {
+    provider: "codecov",
+    description: "Codecov coverage percentage.",
+    freeform: true,
+    topics: [],
+  },
+  {
+    provider: "wakatime",
+    description: "WakaTime coding time.",
+    freeform: true,
+    topics: [],
+  },
+  {
+    provider: "tokscale",
+    description: "Tokscale token usage and rank.",
+    defaultTopic: "stats",
+    topics: [
+      t("tokens", "Tokens used", ["tokens", "someuser"]),
+      t("cost", "Cost", ["cost", "someuser"]),
+      t("rank", "Rank", ["rank", "someuser"]),
+      t("active-days", "Active days", ["active-days", "someuser"]),
+      t("stats", "Aggregate stats", ["stats"]),
+    ],
+  },
+  {
+    provider: "indiedevs",
+    description: "IndieDevs membership badge.",
+    freeform: true,
+    topics: [],
+  },
+  {
+    provider: "gitlab",
+    description: "GitLab repo stats, pipeline status, and releases.",
+    topics: [
+      t("stars", "Stars", ["stars", "gitlab-org", "gitlab"]),
+      t("forks", "Forks", ["forks", "gitlab-org", "gitlab"]),
+      t("issues", "Open issues", ["issues", "gitlab-org", "gitlab"]),
+      t("open-issues", "Open issues", ["open-issues", "gitlab-org", "gitlab"]),
+      t("closed-issues", "Closed issues", ["closed-issues", "gitlab-org", "gitlab"]),
+      t("license", "License", ["license", "gitlab-org", "gitlab"]),
+      t("last-commit", "Time since last commit", ["last-commit", "gitlab-org", "gitlab"]),
+      t("contributors", "Contributors", ["contributors", "gitlab-org", "gitlab"]),
+      t("release", "Latest release", ["release", "gitlab-org", "gitlab"]),
+      state("pipeline", "Pipeline status", ["pipeline", "gitlab-org", "gitlab"]),
+    ],
+  },
+  {
+    provider: "conda",
+    description: "Conda version, downloads, and platform.",
+    defaultTopic: "v",
+    topics: [
+      t("v", "Latest version", ["v", "conda-forge", "numpy"]),
+      t("d", "Downloads", ["d", "conda-forge", "numpy"]),
+      t("platform", "Supported platforms", ["platform", "conda-forge", "numpy"]),
+    ],
+  },
+  {
+    provider: "chrome",
+    description: "Chrome Web Store version, users, and rating.",
+    topics: [
+      t("v", "Latest version", ["v", "cjpalhdlnbpafiamejdnhcphjbkeiagm"]),
+      t("users", "User count", ["users", "cjpalhdlnbpafiamejdnhcphjbkeiagm"]),
+      t("rating", "Average rating", ["rating", "cjpalhdlnbpafiamejdnhcphjbkeiagm"]),
+    ],
+  },
+  {
+    provider: "amo",
+    description: "Firefox Add-ons version, users, rating, and downloads.",
+    defaultTopic: "v",
+    topics: [
+      t("v", "Latest version", ["v", "ublock-origin"]),
+      t("users", "User count", ["users", "ublock-origin"]),
+      t("rating", "Average rating", ["rating", "ublock-origin"]),
+      t("d", "Downloads", ["d", "ublock-origin"]),
+    ],
+  },
+  {
+    provider: "coveralls",
+    description: "Coveralls coverage percentage.",
+    freeform: true,
+    topics: [],
+  },
+  {
+    provider: "sonar",
+    description: "SonarQube quality gate and code health metrics.",
+    topics: [
+      t("bugs", "Bug count", ["bugs", "my-project"]),
+      t("vulnerabilities", "Vulnerability count", ["vulnerabilities", "my-project"]),
+      t("code-smells", "Code smell count", ["code-smells", "my-project"]),
+      t("coverage", "Coverage percentage", ["coverage", "my-project"]),
+      t("duplicated-lines", "Duplicated lines density", ["duplicated-lines", "my-project"]),
+      t("maintainability", "Maintainability rating", ["maintainability", "my-project"]),
+      t("reliability", "Reliability rating", ["reliability", "my-project"]),
+      t("security", "Security rating", ["security", "my-project"]),
+      state("quality-gate", "Quality gate status", ["quality-gate", "my-project"]),
+    ],
+  },
+  {
+    provider: "jsdelivr",
+    description: "jsDelivr CDN hits and rank.",
+    topics: [
+      t("hits", "Monthly hits", ["hits", "npm", "react"]),
+      t("dm", "Monthly hits", ["dm", "npm", "react"]),
+      t("dy", "Yearly hits", ["dy", "npm", "react"]),
+      t("rank", "Popularity rank", ["rank", "npm", "react"]),
+    ],
+  },
+  {
+    provider: "chocolatey",
+    description: "Chocolatey version and downloads.",
+    defaultTopic: "v",
+    topics: [
+      t("v", "Latest version", ["v", "git"]),
+      t("dt", "Total downloads", ["dt", "git"]),
+    ],
+  },
+  {
+    provider: "flathub",
+    description: "Flathub version and downloads.",
+    defaultTopic: "v",
+    topics: [
+      t("v", "Latest version", ["v", "org.gimp.GIMP"]),
+      t("downloads", "Downloads", ["downloads", "org.gimp.GIMP"]),
+    ],
+  },
+  {
+    provider: "snapcraft",
+    description: "Snapcraft latest version.",
+    freeform: true,
+    topics: [],
+  },
+  {
+    provider: "fdroid",
+    description: "F-Droid latest version.",
+    freeform: true,
+    topics: [],
+  },
+  {
+    provider: "discourse",
+    description: "Discourse forum topics, posts, users, and likes.",
+    topics: [
+      t("topics", "Topic count", ["topics", "meta.discourse.org"]),
+      t("posts", "Post count", ["posts", "meta.discourse.org"]),
+      t("users", "User count", ["users", "meta.discourse.org"]),
+      t("likes", "Like count", ["likes", "meta.discourse.org"]),
+    ],
+  },
+  {
+    provider: "stackexchange",
+    description: "Stack Exchange tag questions and reputation.",
+    topics: [
+      t("tag", "Questions for a tag", ["tag", "typescript"]),
+      t("reputation", "User reputation", ["reputation", "22656"]),
+    ],
+  },
+  {
+    provider: "modrinth",
+    description: "Modrinth downloads, followers, and version.",
+    topics: [
+      t("downloads", "Downloads", ["downloads", "sodium"]),
+      t("followers", "Followers", ["followers", "sodium"]),
+      t("v", "Latest version", ["v", "sodium"]),
+      t("game-versions", "Supported game versions", ["game-versions", "sodium"]),
+    ],
+  },
+  {
+    provider: "openvsx",
+    description: "Open VSX version, downloads, and rating.",
+    topics: [
+      t("v", "Latest version", ["rust-lang", "rust-analyzer", "v"]),
+      t("downloads", "Downloads", ["rust-lang", "rust-analyzer", "downloads"]),
+      t("rating", "Average rating", ["rust-lang", "rust-analyzer", "rating"]),
+    ],
+  },
+  {
+    provider: "liberapay",
+    description: "Liberapay receiving, patrons, and goal.",
+    topics: [
+      t("receiving", "Weekly receiving", ["receiving", "someuser"]),
+      t("patrons", "Patron count", ["patrons", "someuser"]),
+      t("goal", "Goal progress", ["goal", "someuser"]),
+    ],
+  },
+  {
+    provider: "matrix",
+    description: "Matrix room members.",
+    defaultTopic: "members",
+    topics: [
+      t("members", "Room members", ["members", "matrix"]),
+    ],
+  },
+  {
+    provider: "weblate",
+    description: "Weblate translation progress and languages.",
+    topics: [
+      t("translation", "Translation progress", ["translation", "hosted.weblate.org", "weblate", "application"]),
+      t("languages", "Language count", ["languages", "hosted.weblate.org", "weblate", "application"]),
+    ],
+  },
+  {
+    provider: "shipperclub",
+    description: "ShipperClub membership badge.",
+    freeform: true,
+    topics: [],
+  },
+]
+
+/** Fast lookup by provider key. */
+export const REGISTRY_BY_PROVIDER: ReadonlyMap<string, BadgeProvider> = new Map(
+  REGISTRY.map((p) => [p.provider, p])
+)
+
+/** Is this provider modeled in the registry yet? */
+export function isRegistered(provider: string): boolean {
+  return REGISTRY_BY_PROVIDER.has(provider)
+}
+
+/**
+ * Resolve the topic for a set of path segments (segments AFTER the provider).
+ * Returns the matching BadgeTopic, or null if the topic is unknown.
+ *
+ * Strategy (order matters):
+ *   1. Freeform providers → the wildcard topic (any path, all variants).
+ *   2. The first segment that is a known topic key wins. This handles every
+ *      segment ordering uniformly — `/{topic}/...`, `/.../{topic}`, etc. —
+ *      because topic keys are distinctive keywords, not user values.
+ *   3. No topic segment present → the provider's defaultTopic, if any.
+ *   4. Otherwise unknown.
+ */
+export function resolveTopic(provider: string, rest: string[]): BadgeTopic | null {
+  const entry = REGISTRY_BY_PROVIDER.get(provider)
+  if (!entry) return null
+  if (entry.freeform) {
+    return entry.variants ? { ...FREEFORM_TOPIC, variants: entry.variants } : FREEFORM_TOPIC
+  }
+
+  const byKey = new Map(entry.topics.map((t) => [t.topic, t]))
+  const pick = (t: BadgeTopic | undefined) =>
+    t && !t.variants && entry.variants ? { ...t, variants: entry.variants } : (t ?? null)
+
+  for (const seg of rest) {
+    const hit = byKey.get(seg)
+    if (hit) return pick(hit)
+  }
+
+  if (entry.defaultTopic) {
+    return pick(byKey.get(entry.defaultTopic))
+  }
+  return null
+}
+
+/** Variants allowed for a topic (falls back to ALL_VARIANTS). */
+export function allowedVariants(topic: BadgeTopic): readonly BadgeStyle[] {
+  return topic.variants ?? ALL_VARIANTS
+}
+
+/**
+ * Variants allowed for a resolved badge path (e.g. "/github/vercel/next.js/ci.svg"
+ * or "github/ci/vercel/react"). Used by the builder/showcase to narrow the
+ * variant dropdown to only what the selected badge actually supports.
+ *
+ * Falls back to ALL_VARIANTS for providers not modeled in the registry yet, so
+ * the dropdown never over-restricts during incremental rollout.
+ */
+export function allowedVariantsForPath(path: string): readonly BadgeStyle[] {
+  const clean = path
+    .replace(/\.(svg|png|gif|json)$/i, "")
+    .split("/")
+    .filter(Boolean)
+  if (clean.length === 0) return ALL_VARIANTS
+
+  // Groups render multiple badges; variants apply uniformly, so allow all.
+  const provider = clean[0]
+  if (provider === "group") return ALL_VARIANTS
+  if (!isRegistered(provider)) return ALL_VARIANTS
+
+  const topic = resolveTopic(provider, clean.slice(1))
+  return topic ? allowedVariants(topic) : ALL_VARIANTS
+}

--- a/packages/core/src/badges/types.ts
+++ b/packages/core/src/badges/types.ts
@@ -5,8 +5,17 @@
  * Shared types for the badge rendering engine.
  */
 
-/** Visual style variants for badges (maps to shadcn Button variant). */
-export type BadgeStyle = "default" | "outline" | "subtle" | "flat" | "ghost" | "secondary" | "destructive" | "branded"
+/**
+ * Visual style variants for badges (maps to shadcn Button variant).
+ *
+ * This is the complete, honest set — every value here has a real case in
+ * `getButtonStyle` (button-tokens.ts). Do not add a value here without a
+ * corresponding render case, or it becomes a phantom variant that silently
+ * falls through to `default`. Legacy shields.io styles (flat, flat-square,
+ * plastic, for-the-badge) are INPUTS that get mapped to one of these — they
+ * are not variants themselves (see migrate/transform.ts).
+ */
+export type BadgeStyle = "default" | "secondary" | "outline" | "ghost" | "destructive" | "branded"
 
 /** Badge size presets (maps to shadcn Button size). */
 export type BadgeSize = "xs" | "sm" | "default" | "lg"

--- a/packages/core/src/badges/validate.ts
+++ b/packages/core/src/badges/validate.ts
@@ -1,0 +1,96 @@
+/**
+ * shieldcn
+ * lib/badges/validate
+ *
+ * Validates an incoming badge request against the registry (the source of truth).
+ *
+ * Design goals:
+ *   - Fail loudly, not silently. An unsupported variant on a badge that doesn't
+ *     support it should be visible, not quietly rendered.
+ *   - Incremental & non-breaking. Only providers present in the registry are
+ *     validated. Unknown providers return `ok` so the legacy switch keeps working
+ *     untouched while we roll the registry out provider-by-provider.
+ */
+
+import type { BadgeStyle } from "./types"
+import { ALL_VARIANTS, allowedVariants, isRegistered, resolveTopic } from "./registry"
+
+export interface ValidationResult {
+  /** True when the request is valid (or the provider isn't modeled yet). */
+  ok: boolean
+  /** Machine-readable failure code. */
+  code?: "unsupported-variant"
+  /** Human-readable message, suitable for an error badge value. */
+  message?: string
+}
+
+const VARIANT_SET = new Set<string>(ALL_VARIANTS)
+
+/**
+ * Validate a parsed badge request.
+ *
+ * @param provider  first URL segment (e.g. "npm")
+ * @param rest      segments AFTER the provider
+ * @param variant   the requested variant (style), already lowercased
+ */
+export function validateBadgeRequest(
+  provider: string,
+  rest: string[],
+  variant: string | undefined
+): ValidationResult {
+  // Not modeled yet → defer to legacy behavior. Non-breaking by design.
+  if (!isRegistered(provider)) return { ok: true }
+
+  // Unknown topic → defer. We can't determine a variant policy, and the data
+  // layer (fetchBadgeData) already returns a graceful "not found" badge for
+  // genuinely unknown topics. Erroring here would risk breaking a real badge
+  // if the registry's topic list is ever incomplete — so we stay non-breaking.
+  const topic = resolveTopic(provider, rest)
+  if (!topic) return { ok: true }
+
+  // No variant requested → default is always valid.
+  if (!variant) return { ok: true }
+
+  // An entirely unknown variant string.
+  if (!VARIANT_SET.has(variant)) {
+    return {
+      ok: false,
+      code: "unsupported-variant",
+      message: `unknown variant "${variant}"`,
+    }
+  }
+
+  // A real variant, but not allowed for this specific badge.
+  const allowed = allowedVariants(topic)
+  if (!allowed.includes(variant as BadgeStyle)) {
+    return {
+      ok: false,
+      code: "unsupported-variant",
+      message: `variant "${variant}" not supported for ${provider}/${topic.topic}`,
+    }
+  }
+
+  return { ok: true }
+}
+
+/**
+ * Resolve the EFFECTIVE variant for a request — the requested one if valid,
+ * otherwise "default". This is non-breaking by design:
+ *   - Unknown variant strings (e.g. legacy `flat`, `subtle`, typos) coerce to
+ *     "default", which is exactly how they rendered before (they fell through
+ *     the renderer's switch to the default case).
+ *   - A real variant that a specific badge doesn't support (e.g. `branded` on
+ *     a CI status badge) coerces to "default" instead of erroring.
+ * No previously-rendering URL ever becomes a broken/error image.
+ */
+export function resolveVariant(
+  provider: string,
+  rest: string[],
+  requested: string | undefined,
+): BadgeStyle {
+  const variant = (requested || "default").toLowerCase()
+  if (variant === "default") return "default"
+  return validateBadgeRequest(provider, rest, variant).ok
+    ? (variant as BadgeStyle)
+    : "default"
+}

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -16,6 +16,7 @@ import { getProviderBrandColor } from "./badges/brand-colors"
 import { parseSvg, decodeSvgDataUri } from "./badges/svg-parser"
 import { normalizeSearchParams } from "./normalize-params"
 import type { BadgeData, BadgeConfig, BadgeStyle, BadgeSize } from "./badges/types"
+import { resolveVariant } from "./badges/validate"
 
 /**
  * A single metric emission. Apps wire this to Sentry.metrics (or any
@@ -1729,7 +1730,14 @@ async function handleBadgeGETInner(
   }
 
   // SVG response
-  let style = (searchParams.get("style") || searchParams.get("variant") || "default") as BadgeStyle
+  // Resolve the effective variant against the registry. Unsupported variants
+  // (legacy `flat`/`subtle`, typos, or `branded` on a state badge) coerce to
+  // "default" — non-breaking: nothing that rendered before becomes an error.
+  let style = resolveVariant(
+    cleanSegments[0],
+    cleanSegments.slice(1),
+    searchParams.get("style") || searchParams.get("variant") || undefined,
+  )
   const size = (searchParams.get("size") || undefined) as BadgeSize | undefined
   const mode = (searchParams.get("mode") === "light" ? "light" : "dark") as "light" | "dark"
   const theme = searchParams.get("theme") ?? undefined

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,13 @@
+/**
+ * shieldcn
+ * packages/core/vitest.config
+ */
+
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    environment: "node",
+  },
+})

--- a/packages/web/components/badge-builder-core.tsx
+++ b/packages/web/components/badge-builder-core.tsx
@@ -92,14 +92,36 @@ function findMatchingPreset(path: string): { preset: BadgePreset; values: Record
 // Variant clamping
 // ---------------------------------------------------------------------------
 
+// Provider → SimpleIcons slug, for the `branded` variant's auto logo/color.
+// A badge can only use `branded` if we have a known icon for its provider AND
+// it isn't a static `/badge/` (which has no auto-brand). This is the builder's
+// branded rule — it MUST be shared by both the dropdown filter and clampVariant
+// so the selected state can never disagree with what the dropdown allows.
+const PROVIDER_ICON: Record<string, string> = {
+  npm: "npm", pypi: "pypi", crates: "rust", docker: "docker",
+  jsr: "jsr", discord: "discord", reddit: "reddit",
+  youtube: "youtube", twitch: "twitch", github: "github",
+  gitlab: "gitlab", bluesky: "bluesky", x: "x", twitter: "x",
+}
+
+/** Whether the `branded` variant is usable for a given badge path. */
+function brandedEligible(path: string): boolean {
+  const provider = path.split("/").filter(Boolean)[0] || ""
+  return !!PROVIDER_ICON[provider] && !path.startsWith("/badge/")
+}
+
 /**
- * If a state's variant isn't valid for its badge path (per the core registry),
- * snap it back to "default". Applied whenever the path changes so the preview
- * never shows a variant the selected badge doesn't support.
+ * If a state's variant isn't valid for its badge path, snap it back to
+ * "default". Applied whenever the path changes so the preview/URL never carry a
+ * variant the selected badge doesn't support. Mirrors the dropdown's rule:
+ * registry-allowed AND (not `branded`, or branded-eligible).
  */
 function clampVariant(next: BuilderState): BuilderState {
   const allowed = allowedVariantsForPath(next.path)
-  return allowed.includes(next.variant as never) ? next : { ...next, variant: "default" }
+  const ok =
+    allowed.includes(next.variant as never) &&
+    (next.variant !== "branded" || brandedEligible(next.path))
+  return ok ? next : { ...next, variant: "default" }
 }
 
 // ---------------------------------------------------------------------------
@@ -211,17 +233,10 @@ export function BadgeBuilderCore({
 
   const isDefault = JSON.stringify(s) === JSON.stringify(BUILDER_DEFAULTS)
 
-  // Map provider to its SimpleIcons slug for branded preview
-  const PROVIDER_ICON: Record<string, string> = {
-    npm: "npm", pypi: "pypi", crates: "rust", docker: "docker",
-    jsr: "jsr", discord: "discord", reddit: "reddit",
-    youtube: "youtube", twitch: "twitch", github: "github",
-    gitlab: "gitlab", bluesky: "bluesky", x: "x", twitter: "x",
-  }
-
   const currentProvider = useMemo(() => s.path.split("/").filter(Boolean)[0] || "", [s.path])
   const brandedIcon = PROVIDER_ICON[currentProvider] || ""
-  const hasBranded = brandedIcon !== "" && !s.path.startsWith("/badge/")
+  // Shared with clampVariant so the dropdown and the selected state never drift.
+  const hasBranded = brandedEligible(s.path)
 
   // Variants the SELECTED badge actually supports, per the core registry
   // (source of truth). Combined with the branded-icon check below so the

--- a/packages/web/components/badge-builder-core.tsx
+++ b/packages/web/components/badge-builder-core.tsx
@@ -39,6 +39,8 @@ import {
   resolveTemplate,
   resolveDefaultLinkUrl,
   VARIANTS,
+  VARIANT_LABELS,
+  allowedVariantsForPath,
   SIZES,
   MODES,
   FONTS,
@@ -87,16 +89,17 @@ function findMatchingPreset(path: string): { preset: BadgePreset; values: Record
 }
 
 // ---------------------------------------------------------------------------
-// Variant display
+// Variant clamping
 // ---------------------------------------------------------------------------
 
-const VARIANT_DISPLAY: Record<string, { label: string }> = {
-  default: { label: "Default" },
-  secondary: { label: "Secondary" },
-  outline: { label: "Outline" },
-  ghost: { label: "Ghost" },
-  destructive: { label: "Destructive" },
-  branded: { label: "Branded" },
+/**
+ * If a state's variant isn't valid for its badge path (per the core registry),
+ * snap it back to "default". Applied whenever the path changes so the preview
+ * never shows a variant the selected badge doesn't support.
+ */
+function clampVariant(next: BuilderState): BuilderState {
+  const allowed = allowedVariantsForPath(next.path)
+  return allowed.includes(next.variant as never) ? next : { ...next, variant: "default" }
 }
 
 // ---------------------------------------------------------------------------
@@ -157,7 +160,7 @@ export function BadgeBuilderCore({
 
   const updatePath = useCallback((preset: BadgePreset, values: Record<string, string>, extraState?: Partial<BuilderState>) => {
     const path = resolveTemplate(preset, values)
-    onChange({ ...s, ...extraState, path })
+    onChange(clampVariant({ ...s, ...extraState, path }))
     setImgError(false)
   }, [s, onChange])
 
@@ -193,7 +196,7 @@ export function BadgeBuilderCore({
     setRawPathInput(val)
     if (debounceRef.current) clearTimeout(debounceRef.current)
     debounceRef.current = setTimeout(() => {
-      onChange({ ...s, path: val })
+      onChange(clampVariant({ ...s, path: val }))
       setImgError(false)
     }, 400)
   }, [s, onChange])
@@ -220,6 +223,16 @@ export function BadgeBuilderCore({
   const brandedIcon = PROVIDER_ICON[currentProvider] || ""
   const hasBranded = brandedIcon !== "" && !s.path.startsWith("/badge/")
 
+  // Variants the SELECTED badge actually supports, per the core registry
+  // (source of truth). Combined with the branded-icon check below so the
+  // dropdown never lists a variant this badge can't render.
+  const allowedForPath = useMemo(() => new Set(allowedVariantsForPath(s.path)), [s.path])
+  const variantAllowed = useCallback(
+    (v: string) => allowedForPath.has(v as never) && (v !== "branded" || hasBranded),
+    [allowedForPath, hasBranded],
+  )
+
+
   // Build variant preview URLs — static badges showing variant name in that variant's style
   const variantPreviewUrls = useMemo(() => {
     if (!badgeUrl) return {} as Record<string, string>
@@ -227,8 +240,8 @@ export function BadgeBuilderCore({
     try {
       const base = new URL(badgeUrl).origin
       for (const v of VARIANTS) {
-        if (v === "branded" && !hasBranded) continue
-        const label = VARIANT_DISPLAY[v]?.label ?? v
+        if (!variantAllowed(v)) continue
+        const label = VARIANT_LABELS[v] ?? v
         const p = new URLSearchParams()
         if (v !== "default") p.set("variant", v)
         p.set("size", "default")
@@ -240,7 +253,7 @@ export function BadgeBuilderCore({
       }
     } catch { /* noop */ }
     return map
-  }, [badgeUrl, s.mode, brandedIcon, hasBranded])
+  }, [badgeUrl, s.mode, brandedIcon, variantAllowed])
 
   const handleReset = useCallback(() => {
     onChange(BUILDER_DEFAULTS)
@@ -368,8 +381,8 @@ export function BadgeBuilderCore({
           {/* ── Row 2: Style (variant + dropdowns) ── */}
           <div className="space-y-3">
             <SectionLabel>Style</SectionLabel>
-            <div className={cn("grid grid-cols-3 gap-1.5", hasBranded ? "sm:grid-cols-6" : "sm:grid-cols-5")}>
-              {VARIANTS.filter(v => v !== "branded" || hasBranded).map(v => (
+            <div className={cn("grid grid-cols-3 gap-1.5", "sm:grid-cols-6")}>
+              {VARIANTS.filter(variantAllowed).map(v => (
                 <button
                   key={v}
                   onClick={() => set("variant", v)}
@@ -384,12 +397,12 @@ export function BadgeBuilderCore({
                     // eslint-disable-next-line @next/next/no-img-element
                     <img
                       src={variantPreviewUrls[v]}
-                      alt={VARIANT_DISPLAY[v]?.label ?? v}
+                      alt={VARIANT_LABELS[v] ?? v}
                       className="h-[26px] select-none"
                     />
                   ) : (
                     <span className="text-[11px] text-muted-foreground">
-                      {VARIANT_DISPLAY[v]?.label ?? v}
+                      {VARIANT_LABELS[v] ?? v}
                     </span>
                   )}
                 </button>

--- a/packages/web/components/badge-group-modal.tsx
+++ b/packages/web/components/badge-group-modal.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { useState, useCallback, useEffect, useMemo } from "react"
+import { useState, useCallback, useMemo, useSyncExternalStore } from "react"
+import Link from "next/link"
 import { Copy, Check, ExternalLink, Plus, Trash2, GripVertical } from "lucide-react"
 import { useBadgeMode } from "@/lib/use-badge-mode"
 import {
@@ -20,6 +21,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { ALL_VARIANTS } from "@shieldcn/core/badges/registry"
 
 interface BadgeGroupModalProps {
   title: string
@@ -29,7 +31,9 @@ interface BadgeGroupModalProps {
   onOpenChange: (open: boolean) => void
 }
 
-const VARIANTS = ["default", "secondary", "outline", "ghost", "destructive", "branded"]
+// Groups apply one variant uniformly across all badges, so every variant is
+// valid. Sourced from the registry (single source of truth) rather than a copy.
+const VARIANTS = [...ALL_VARIANTS]
 const SIZES = ["xs", "sm", "default", "lg"]
 const THEMES = ["_none", "zinc", "slate", "blue", "green", "rose", "orange", "violet", "purple", "cyan", "emerald"]
 const MODES = ["dark", "light"]
@@ -97,29 +101,34 @@ export function BadgeGroupModal({
   const [theme, setTheme] = useState(parsed.theme)
   const { mode: siteMode } = useBadgeMode()
   const [mode, setMode] = useState(parsed.mode || siteMode)
-  const [baseUrl, setBaseUrl] = useState("https://shieldcn.dev")
   const [outputFormat, setOutputFormat] = useState<OutputFormat>("markdown")
   const [copied, setCopied] = useState(false)
   const [newSegment, setNewSegment] = useState("")
-  const [mounted, setMounted] = useState(false)
 
-  useEffect(() => { setMounted(true) }, [])
+  // Hydration-safe flags (server snapshot differs from client) — no
+  // setState-in-effect. `mounted` gates badge <img> rendering to avoid an SSR
+  // mismatch; `baseUrl` swaps the canonical host for the real origin on client.
+  const mounted = useSyncExternalStore(() => () => {}, () => true, () => false)
+  const baseUrl = useSyncExternalStore(
+    () => () => {},
+    () => window.location.origin,
+    () => "https://shieldcn.dev",
+  )
 
-  useEffect(() => {
-    setBaseUrl(window.location.origin)
-  }, [])
-
-  // Reset when opening with a different badge
-  useEffect(() => {
-    if (open) {
-      const p = parseGroupPath(badgePath)
-      setSegments(p.segments)
-      setVariant(p.variant)
-      setSize(p.size)
-      setTheme(p.theme)
-      setMode(p.mode || siteMode)
-    }
-  }, [badgePath, open, siteMode])
+  // Re-sync controls when the modal (re)opens with a different badge or the
+  // site theme changes — done during render via a sync key (the React “adjust
+  // state when inputs change” pattern) instead of a setState-in-effect.
+  const [syncKey, setSyncKey] = useState("")
+  const nextSyncKey = `${open}|${siteMode}|${badgePath}`
+  if (open && nextSyncKey !== syncKey) {
+    setSyncKey(nextSyncKey)
+    const p = parseGroupPath(badgePath)
+    setSegments(p.segments)
+    setVariant(p.variant)
+    setSize(p.size)
+    setTheme(p.theme)
+    setMode(p.mode || siteMode)
+  }
 
   const resolvedPath = useMemo(
     () => buildGroupPath(segments, { variant, size, theme, mode }),
@@ -298,10 +307,10 @@ export function BadgeGroupModal({
           <p className="text-[11px] text-muted-foreground">badge group · {segments.length} segment{segments.length !== 1 ? "s" : ""}</p>
           <div className="flex items-center gap-2">
             <Button variant="ghost" size="sm" className="h-7 gap-1 text-xs" asChild>
-              <a href="/docs/badges/group">
+              <Link href="/docs/badges/group">
                 <ExternalLink className="size-3" />
                 Docs
-              </a>
+              </Link>
             </Button>
             <Button variant="ghost" size="sm" className="h-7 gap-1 text-xs" asChild>
               <a href={resolvedPath} target="_blank" rel="noopener noreferrer">

--- a/packages/web/components/badge-modal.tsx
+++ b/packages/web/components/badge-modal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useCallback, useEffect, useMemo } from "react"
+import { useState, useCallback, useMemo, useSyncExternalStore } from "react"
 import { Copy, Check, ExternalLink } from "lucide-react"
 import { useBadgeMode } from "@/lib/use-badge-mode"
 import {
@@ -21,6 +21,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { SvgIconUpload } from "@/components/svg-icon-upload"
+import { allowedVariantsForPath } from "@shieldcn/core/badges/registry"
 
 interface BadgeModalProps {
   title: string
@@ -32,7 +33,6 @@ interface BadgeModalProps {
   onOpenChange: (open: boolean) => void
 }
 
-const VARIANTS = ["default", "secondary", "outline", "ghost", "destructive", "branded"]
 const SIZES = ["xs", "sm", "default", "lg"]
 const THEMES = ["_none", "zinc", "slate", "blue", "green", "rose", "orange", "violet", "purple", "cyan", "emerald"]
 const MODES = ["dark", "light"]
@@ -57,10 +57,17 @@ function withStyleParams(
   }
 ) {
   const url = new URL(badgePath, "https://shieldcn.dev")
+  // badgePath may already carry preset query params (e.g. ?theme=blue), so each
+  // of these must DELETE when at its default — otherwise switching back to the
+  // default (e.g. theme “auto”) would leave a stale param in the URL.
   if (opts.variant !== "default") url.searchParams.set("variant", opts.variant)
+  else url.searchParams.delete("variant")
   if (opts.size !== "sm") url.searchParams.set("size", opts.size)
+  else url.searchParams.delete("size")
   if (opts.theme !== "_none") url.searchParams.set("theme", opts.theme)
+  else url.searchParams.delete("theme")
   if (opts.mode !== "dark") url.searchParams.set("mode", opts.mode)
+  else url.searchParams.delete("mode")
   if (opts.color) url.searchParams.set("color", opts.color)
   else url.searchParams.delete("color")
   if (opts.labelColor) url.searchParams.set("labelColor", opts.labelColor)
@@ -89,7 +96,16 @@ export function BadgeModal({
   onOpenChange,
 }: BadgeModalProps) {
   const initialParams = useMemo(() => new URL(badgePath, "https://shieldcn.dev").searchParams, [badgePath])
-  const [baseUrl, setBaseUrl] = useState("https://shieldcn.dev")
+  // Variant options come from the core registry — only what this badge supports
+  // (e.g. no `branded` on a flag, which has no brand identity).
+  const availableVariants = useMemo(() => [...allowedVariantsForPath(badgePath)], [badgePath])
+  // Hydration-safe origin (server renders canonical host, client swaps in real
+  // origin after hydration) — no setState-in-effect.
+  const baseUrl = useSyncExternalStore(
+    () => () => {},
+    () => window.location.origin,
+    () => "https://shieldcn.dev",
+  )
   const [variant, setVariant] = useState(initialParams.get("variant") ?? "default")
   const [size, setSize] = useState(initialParams.get("size") ?? "sm")
   const [theme, setTheme] = useState(initialParams.get("theme") ?? "_none")
@@ -107,16 +123,21 @@ export function BadgeModal({
   const [label, setLabel] = useState("")
   const [split, setSplit] = useState(false)
 
-  useEffect(() => {
-    setBaseUrl(window.location.origin)
-  }, [])
-
-  useEffect(() => {
-    setVariant(initialParams.get("variant") ?? "default")
+  // Re-sync the controls from the badge path each time the modal (re)opens or
+  // the site theme changes. Done during render via a sync key (the React
+  // “adjust state when inputs change” pattern) instead of a setState-in-effect.
+  // Also clamps the variant to what this badge supports (e.g. no `branded` on a
+  // flag) so a stale value can't slip through.
+  const [syncKey, setSyncKey] = useState("")
+  const nextSyncKey = `${open}|${siteMode}|${badgePath}`
+  if (open && nextSyncKey !== syncKey) {
+    setSyncKey(nextSyncKey)
+    const requested = initialParams.get("variant") ?? "default"
+    setVariant((availableVariants as string[]).includes(requested) ? requested : "default")
     setSize(initialParams.get("size") ?? "sm")
     setTheme(initialParams.get("theme") ?? "_none")
     setMode(initialParams.get("mode") || siteMode)
-  }, [initialParams, open, siteMode])
+  }
 
   const resolvedBadgePath = useMemo(
     () => withStyleParams(badgePath, {
@@ -182,7 +203,7 @@ export function BadgeModal({
         </div>
 
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          <Control label="Variant" value={variant} onValueChange={setVariant} options={VARIANTS} />
+          <Control label="Variant" value={variant} onValueChange={setVariant} options={availableVariants} />
           <Control label="Size" value={size} onValueChange={setSize} options={SIZES} />
           <Control label="Theme" value={theme} onValueChange={setTheme} options={THEMES} />
           <Control label="Mode" value={mode} onValueChange={setMode} options={MODES} />

--- a/packages/web/components/badge-sandbox.tsx
+++ b/packages/web/components/badge-sandbox.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useCallback, useMemo, useEffect } from "react"
+import { useState, useCallback, useMemo, useSyncExternalStore } from "react"
 import { Copy, Check, Play } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -19,6 +19,7 @@ import { Separator } from "@/components/ui/separator"
 import { Checkbox } from "@/components/ui/checkbox"
 import { LogoPicker } from "@/components/logo-picker"
 import { SvgIconUpload } from "@/components/svg-icon-upload"
+import { allowedVariantsForPath, VARIANT_LABELS } from "@shieldcn/core/badges/registry"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -100,9 +101,27 @@ export function BadgeSandbox({
   const [format, setFormat] = useState("markdown")
   const [copied, setCopied] = useState(false)
   const [executed, setExecuted] = useState(true) // auto-execute on load
-  const [baseUrl, setBaseUrl] = useState("https://shieldcn.dev")
 
-  useEffect(() => { setBaseUrl(window.location.origin) }, [])
+  // Hydration-safe origin: server renders the canonical host, client swaps in
+  // the real origin after hydration without a setState-in-effect.
+  const baseUrl = useSyncExternalStore(
+    () => () => {},
+    () => window.location.origin,
+    () => "https://shieldcn.dev",
+  )
+
+  // Changing the output format clears the "copied" state — handled in the tab
+  // change handler (below) rather than an effect.
+  const handleFormatChange = useCallback((next: string) => {
+    setFormat(next)
+    setCopied(false)
+  }, [])
+
+  // Variants the THIS badge actually supports, from the core registry (source
+  // of truth). `:param` placeholders aren't topic keys, so they're ignored;
+  // the literal topic segment (e.g. "ci") drives the policy. Keeps the dropdown
+  // honest — no missing `branded`, no `branded` on pass/fail state badges.
+  const availableVariants = useMemo(() => allowedVariantsForPath(endpoint), [endpoint])
 
   const setValue = useCallback((name: string, value: string) => {
     setValues(prev => ({ ...prev, [name]: value }))
@@ -160,8 +179,6 @@ export function BadgeSandbox({
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
   }, [formattedOutput])
-
-  useEffect(() => { setCopied(false) }, [format])
 
   const sizeHeight = { xs: "h-6", sm: "h-8", default: "h-9", lg: "h-10" }[size] || "h-8"
 
@@ -238,8 +255,8 @@ export function BadgeSandbox({
             <Select value={variant} onValueChange={setVariant}>
               <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
               <SelectContent>
-                {["default", "secondary", "outline", "ghost", "destructive"].map(v =>
-                  <SelectItem key={v} value={v}>{v}</SelectItem>
+                {availableVariants.map(v =>
+                  <SelectItem key={v} value={v}>{VARIANT_LABELS[v] ?? v}</SelectItem>
                 )}
               </SelectContent>
             </Select>
@@ -334,7 +351,7 @@ export function BadgeSandbox({
         <Separator />
 
         {/* Output format tabs + preview */}
-        <Tabs value={format} onValueChange={setFormat}>
+        <Tabs value={format} onValueChange={handleFormatChange}>
           <TabsList>
             <TabsTrigger value="url">URL</TabsTrigger>
             <TabsTrigger value="markdown">Markdown</TabsTrigger>

--- a/packages/web/lib/badge-builder-shared.ts
+++ b/packages/web/lib/badge-builder-shared.ts
@@ -118,7 +118,10 @@ export function resolveTemplate(preset: BadgePreset, values: Record<string, stri
 // Options
 // ---------------------------------------------------------------------------
 
-export const VARIANTS = ["default", "secondary", "outline", "ghost", "destructive", "branded"] as const
+// Single source of truth — the variants the renderer actually supports.
+// Re-exported from the core registry so the builder/showcase can never drift
+// from what really renders (no phantom variants in dropdowns).
+export { ALL_VARIANTS as VARIANTS, VARIANT_LABELS, allowedVariantsForPath } from "@shieldcn/core/badges/registry"
 export const SIZES = ["xs", "sm", "default", "lg"] as const
 export const MODES = ["dark", "light"] as const
 export const FONTS = ["inter", "geist", "geist-mono", "jetbrains-mono", "fira-code", "roboto", "space-grotesk"] as const

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^3
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.14.2(@types/node@20.19.39)(typescript@5.9.3))(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/engine:
     dependencies:
@@ -148,7 +151,7 @@ importers:
         version: 2.6.2
       '@sentry/nextjs':
         specifier: ^10.56.0
-        version: 10.56.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.107.2)
+        version: 10.56.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.107.2(lightningcss@1.32.0))
       '@shieldcn/core':
         specifier: workspace:*
         version: link:../core
@@ -175,7 +178,7 @@ importers:
         version: 16.8.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@1.8.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
       fumadocs-mdx:
         specifier: ^14.3.1
-        version: 14.3.1(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.8.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@1.8.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 14.3.1(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.8.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@1.8.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.5(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       fumadocs-ui:
         specifier: npm:@fumadocs/base-ui@^16.8.2
         version: '@fumadocs/base-ui@16.8.2(@tailwindcss/oxide@4.2.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.8.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@1.8.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.4)'
@@ -2473,11 +2476,17 @@ packages:
   '@types/bezier-js@0.0.6':
     resolution: {integrity: sha512-kXsAlt8e8N6zt9R6LcMYWB1HkBw3q2g+M9BdI/UE+s4agIONuIscQaRCoInH22+Jas3rw8yLUehL2InaZjyNSA==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/css-font-loading-module@0.0.7':
     resolution: {integrity: sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -2716,6 +2725,35 @@ packages:
   '@upstash/redis@1.37.0':
     resolution: {integrity: sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==}
 
+  '@vitest/expect@3.2.6':
+    resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
+
+  '@vitest/mocker@3.2.6':
+    resolution: {integrity: sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.6':
+    resolution: {integrity: sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==}
+
+  '@vitest/runner@3.2.6':
+    resolution: {integrity: sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==}
+
+  '@vitest/snapshot@3.2.6':
+    resolution: {integrity: sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==}
+
+  '@vitest/spy@3.2.6':
+    resolution: {integrity: sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==}
+
+  '@vitest/utils@3.2.6':
+    resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
+
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
 
@@ -2900,6 +2938,10 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -3026,6 +3068,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -3045,6 +3091,10 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
@@ -3304,6 +3354,10 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -3458,6 +3512,9 @@ packages:
   es-iterator-helpers@1.3.2:
     resolution: {integrity: sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
@@ -3695,6 +3752,10 @@ packages:
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.4.1:
     resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
@@ -4392,6 +4453,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -4595,6 +4659,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
@@ -5149,6 +5216,10 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   pg-cloudflare@1.3.0:
     resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
 
@@ -5619,6 +5690,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -5666,6 +5740,9 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stacktrace-parser@0.1.11:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
@@ -5673,6 +5750,9 @@ packages:
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -5757,6 +5837,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -5874,6 +5957,9 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
@@ -5884,6 +5970,18 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.29:
     resolution: {integrity: sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==}
@@ -6130,6 +6228,79 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.5:
+    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.6:
+    resolution: {integrity: sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.6
+      '@vitest/ui': 3.2.6
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   watchpack@2.5.1:
     resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
     engines: {node: '>=10.13.0'}
@@ -6194,6 +6365,11 @@ packages:
   which@4.0.0:
     resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
     engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -8096,6 +8272,31 @@ snapshots:
 
   '@sentry/core@10.56.0': {}
 
+  '@sentry/nextjs@10.56.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.107.2(lightningcss@1.32.0))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@rollup/plugin-commonjs': 28.0.1(rollup@4.60.3)
+      '@sentry-internal/browser-utils': 10.56.0
+      '@sentry/bundler-plugin-core': 5.3.0
+      '@sentry/core': 10.56.0
+      '@sentry/node': 10.56.0
+      '@sentry/opentelemetry': 10.56.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      '@sentry/react': 10.56.0(react@19.2.4)
+      '@sentry/vercel-edge': 10.56.0
+      '@sentry/webpack-plugin': 5.3.0(webpack@5.107.2(lightningcss@1.32.0))
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      rollup: 4.60.3
+      stacktrace-parser: 0.1.11
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - '@opentelemetry/sdk-trace-base'
+      - encoding
+      - react
+      - supports-color
+      - webpack
+
   '@sentry/nextjs@10.56.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.107.2)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -8177,6 +8378,14 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@sentry/core': 10.56.0
+
+  '@sentry/webpack-plugin@5.3.0(webpack@5.107.2(lightningcss@1.32.0))':
+    dependencies:
+      '@sentry/bundler-plugin-core': 5.3.0
+      webpack: 5.107.2(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   '@sentry/webpack-plugin@5.3.0(webpack@5.107.2)':
     dependencies:
@@ -8346,11 +8555,18 @@ snapshots:
 
   '@types/bezier-js@0.0.6': {}
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/css-font-loading-module@0.0.7': {}
 
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -8575,6 +8791,49 @@ snapshots:
   '@upstash/redis@1.37.0':
     dependencies:
       uncrypto: 0.1.3
+
+  '@vitest/expect@3.2.6':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.6(msw@2.14.2(@types/node@20.19.39)(typescript@5.9.3))(vite@7.3.5(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.14.2(@types/node@20.19.39)(typescript@5.9.3)
+      vite: 7.3.5(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@vitest/pretty-format@3.2.6':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.6':
+    dependencies:
+      '@vitest/utils': 3.2.6
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.6':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -8808,6 +9067,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   ast-types@0.16.1:
@@ -8919,6 +9180,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -8933,6 +9202,8 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
+
+  check-error@2.1.3: {}
 
   cheerio-select@2.1.0:
     dependencies:
@@ -9176,6 +9447,8 @@ snapshots:
 
   dedent@1.7.2: {}
 
+  deep-eql@5.0.2: {}
+
   deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
@@ -9377,6 +9650,8 @@ snapshots:
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
 
+  es-module-lexer@1.7.0: {}
+
   es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
@@ -9485,8 +9760,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.4
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
@@ -9508,7 +9783,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -9519,22 +9794,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9545,7 +9820,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -9772,6 +10047,8 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
 
+  expect-type@1.3.0: {}
+
   express-rate-limit@8.4.1(express@5.2.1):
     dependencies:
       express: 5.2.1
@@ -9968,7 +10245,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.3.1(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.8.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@1.8.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+  fumadocs-mdx@14.3.1(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.8.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@1.8.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.5(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
@@ -9994,6 +10271,7 @@ snapshots:
       '@types/react': 19.2.14
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
+      vite: 7.3.5(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -10518,6 +10796,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -10690,6 +10970,8 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  loupe@3.2.1: {}
 
   lru-cache@11.3.5: {}
 
@@ -11523,6 +11805,8 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pathval@2.0.1: {}
+
   pg-cloudflare@1.3.0:
     optional: true
 
@@ -12238,6 +12522,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -12273,11 +12559,15 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  stackback@0.0.2: {}
+
   stacktrace-parser@0.1.11:
     dependencies:
       type-fest: 0.7.1
 
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -12386,6 +12676,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -12439,6 +12733,16 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  terser-webpack-plugin@5.6.1(lightningcss@1.32.0)(webpack@5.107.2(lightningcss@1.32.0)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.48.0
+      webpack: 5.107.2(lightningcss@1.32.0)
+    optionalDependencies:
+      lightningcss: 1.32.0
+
   terser-webpack-plugin@5.6.1(webpack@5.107.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -12466,6 +12770,8 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@0.3.2: {}
 
   tinyexec@1.1.1: {}
@@ -12474,6 +12780,12 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   tldts-core@7.0.29: {}
 
@@ -12777,6 +13089,86 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@3.2.4(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.5(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.5(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rollup: 4.60.3
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 20.19.39
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      terser: 5.48.0
+      tsx: 4.21.0
+      yaml: 2.8.3
+
+  vitest@3.2.6(@types/debug@4.1.13)(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.14.2(@types/node@20.19.39)(typescript@5.9.3))(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(msw@2.14.2(@types/node@20.19.39)(typescript@5.9.3))(vite@7.3.5(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.5(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.13
+      '@types/node': 20.19.39
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   watchpack@2.5.1:
     dependencies:
       glob-to-regexp: 0.4.1
@@ -12813,6 +13205,45 @@ snapshots:
       schema-utils: 4.3.3
       tapable: 2.3.3
       terser-webpack-plugin: 5.6.1(webpack@5.107.2)
+      watchpack: 2.5.1
+      webpack-sources: 3.5.0
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+
+  webpack@5.107.2(lightningcss@1.32.0):
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.2
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.23.0
+      es-module-lexer: 2.1.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      loader-runner: 4.3.2
+      mime-db: 1.54.0
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.6.1(lightningcss@1.32.0)(webpack@5.107.2(lightningcss@1.32.0))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:
@@ -12888,6 +13319,11 @@ snapshots:
   which@4.0.0:
     dependencies:
       isexe: 3.1.5
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
## What

Introduces a declarative **badge variant registry** (`packages/core/src/badges/registry.ts`) that defines, per provider and topic, which variants each badge supports. Every badge UI and the route handler now reads from it, replacing four divergent hardcoded variant lists.

## Why

Variant dropdowns across the app were hardcoded and inconsistent:
- The builder/sandbox/modals each kept their own list — some omitted `branded`, some offered variants a badge can't use (e.g. `branded` on a flag, which has no brand identity).
- `BadgeStyle` declared `subtle`/`flat` that the renderer never implemented (they silently fell through to `default`).
- There was zero programmatic test coverage for badges.

## How

- **`registry.ts`** — 57 providers modeled with topics, examples, and variant policy. Pass/fail **state** badges (`github` ci/checks/dependabot, `gitlab` pipeline, `sonar` quality-gate) and the `flag` provider drop `branded`. `resolveTopic` handles every segment ordering; `defaultTopic`/`freeform` cover bare and custom paths.
- **`validate.ts`** — `resolveVariant()` coerces unsupported/legacy variants to `default` at the route. **Non-breaking**: legacy `flat`/`subtle`/typos render exactly as before; only `branded` on state/flag badges changes (to `default`), and nothing ever renders as an error.
- **`types.ts`** — `BadgeStyle` trimmed to the 6 implemented variants.
- **UIs** — builder, sandbox, showcase modal, and group modal source variants from the registry (`allowedVariantsForPath` / `ALL_VARIANTS`), with clamping on badge switch.
- **Bug fix** — `badge-modal` left stale query params; `theme`/`variant`/`size`/`mode` now delete at their default, so switching theme to "auto" produces a clean URL.

## Testing

- Vitest added to `@shieldcn/core`: **34 tests** covering registry integrity, variant policy, route coercion, and a round-trip drift guard across all providers. Run: `pnpm --filter @shieldcn/core test`
- Both packages typecheck clean; all touched web files pass eslint (commit went through lint-staged).

## Notes

Incidental lint cleanup in touched modal components (`set-state-in-effect` → `useSyncExternalStore` + render-phase sync; one internal `<a>` → `next/link`). An unrelated stray `public/Group 1.svg` was intentionally left out of this branch.
