### PR TITLE
feat(badges): add Twemoji emoji logo support

### DIFF
--- a/packages/core/src/badges/render.tsx
+++ b/packages/core/src/badges/render.tsx
@@ -205,6 +205,9 @@ interface ResolvedBadge {
 
   // Full-color flag SVG rendered as a left inset (preserves original colors)
   flagSvg: string | undefined
+
+  // Full-color emoji (Twemoji) SVG rendered as a square left inset
+  emojiSvg: string | undefined
 }
 
 // ---------------------------------------------------------------------------
@@ -351,6 +354,7 @@ function resolve(config: BadgeConfig): ResolvedBadge {
     iconStrokeLinejoin: config.iconStrokeLinejoin,
     iconRotation: config.iconRotation,
     flagSvg: config.flagSvg,
+    emojiSvg: config.emojiSvg,
   }
 }
 
@@ -538,6 +542,22 @@ function FlagEl({ r }: { r: ResolvedBadge }) {
   )
 }
 
+// Full-color emoji (Twemoji) inset. Unlike flags (3:2, cover), emoji are square
+// (1:1, contain) and unrounded so the glyph keeps its natural shape.
+function EmojiEl({ r }: { r: ResolvedBadge }) {
+  if (!r.emojiSvg) return null
+  const size = Math.round(r.iconSize * 1.15)
+  const src = `data:image/svg+xml;base64,${Buffer.from(r.emojiSvg).toString("base64")}`
+  return (
+    <img
+      src={src}
+      width={size}
+      height={size}
+      style={{ width: size, height: size, objectFit: "contain", flexShrink: 0 }}
+    />
+  )
+}
+
 function IconEl({ r }: { r: ResolvedBadge }) {
   if (!r.icon) return null
   const vb = r.iconViewBox || "0 0 16 16"
@@ -657,6 +677,8 @@ function renderSingle(r: ResolvedBadge): React.ReactElement {
       <DotEl r={r} />
       <FlagEl r={r} />
       {r.flagSvg && <div style={{ width: r.gap }} />}
+      <EmojiEl r={r} />
+      {r.emojiSvg && <div style={{ width: r.gap }} />}
       <IconEl r={r} />
       {r.icon && <div style={{ width: r.gap }} />}
       {r.label && (
@@ -702,6 +724,8 @@ function renderSplit(r: ResolvedBadge): React.ReactElement {
         paddingRight: r.paddingX,
       }}>
         <DotEl r={r} />
+        <EmojiEl r={r} />
+        {r.emojiSvg && <div style={{ width: r.gap }} />}
         <IconEl r={r} />
         {r.icon && <div style={{ width: r.gap }} />}
         {r.label && <span style={{ color: r.labelFg, ...textStyle }}>{r.label}</span>}

--- a/packages/core/src/badges/twemoji.test.ts
+++ b/packages/core/src/badges/twemoji.test.ts
@@ -1,0 +1,60 @@
+/**
+ * shieldcn
+ * lib/badges/twemoji.test
+ *
+ * Covers emoji detection and codepoint resolution (the pure logic). The CDN
+ * fetch in resolveTwemojiSvg is not exercised here.
+ */
+
+import { describe, expect, it } from "vitest"
+import { isTwemojiLogo, twemojiCodepoint } from "./twemoji"
+
+describe("isTwemojiLogo", () => {
+  it("detects the explicit twemoji: prefix", () => {
+    expect(isTwemojiLogo("twemoji:🚀")).toBe(true)
+    expect(isTwemojiLogo("twemoji:1f680")).toBe(true)
+  })
+
+  it("auto-detects a bare emoji char", () => {
+    expect(isTwemojiLogo("🚀")).toBe(true)
+    expect(isTwemojiLogo("🇺🇸")).toBe(true)
+    expect(isTwemojiLogo("👨‍💻")).toBe(true)
+  })
+
+  it("does not treat slugs, prefixed icons, or data URIs as emoji", () => {
+    expect(isTwemojiLogo("react")).toBe(false)
+    expect(isTwemojiLogo("ri:FaReact")).toBe(false)
+    expect(isTwemojiLogo("lu:Check")).toBe(false)
+    expect(isTwemojiLogo("data:image/svg+xml;base64,abc")).toBe(false)
+  })
+})
+
+describe("twemojiCodepoint", () => {
+  it("converts a simple emoji to its codepoint", () => {
+    expect(twemojiCodepoint("🚀")).toBe("1f680")
+    expect(twemojiCodepoint("twemoji:🚀")).toBe("1f680")
+  })
+
+  it("passes through a hex codepoint (lowercased)", () => {
+    expect(twemojiCodepoint("twemoji:1F680")).toBe("1f680")
+    expect(twemojiCodepoint("twemoji:1f1fa-1f1f8")).toBe("1f1fa-1f1f8")
+  })
+
+  it("strips the FE0F variation selector when there is no ZWJ", () => {
+    // ❤️ = U+2764 U+FE0F → twemoji asset is "2764"
+    expect(twemojiCodepoint("❤️")).toBe("2764")
+  })
+
+  it("keeps FE0F inside a ZWJ sequence", () => {
+    // 👨‍💻 = man + ZWJ + computer
+    expect(twemojiCodepoint("👨‍💻")).toBe("1f468-200d-1f4bb")
+  })
+
+  it("handles regional-indicator flags (surrogate pairs)", () => {
+    expect(twemojiCodepoint("🇺🇸")).toBe("1f1fa-1f1f8")
+  })
+
+  it("returns null for an empty value", () => {
+    expect(twemojiCodepoint("twemoji:")).toBeNull()
+  })
+})

--- a/packages/core/src/badges/twemoji.ts
+++ b/packages/core/src/badges/twemoji.ts
@@ -1,0 +1,121 @@
+/**
+ * shieldcn
+ * lib/badges/twemoji
+ *
+ * Resolves an emoji logo to a full-color Twemoji SVG, rendered as a square
+ * inset (like the flag mechanism, but 1:1 instead of 3:2).
+ *
+ * Sources the art from jdecked/twemoji (the maintained fork) via jsDelivr,
+ * cached aggressively since the assets are immutable per release.
+ *
+ * Trigger forms (handled by isTwemojiLogo / resolveTwemojiSvg):
+ *   ?logo=twemoji:🚀      explicit prefix + emoji char
+ *   ?logo=twemoji:1f680   explicit prefix + hex codepoint(s, dash-joined)
+ *   ?logo=🚀              bare emoji char (auto-detected)
+ */
+
+import { cacheGet, cacheSet } from "../cache"
+
+// Pinned release of jdecked/twemoji. Bump deliberately; @latest would risk a
+// silent upstream change breaking cached codepoint → asset mappings.
+const TWEMOJI_VERSION = "15.1.0"
+const TWEMOJI_BASE = `https://cdn.jsdelivr.net/gh/jdecked/twemoji@${TWEMOJI_VERSION}/assets/svg`
+
+// Emoji assets are immutable for a given version → cache for 30 days.
+const TWEMOJI_TTL = 60 * 60 * 24 * 30
+
+const ZWJ = 0x200d
+const VARIATION_SELECTOR = /\ufe0f/g
+
+/**
+ * Convert a unicode string to Twemoji's dash-joined lowercase-hex codepoint id,
+ * matching jdecked/twemoji's `toCodePoint`. Handles surrogate pairs.
+ */
+function toCodePoint(unicode: string): string {
+  const out: string[] = []
+  let high = 0
+  for (let i = 0; i < unicode.length; i++) {
+    const c = unicode.charCodeAt(i)
+    if (high) {
+      out.push((0x10000 + ((high - 0xd800) << 10) + (c - 0xdc00)).toString(16))
+      high = 0
+    } else if (c >= 0xd800 && c <= 0xdbff) {
+      high = c
+    } else {
+      out.push(c.toString(16))
+    }
+  }
+  return out.join("-")
+}
+
+/**
+ * Resolve an emoji char to its Twemoji asset codepoint id. Mirrors Twemoji's
+ * `grabTheRightIcon`: strip the FE0F variation selector unless the sequence
+ * contains a ZWJ (e.g. 👨‍💻), where FE0F is significant.
+ */
+function emojiToCodepoint(emoji: string): string {
+  const hasZwj = emoji.includes(String.fromCharCode(ZWJ))
+  const normalized = hasZwj ? emoji : emoji.replace(VARIATION_SELECTOR, "")
+  return toCodePoint(normalized)
+}
+
+/**
+ * A hex codepoint id is one or more dash-joined groups of 1–6 hex digits,
+ * e.g. "1f680" or "1f1fa-1f1f8".
+ */
+function isHexCodepoint(value: string): boolean {
+  return /^[0-9a-f]{1,6}(-[0-9a-f]{1,6})*$/i.test(value)
+}
+
+// Matches an emoji-class glyph (pictographic) or a regional-indicator symbol
+// (flag halves like 🇺🇸 are not Extended_Pictographic). Used to auto-detect a
+// bare emoji logo without an explicit prefix.
+const EMOJI_RE = /[\p{Extended_Pictographic}\p{Regional_Indicator}]/u
+
+/** Whether a logo param should be resolved as a Twemoji emoji. */
+export function isTwemojiLogo(logo: string): boolean {
+  if (logo.startsWith("twemoji:")) return true
+  // Bare emoji char (but not a data URI, slug, or prefixed icon).
+  if (logo.includes(":") || logo.startsWith("data:")) return false
+  return EMOJI_RE.test(logo)
+}
+
+/**
+ * Resolve a Twemoji logo param to its asset codepoint id (e.g. "1f680"), or
+ * null if empty. Accepts the `twemoji:` prefix, a raw emoji char, or a hex
+ * codepoint. Exported for testing and reuse.
+ */
+export function twemojiCodepoint(logo: string): string | null {
+  const raw = logo.startsWith("twemoji:") ? logo.slice("twemoji:".length) : logo
+  if (!raw) return null
+  return isHexCodepoint(raw) ? raw.toLowerCase() : emojiToCodepoint(raw)
+}
+
+/**
+ * Resolve a Twemoji logo param to a raw full-color SVG string, or null if it
+ * can't be resolved (unknown emoji, network failure, etc.). Cached.
+ */
+export async function resolveTwemojiSvg(logo: string): Promise<string | null> {
+  const codepoint = twemojiCodepoint(logo)
+  if (!codepoint) return null
+
+  const cacheKeyId = `twemoji:${TWEMOJI_VERSION}:${codepoint}`
+  const cached = await cacheGet<string>(cacheKeyId)
+  if (cached !== undefined) return cached || null
+
+  try {
+    const res = await fetch(`${TWEMOJI_BASE}/${codepoint}.svg`, {
+      headers: { Accept: "image/svg+xml", "User-Agent": "shieldcn/1.0" },
+    })
+    if (!res.ok) {
+      // Cache the miss briefly so a bad emoji doesn't hammer the CDN.
+      await cacheSet(cacheKeyId, "", 60 * 10)
+      return null
+    }
+    const svg = await res.text()
+    await cacheSet(cacheKeyId, svg, TWEMOJI_TTL)
+    return svg
+  } catch {
+    return null
+  }
+}

--- a/packages/core/src/badges/types.ts
+++ b/packages/core/src/badges/types.ts
@@ -115,6 +115,12 @@ export interface BadgeConfig {
    * preserves the flag's original multi-color fills instead of recoloring it.
    */
   flagSvg?: string
+  /**
+   * Full-color emoji (Twemoji) SVG (raw markup) rendered as a square left
+   * inset at its natural 1:1 aspect ratio. Like `flagSvg`, this preserves the
+   * original multi-color fills instead of recoloring it.
+   */
+  emojiSvg?: string
   /** Animation mode: "pulse" | "glow" | "shimmer" | "none". Default: none. */
   animate?: "pulse" | "glow" | "shimmer" | "none"
 }

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -12,6 +12,7 @@ import { renderGif } from "./badges/gif"
 import { renderBadgeGroup, type GroupSegment, type GroupConfig } from "./badges/render-group"
 import { resolveTheme, applyColorOverrides, statusColors } from "./badges/themes"
 import { getSimpleIcon } from "./badges/simple-icons"
+import { isTwemojiLogo, resolveTwemojiSvg } from "./badges/twemoji"
 import { getProviderBrandColor } from "./badges/brand-colors"
 import { parseSvg, decodeSvgDataUri } from "./badges/svg-parser"
 import { normalizeSearchParams } from "./normalize-params"
@@ -1803,11 +1804,20 @@ async function handleBadgeGETInner(
   // For branded variant, get provider brand color as fallback
   const providerBrand = getProviderBrandColor(provider)
 
+  // Emoji (Twemoji) logo, rendered as a full-color square inset (not recolored).
+  let emojiSvg: string | undefined
+
   if (logoParam === "false" || logoParam === "none") {
     // Explicitly hidden — still use provider brand for branded variant
     if (style === "branded" && providerBrand) {
       brandColor = providerBrand
     }
+  } else if (logoParam && logoParam !== "true" && isTwemojiLogo(logoParam)) {
+    // Twemoji emoji: ?logo=twemoji:🚀, ?logo=twemoji:1f680, or bare ?logo=🚀
+    emojiSvg = (await resolveTwemojiSvg(logoParam)) ?? undefined
+    // Branded variant still needs a bg color; emoji carry no single brand color,
+    // so fall back to the provider brand if any.
+    if (style === "branded" && providerBrand) brandColor = providerBrand
   } else if (logoParam && logoParam.startsWith("data:image/svg+xml")) {
     // Custom SVG icon via data URI
     const svgContent = decodeSvgDataUri(logoParam)
@@ -1981,6 +1991,7 @@ async function handleBadgeGETInner(
     font,
     gradient,
     flagSvg,
+    emojiSvg,
     animate,
     valueColor: searchParams.get("valueColor") ?? undefined,
     labelTextColor: searchParams.get("labelTextColor") ?? undefined,

--- a/packages/web/app/dev/social/page.tsx
+++ b/packages/web/app/dev/social/page.tsx
@@ -56,6 +56,7 @@ interface BadgeItem {
   animate: Animate
   label: LabelKind
   labelText: string // used when label === "custom"
+  logo?: string // optional ?logo= value (e.g. an emoji / twemoji:<emoji>)
 }
 
 // Resolve the caption text for a badge from its label setting.
@@ -89,6 +90,7 @@ function buildSrc(item: BadgeItem, mode: Bg): string {
   if (item.size !== "sm") params.set("size", item.size)
   if (item.font !== "inter") params.set("font", item.font)
   if (item.animate !== "none") params.set("animate", item.animate)
+  if (item.logo) params.set("logo", item.logo)
   return `${item.path}.svg?${params.toString()}`
 }
 
@@ -99,6 +101,7 @@ function buildGifUrl(item: BadgeItem, mode: Bg): string {
   if (item.size !== "sm") params.set("size", item.size)
   if (item.font !== "inter") params.set("font", item.font)
   if (item.animate !== "none") params.set("animate", item.animate)
+  if (item.logo) params.set("logo", item.logo)
   return `${item.path}.gif?${params.toString()}`
 }
 
@@ -131,21 +134,37 @@ async function downloadGif(item: BadgeItem, mode: Bg): Promise<void> {
   }
 }
 
-// A geographically diverse sample of country flags, seeded onto the canvas so
-// /dev/social opens ready to screenshot a “built in {country}” showcase for
-// social posts. Flags default to the `secondary` variant (their look in-app).
-const FLAG_SAMPLE = [
-  "us", "gb", "ca", "mx", "br", "ar",
-  "fr", "de", "es", "it", "nl", "pt",
-  "se", "no", "fi", "pl", "ua", "ie",
-  "jp", "kr", "cn", "in", "id", "sg",
-  "au", "nz", "za", "ng", "ke", "eg",
+// A curated set of emoji (Twemoji) badges, seeded onto the canvas so
+// /dev/social opens ready to screenshot an emoji-logo showcase for social
+// posts. Each entry: [static badge path, emoji logo, variant].
+const EMOJI_SAMPLE: Array<[string, string, Variant]> = [
+  ["/badge/ship-it", "\uD83D\uDE80", "secondary"],
+  ["/badge/made%20with-love", "\u2764\uFE0F", "outline"],
+  ["/badge/status-on%20fire", "\uD83D\uDD25", "destructive"],
+  ["/badge/coffee-driven", "\u2615", "secondary"],
+  ["/badge/release-shipped", "\uD83C\uDF89", "outline"],
+  ["/badge/built%20by-a%20human", "\uD83D\uDC68\u200D\uD83D\uDCBB", "default"],
+  ["/badge/quality-magic", "\u2728", "secondary"],
+  ["/badge/score-100", "\uD83D\uDCAF", "outline"],
+  ["/badge/speed-blazing", "\u26A1", "default"],
+  ["/badge/mood-chill", "\uD83D\uDE0E", "secondary"],
+  ["/badge/star-this%20repo", "\u2B50", "outline"],
+  ["/badge/packaged%20with-care", "\uD83D\uDCE6", "secondary"],
+  ["/badge/idea-bright", "\uD83D\uDCA1", "outline"],
+  ["/badge/powered%20by-vibes", "\uD83C\uDF08", "secondary"],
+  ["/badge/tests-passing", "\u2705", "outline"],
+  ["/badge/build-rocketing", "\uD83D\uDEF0\uFE0F", "default"],
+  ["/badge/security-locked", "\uD83D\uDD12", "secondary"],
+  ["/badge/docs-sparkling", "\uD83D\uDCDA", "outline"],
+  ["/badge/made%20in-the%20usa", "\uD83C\uDDFA\uD83C\uDDF8", "secondary"],
+  ["/badge/party-time", "\uD83E\uDD73", "outline"],
 ]
 
-const DEFAULT_ITEMS: BadgeItem[] = FLAG_SAMPLE.map((code) => ({
+const DEFAULT_ITEMS: BadgeItem[] = EMOJI_SAMPLE.map(([path, logo, variant]) => ({
   id: nextId(),
-  path: `/flag/${code}`,
-  variant: "secondary",
+  path,
+  logo,
+  variant,
   size: "sm",
   font: "inter",
   animate: "none",
@@ -169,6 +188,7 @@ function buildBaseSrc(item: BadgeItem, mode: Bg): string {
   params.set("mode", mode === "black" ? "dark" : "light")
   if (item.size !== "sm") params.set("size", item.size)
   if (item.font !== "inter") params.set("font", item.font)
+  if (item.logo) params.set("logo", item.logo)
   return `${item.path}.svg?${params.toString()}`
 }
 

--- a/packages/web/components/sidebar.tsx
+++ b/packages/web/components/sidebar.tsx
@@ -57,6 +57,7 @@ const docsNav: NavGroup[] = [
     items: [
       { title: "Themes", href: "/docs/customization/themes" },
       { title: "Styles", href: "/docs/customization/styles" },
+      { title: "Logos & Icons", href: "/docs/customization/logos" },
       { title: "Fonts", href: "/docs/customization/fonts" },
       { title: "Light & Dark Mode", href: "/docs/customization/light-dark-mode" },
     ],

--- a/packages/web/content/docs/api-reference.mdx
+++ b/packages/web/content/docs/api-reference.mdx
@@ -191,13 +191,13 @@ Join any badge paths with `+`. Query params apply to all segments. See [Badge Gr
       name: "logo",
       type: "string | false",
       default: "auto",
-      description: "SimpleIcons slug (e.g. react, typescript), React Icons (e.g. ri:FaReact, ri:GoStarFill), a base64 SVG data URI (data:image/svg+xml;base64,...) for custom icons, or false to hide.",
+      description: "SimpleIcons slug (e.g. react, typescript), React Icons (ri:FaReact), Lucide (lu:Check), an emoji via Twemoji (twemoji:🚀, twemoji:1f680, or a bare emoji like 🚀), a base64 SVG data URI (data:image/svg+xml;base64,...) for custom icons, or false to hide.",
     },
     {
       name: "logoColor",
       type: "string",
       default: "—",
-      description: "Override logo color (hex without #).",
+      description: "Override logo color (hex without #). No effect on emoji or multi-color SVGs.",
     },
   ]}
 />

--- a/packages/web/content/docs/customization/logos.mdx
+++ b/packages/web/content/docs/customization/logos.mdx
@@ -1,0 +1,114 @@
+---
+title: Logos & Icons
+description: Add a logo to any badge — SimpleIcons, React Icons, Lucide, emoji (Twemoji), or your own SVG.
+---
+
+Add an icon to any badge with the `?logo=` query parameter. shieldcn resolves logos from several sources, picked by a small prefix convention.
+
+## Logo sources
+
+| Source | Syntax | Example |
+|--------|--------|---------|
+| **SimpleIcons** (2,400+ brands) | bare slug | `?logo=react` |
+| **React Icons** (40,000+) | `ri:` prefix | `?logo=ri:FaReact` |
+| **Lucide** | `lu:` prefix | `?logo=lu:Check` |
+| **Twemoji** (emoji) | `twemoji:` prefix or bare emoji | `?logo=twemoji:🚀` |
+| **Custom SVG** | `data:` URI | `?logo=data:image/svg+xml;base64,…` |
+| **None** | `false` / `none` | `?logo=false` |
+
+Single-color icons (SimpleIcons, React Icons, Lucide) are recolored to match the badge variant and respect `?logoColor=`. Full-color sources (Twemoji, custom multi-color SVGs) keep their original colors.
+
+## Emoji (Twemoji)
+
+Any emoji can be a badge logo, rendered as a crisp full-color [Twemoji](https://github.com/jdecked/twemoji) glyph. Three forms work:
+
+```md
+![rocket](https://shieldcn.dev/badge/ship-it.svg?logo=twemoji:🚀)
+![rocket by codepoint](https://shieldcn.dev/badge/ship-it.svg?logo=twemoji:1f680)
+![rocket bare](https://shieldcn.dev/badge/ship-it.svg?logo=🚀)
+```
+
+- `twemoji:🚀` — explicit prefix with the emoji character.
+- `twemoji:1f680` — explicit prefix with the hex codepoint (handy when pasting emoji is awkward, e.g. in YAML).
+- `🚀` — a bare emoji is auto-detected as Twemoji.
+
+<BadgeSandbox
+  endpoint="/badge/:content.svg"
+  pathParams={[
+    { name: "content", label: "content", placeholder: "ship-it", required: true, description: "Static badge text, e.g. label-value or label-value-color" }
+  ]}
+  defaults={{ content: "ship-it", logo: "twemoji:🚀" }}
+  extraParams={[
+    { name: "logo", label: "logo", placeholder: "twemoji:🚀", description: "An emoji, twemoji:<emoji>, or twemoji:<codepoint>" }
+  ]}
+/>
+
+### Examples
+
+<BadgePreviewGroup>
+  <BadgePreviewCard src="/badge/ship-it.svg?logo=twemoji:🚀&variant=secondary" alt="rocket" description="🚀 on a custom badge" />
+  <BadgePreviewCard src="/badge/made%20with-love.svg?logo=❤️&variant=outline" alt="heart" description="Bare ❤️ auto-detected" />
+  <BadgePreviewCard src="/badge/status-on%20fire.svg?logo=twemoji:1f525&variant=destructive" alt="fire" description="🔥 by codepoint" />
+  <BadgePreviewCard src="/badge/coffee-driven.svg?logo=☕&variant=secondary" alt="coffee" description="☕ powered" />
+  <BadgePreviewCard src="/badge/built%20by-a%20human.svg?logo=👨‍💻" alt="developer" description="ZWJ sequence 👨‍💻" />
+  <BadgePreviewCard src="/badge/made%20in-the%20usa.svg?logo=🇺🇸&variant=secondary" alt="flag" description="Flag emoji 🇺🇸" />
+</BadgePreviewGroup>
+
+Emoji logos compose with every variant, size, theme, mode, and `split`. Because emoji are inherently multi-color, `?logoColor=` has no effect on them.
+
+<BadgePreview
+  src="/badge/release-shipped.svg?logo=🎉&variant=outline&theme=green"
+  alt="party badge"
+  description="🎉 with an outline variant and the green theme."
+/>
+
+## Brand icons (SimpleIcons)
+
+The most common case — use a brand's slug directly. Browse the full set in the [Gallery](/gallery).
+
+```md
+![react](https://shieldcn.dev/badge/built%20with-react.svg?logo=react)
+![typescript](https://shieldcn.dev/badge/typed-strict.svg?logo=typescript&variant=branded)
+```
+
+<BadgePreviewGroup>
+  <BadgePreviewCard src="/badge/built%20with-react.svg?logo=react&variant=branded" alt="react" description="?logo=react" />
+  <BadgePreviewCard src="/badge/typed-strict.svg?logo=typescript&variant=branded" alt="typescript" description="?logo=typescript" />
+  <BadgePreviewCard src="/badge/runtime-bun.svg?logo=bun&variant=branded" alt="bun" description="?logo=bun" />
+</BadgePreviewGroup>
+
+## React Icons & Lucide
+
+Reach 40,000+ icons via React Icons with the `ri:` prefix (use the exact component name), or Lucide with `lu:`.
+
+```md
+![react icon](https://shieldcn.dev/badge/icon-react.svg?logo=ri:FaReact)
+![lucide](https://shieldcn.dev/badge/check-passing.svg?logo=lu:Check)
+```
+
+<BadgePreviewGroup>
+  <BadgePreviewCard src="/badge/icon-FaReact.svg?logo=ri:FaReact" alt="react icon" description="?logo=ri:FaReact" />
+  <BadgePreviewCard src="/badge/check-passing.svg?logo=lu:Check&variant=outline" alt="lucide check" description="?logo=lu:Check" />
+</BadgePreviewGroup>
+
+## Custom SVG
+
+Pass your own icon as an inline `data:` URI (base64 or UTF-8 encoded SVG). The builder's logo uploader generates this for you.
+
+```md
+![custom](https://shieldcn.dev/badge/custom-icon.svg?logo=data:image/svg+xml;base64,PHN2Zy4uLg==)
+```
+
+## Logo color
+
+For single-color icons, override the fill with `?logoColor=` (hex without `#`):
+
+```md
+![colored](https://shieldcn.dev/badge/built%20with-react.svg?logo=react&logoColor=ff0000)
+```
+
+`logoColor` does not apply to Twemoji or multi-color custom SVGs, which keep their original colors.
+
+## In the builder
+
+Both the [Badge Builder](/gen) and [Profile Generator](/gen/profile) include a logo picker and an SVG uploader under the logo control.

--- a/packages/web/content/docs/customization/meta.json
+++ b/packages/web/content/docs/customization/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Customization",
-  "pages": ["themes", "styles", "fonts", "light-dark-mode"]
+  "pages": ["themes", "styles", "logos", "fonts", "light-dark-mode"]
 }

--- a/packages/web/lib/showcase-data.ts
+++ b/packages/web/lib/showcase-data.ts
@@ -52,6 +52,7 @@ export const featuredBadges: ShowcaseBadge[] = [
   dynamicBadge("Bluesky Followers", "featured social", "/bluesky/jay.bsky.team.svg?variant=outline", "Social proof badge for Bluesky profiles.", "/docs/badges/bluesky"),
   dynamicBadge("Bundle Size", "featured bundlephobia", "/bundlephobia/minzip/react.svg?variant=secondary", "Show how lightweight your package is.", "/docs/badges/bundlephobia"),
   dynamicBadge("Built in the USA", "featured location", "/flag/us.svg", "Country flag badge with a natural-aspect flag chip.", "/docs/badges/flag"),
+  dynamicBadge("Ship It", "featured emoji", "/badge/ship-it.svg?logo=twemoji:\uD83D\uDE80&variant=secondary", "Any emoji as a logo, rendered via Twemoji.", "/docs/customization/logos"),
 ]
 
 export const categories: Category[] = [
@@ -408,6 +409,20 @@ export const categories: Category[] = [
       dynamicBadge("README > Code", "meta", "/badge/README-longer%20than%20code-blue.svg?variant=secondary", "The documentation is the product."),
       dynamicBadge("Hopes & Dreams", "fuel", "/badge/Runs%20on-hopes%20%26%20dreams-FF69B4.svg?variant=secondary", "The real runtime environment."),
       dynamicBadge("Type Safety: Eventual", "aspiration", "/badge/type%20safety-eventual-orange.svg?variant=outline", "any any any any any."),
+    ],
+  },
+  {
+    name: "Emoji",
+    description: "Any emoji can be a badge logo, rendered as a crisp full-color Twemoji glyph. Use ?logo=<emoji>, ?logo=twemoji:<emoji>, or ?logo=twemoji:<codepoint>. See the Logos & Icons docs.",
+    icons: [
+      dynamicBadge("Ship It", "emoji logo", "/badge/ship-it.svg?logo=twemoji:\uD83D\uDE80&variant=secondary", "\uD83D\uDE80 rocket emoji as a logo via Twemoji.", "/docs/customization/logos"),
+      dynamicBadge("Made with Love", "emoji logo", "/badge/made%20with-love.svg?logo=\u2764\uFE0F&variant=outline", "Bare \u2764\uFE0F emoji \u2014 auto-detected as Twemoji.", "/docs/customization/logos"),
+      dynamicBadge("On Fire", "emoji logo", "/badge/status-on%20fire.svg?logo=twemoji:1f525&variant=destructive", "\uD83D\uDD25 by hex codepoint (twemoji:1f525).", "/docs/customization/logos"),
+      dynamicBadge("Coffee Driven", "emoji logo", "/badge/coffee-driven.svg?logo=\u2615&variant=secondary", "\u2615 the real dependency.", "/docs/customization/logos"),
+      dynamicBadge("Party", "emoji logo", "/badge/release-shipped.svg?logo=\uD83C\uDF89&variant=outline&theme=green", "\uD83C\uDF89 emoji + outline + green theme.", "/docs/customization/logos"),
+      dynamicBadge("Built by a Human", "emoji logo", "/badge/built%20by-a%20human.svg?logo=\uD83D\uDC68\u200D\uD83D\uDCBB", "\uD83D\uDC68\u200D\uD83D\uDCBB ZWJ sequence rendered correctly.", "/docs/customization/logos"),
+      dynamicBadge("Sparkles", "emoji logo", "/badge/quality-magic.svg?logo=\u2728&variant=secondary", "\u2728 add a little shine.", "/docs/customization/logos"),
+      dynamicBadge("100", "emoji logo", "/badge/score-100.svg?logo=\uD83D\uDCAF&variant=outline", "\uD83D\uDCAF keepin' it real.", "/docs/customization/logos"),
     ],
   },
   {


### PR DESCRIPTION
## What

Adds **Twemoji emoji logo support** — any emoji can be used as a badge logo, rendered as a crisp full-color [Twemoji](https://github.com/jdecked/twemoji) glyph.

## Why

shieldcn supported SimpleIcons, React Icons, Lucide, and custom SVG logos — but not emoji. Emoji logos are expressive, universally recognizable, and great for "for fun" / personality badges.

## How

**Engine (`@shieldcn/core`)**
- `twemoji.ts` — detects and resolves emoji logos. Accepts `?logo=twemoji:🚀`, `?logo=twemoji:1f680` (hex codepoint), or a bare `?logo=🚀` (auto-detected). Handles surrogate pairs, ZWJ sequences (👨‍💻), and regional-indicator flags (🇺🇸) using Twemoji's own codepoint rules. Art is fetched from `jdecked/twemoji` via jsDelivr (pinned version) and cached for 30 days.
- `render.tsx` — new square full-color emoji inset (1:1, `contain`) alongside the existing 3:2 flag inset; wired into both single and split renders.
- `route-handler.ts` — resolves emoji logos before the icon path and passes `emojiSvg` to the renderer. `logoColor` has no effect on emoji (they're multi-color).
- `types.ts` — `emojiSvg` added to `BadgeConfig`.

**Site (`@shieldcn/web`)**
- New `customization/logos.mdx` — documents *all* logo sources (SimpleIcons, React Icons, Lucide, Twemoji, custom SVG) with an interactive sandbox + examples. Wired into the sidebar.
- `api-reference.mdx` `logo` param updated.
- Showcase: new **Emoji** category + a featured emoji badge.
- `/dev/social` seeds a curated emoji-badge set (added an optional `logo` to its item model) so it's screenshot-ready.

## Testing

- `twemoji.test.ts`: emoji detection + codepoint resolution (prefix, bare emoji, hex codepoint, FE0F stripping, ZWJ, regional flags). All core tests pass: `pnpm --filter @shieldcn/core test`.
- Verified live: all three logo forms render an embedded full-color emoji; existing SimpleIcons/flag logos and `logo=false` unaffected; docs + showcase + `/dev/social` load.

## Notes

Air-gapped self-hosted engines won't fetch emoji art (same network dependency as country flags). Unrelated stray `public/Group 1.svg` left out of this branch.
