### PR TITLE
fix(badges): make GitHub badges reliable + surface provider failures in Sentry

### DIFF
--- a/packages/core/src/badges/registry.ts
+++ b/packages/core/src/badges/registry.ts
@@ -171,8 +171,6 @@ export const REGISTRY: BadgeProvider[] = [
       t("downloads", "Release downloads", ["downloads", "facebook", "react"]),
       t("downloads-all", "All release downloads", ["downloads-all", "facebook", "react"]),
       t("downloads-asset", "Specific asset downloads", ["downloads-asset", "facebook", "react"]),
-      t("dependents-repo", "Dependent repositories", ["dependents-repo", "facebook", "react"]),
-      t("dependents-pkg", "Dependent packages", ["dependents-pkg", "facebook", "react"]),
       // Pass/fail state badges — no `branded`.
       state("ci", "GitHub Actions CI status", ["ci", "facebook", "react"]),
       state("checks", "Combined check status", ["checks", "facebook", "react"]),

--- a/packages/core/src/badges/types.ts
+++ b/packages/core/src/badges/types.ts
@@ -135,4 +135,11 @@ export interface BadgeData {
   color?: string
   /** Optional link URL. */
   link?: string
+  /**
+   * Marks a terminal error verdict that still renders a real badge (e.g. a
+   * genuine 404 → "invalid repository"). Such results are cached only briefly
+   * and never persisted as a last-known-good value, so they self-heal quickly
+   * instead of being pinned at the CDN like a success.
+   */
+  error?: boolean
 }

--- a/packages/core/src/cache.test.ts
+++ b/packages/core/src/cache.test.ts
@@ -6,8 +6,8 @@
  * badges from collapsing into "not found" on a transient upstream failure.
  */
 
-import { describe, it, expect, vi } from "vitest"
-import { cachedFetchStale } from "./cache"
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { cachedFetchStale, setProviderAlertCallback, type ProviderAlert } from "./cache"
 
 // Unique key per case so the process-wide memory LRU doesn't bleed between tests.
 let n = 0
@@ -67,5 +67,37 @@ describe("cachedFetchStale", () => {
       vi.fn().mockRejectedValue(new Error("network")),
     )
     expect(result).toBeNull()
+  })
+})
+
+describe("provider alerts", () => {
+  afterEach(() => setProviderAlertCallback(null))
+
+  it("fires a badge_unavailable alert when a fetch fails with no cached value", async () => {
+    const alerts: ProviderAlert[] = []
+    setProviderAlertCallback((a) => alerts.push(a))
+
+    const result = await cachedFetchStale(
+      "test", freshKey(),
+      vi.fn().mockResolvedValue(null),
+    )
+
+    expect(result).toBeNull()
+    expect(alerts).toHaveLength(1)
+    expect(alerts[0]).toMatchObject({ provider: "test", reason: "badge_unavailable" })
+  })
+
+  it("does NOT alert when a stale value is available to serve", async () => {
+    const key = freshKey()
+    // Prime stale store, expire fresh immediately.
+    await cachedFetchStale("test", key, vi.fn().mockResolvedValue({ label: "x", value: "1" }), 0, 3600)
+
+    const alerts: ProviderAlert[] = []
+    setProviderAlertCallback((a) => alerts.push(a))
+
+    const result = await cachedFetchStale("test", key, vi.fn().mockResolvedValue(null), 0, 3600)
+
+    expect(result).toEqual({ label: "x", value: "1" })
+    expect(alerts).toHaveLength(0)
   })
 })

--- a/packages/core/src/cache.test.ts
+++ b/packages/core/src/cache.test.ts
@@ -1,0 +1,71 @@
+/**
+ * shieldcn
+ * cache.test
+ *
+ * Covers the last-known-good ("stale on error") behavior that keeps GitHub
+ * badges from collapsing into "not found" on a transient upstream failure.
+ */
+
+import { describe, it, expect, vi } from "vitest"
+import { cachedFetchStale } from "./cache"
+
+// Unique key per case so the process-wide memory LRU doesn't bleed between tests.
+let n = 0
+const freshKey = () => `test-key-${Date.now()}-${n++}`
+
+describe("cachedFetchStale", () => {
+  it("returns the fetched value and serves it from cache on the next call", async () => {
+    const key = freshKey()
+    const fetcher = vi.fn().mockResolvedValue({ label: "stars", value: "325" })
+
+    const first = await cachedFetchStale("test", key, fetcher)
+    expect(first).toEqual({ label: "stars", value: "325" })
+    expect(fetcher).toHaveBeenCalledTimes(1)
+
+    // Second call hits the fresh cache — fetcher is not invoked again.
+    const second = await cachedFetchStale("test", key, fetcher)
+    expect(second).toEqual({ label: "stars", value: "325" })
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it("serves last-known-good when a later fetch fails", async () => {
+    const key = freshKey()
+
+    // Prime the stale store with a good value, using a tiny fresh TTL so the
+    // fresh copy expires immediately but the stale copy survives.
+    const good = await cachedFetchStale(
+      "test", key,
+      vi.fn().mockResolvedValue({ label: "stars", value: "325" }),
+      0,        // fresh TTL: expire right away
+      3600,     // stale TTL: keep last-known-good
+    )
+    expect(good).toEqual({ label: "stars", value: "325" })
+
+    // Upstream now fails (returns null). We must still get the old value.
+    const stale = await cachedFetchStale(
+      "test", key,
+      vi.fn().mockResolvedValue(null),
+      0,
+      3600,
+    )
+    expect(stale).toEqual({ label: "stars", value: "325" })
+  })
+
+  it("returns null when a fetch fails and there is no prior good value", async () => {
+    const key = freshKey()
+    const result = await cachedFetchStale(
+      "test", key,
+      vi.fn().mockResolvedValue(null),
+    )
+    expect(result).toBeNull()
+  })
+
+  it("treats a thrown error like a failed fetch (last-known-good or null)", async () => {
+    const key = freshKey()
+    const result = await cachedFetchStale(
+      "test", key,
+      vi.fn().mockRejectedValue(new Error("network")),
+    )
+    expect(result).toBeNull()
+  })
+})

--- a/packages/core/src/cache.test.ts
+++ b/packages/core/src/cache.test.ts
@@ -12,6 +12,8 @@ import {
   setProviderAlertCallback,
   recordBackoff,
   clearBackoff,
+  cacheGet,
+  cacheSet,
   type ProviderAlert,
 } from "./cache"
 
@@ -55,6 +57,27 @@ describe("cachedFetchStale", () => {
       3600,
     )
     expect(stale).toEqual({ label: "stars", value: "325" })
+  })
+
+  it("returns a terminal-error result but never persists it as last-known-good", async () => {
+    const key = freshKey()
+    const staleKey = `shieldcn:test:stale:${key}`
+    const isError = (d: { error?: boolean }) => d.error === true
+
+    // Seed the last-known-good store directly (fresh cache stays empty).
+    await cacheSet(staleKey, { label: "stars", value: "325" }, 3600)
+
+    // Upstream now returns a terminal error verdict ("invalid repository").
+    const errVal = await cachedFetchStale(
+      "test", key,
+      vi.fn().mockResolvedValue({ label: "github", value: "invalid repository", error: true }),
+      300, 3600, { isError },
+    )
+    // It is returned to the caller...
+    expect(errVal).toMatchObject({ value: "invalid repository" })
+    // ...but must NOT have overwritten the last-known-good value, so a repo
+    // that recovers self-heals instead of being stuck on the error verdict.
+    expect(await cacheGet(staleKey)).toEqual({ label: "stars", value: "325" })
   })
 
   it("returns null when a fetch fails and there is no prior good value", async () => {

--- a/packages/core/src/cache.test.ts
+++ b/packages/core/src/cache.test.ts
@@ -7,7 +7,13 @@
  */
 
 import { describe, it, expect, vi, afterEach } from "vitest"
-import { cachedFetchStale, setProviderAlertCallback, type ProviderAlert } from "./cache"
+import {
+  cachedFetchStale,
+  setProviderAlertCallback,
+  recordBackoff,
+  clearBackoff,
+  type ProviderAlert,
+} from "./cache"
 
 // Unique key per case so the process-wide memory LRU doesn't bleed between tests.
 let n = 0
@@ -99,5 +105,23 @@ describe("provider alerts", () => {
 
     expect(result).toEqual({ label: "x", value: "1" })
     expect(alerts).toHaveLength(0)
+  })
+
+  it("alerts any provider once per backoff cycle on a rate limit", async () => {
+    const provider = `prov-${Date.now()}-${n++}`
+    clearBackoff(provider)
+    const alerts: ProviderAlert[] = []
+    setProviderAlertCallback((a) => alerts.push(a))
+
+    // First failure starts a backoff cycle → one alert with the status.
+    recordBackoff(provider, 429)
+    // Subsequent failures within the same active window must NOT re-alert.
+    recordBackoff(provider, 429)
+    recordBackoff(provider, 429)
+
+    expect(alerts).toHaveLength(1)
+    expect(alerts[0]).toMatchObject({ provider, reason: "rate_limit", status: 429 })
+
+    clearBackoff(provider)
   })
 })

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -79,15 +79,41 @@ export function isBackedOff(provider: string): boolean {
 /**
  * Record a rate limit or server error for a provider.
  * Applies exponential backoff: 15s, 30s, 60s, 120s, 300s.
+ *
+ * Also surfaces a provider alert (Sentry issue) on the request that *starts*
+ * a backoff cycle — when there is no active backoff window. Subsequent
+ * blocked requests within the same window don't re-alert, so this stays
+ * roughly one alert per outage rather than one per request. This is the
+ * single chokepoint every provider funnels rate limits / 5xx through (via
+ * githubFetch, handleUpstreamStatus, or provider-fetch), so adding it here
+ * gives every provider rate-limit alerting, not just GitHub.
+ *
+ * @param provider - provider name (e.g. "github", "npm")
+ * @param status - upstream HTTP status that triggered the backoff, if known
  */
-export function recordBackoff(provider: string): void {
+export function recordBackoff(provider: string, status?: number): void {
   const state = backoff.get(provider)
+  // A new cycle = no backoff state, or the previous window has elapsed.
+  const newCycle = !state || Date.now() >= state.until
   const count = (state?.count ?? 0) + 1
   const delay = Math.min(15000 * Math.pow(2, count - 1), MAX_BACKOFF_MS)
   backoff.set(provider, {
     until: Date.now() + delay,
     count,
   })
+
+  if (newCycle) {
+    reportProviderAlert({
+      provider,
+      reason: status === 503 ? "unavailable" : "rate_limit",
+      status,
+      message: status === 503
+        ? `${provider} API unavailable (503)`
+        : status
+          ? `${provider} API rate limited (${status})`
+          : `${provider} API rate limited`,
+    })
+  }
 }
 
 /**
@@ -369,7 +395,7 @@ export async function cachedFetch<T>(
     if (err instanceof Response) {
       const status = err.status
       if (status === 429 || status === 503) {
-        recordBackoff(provider)
+        recordBackoff(provider, status)
       }
     }
     return null
@@ -460,7 +486,7 @@ export async function cachedFetchStale<T>(
     data = await fetcher()
   } catch (err) {
     if (err instanceof Response && (err.status === 429 || err.status === 503)) {
-      recordBackoff(provider)
+      recordBackoff(provider, err.status)
     }
     data = null
   }
@@ -483,7 +509,7 @@ export async function cachedFetchStale<T>(
  */
 export function handleUpstreamStatus(provider: string, status: number): void {
   if (status === 429 || status === 503) {
-    recordBackoff(provider)
+    recordBackoff(provider, status)
   } else if (status >= 200 && status < 400) {
     clearBackoff(provider)
   }

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -331,6 +331,98 @@ export async function cachedFetch<T>(
 }
 
 /**
+ * Cached provider fetch with last-known-good fallback ("stale on error").
+ *
+ * Unlike {@link cachedFetch}, this keeps two copies of every successful
+ * result:
+ *   - a "fresh" copy with a short TTL (`freshTtl`), and
+ *   - a "stale" copy with a long TTL (`staleTtl`).
+ *
+ * When a fetch fails (returns `null`) or the provider is currently backed
+ * off, the stale copy is served instead of failing. This prevents a
+ * transient upstream blip (429/503, network error, empty token pool) from
+ * collapsing a previously-good badge into a "not found" — the badge keeps
+ * showing its last-known value until the upstream recovers.
+ *
+ * Only non-null results are cached; a genuine miss with no prior good value
+ * still returns `null` (caller decides how to render / cache that).
+ *
+ * @param provider - provider name (e.g. "github")
+ * @param key - unique cache key for this request
+ * @param fetcher - async function that fetches the data
+ * @param freshTtl - fresh-copy TTL in seconds (default 300)
+ * @param staleTtl - last-known-good TTL in seconds (default 7 days)
+ */
+export async function cachedFetchStale<T>(
+  provider: string,
+  key: string,
+  fetcher: () => Promise<T | null>,
+  freshTtl: number = 300,
+  staleTtl: number = 60 * 60 * 24 * 7,
+): Promise<T | null> {
+  const freshKey = cacheKey(provider, key)
+  const staleKey = cacheKey(provider, "stale", key)
+
+  // 1. Fresh cache hit?
+  const fresh = await cacheGet<T>(freshKey)
+  if (fresh !== undefined) {
+    cacheMetricsCallback?.({
+      type: "counter", name: "badge.cache", value: 1,
+      tags: { provider, result: "hit" },
+    })
+    return fresh
+  }
+  cacheMetricsCallback?.({
+    type: "counter", name: "badge.cache", value: 1,
+    tags: { provider, result: "miss" },
+  })
+
+  // Helper: serve last-known-good if we have it.
+  const serveStale = async (): Promise<T | null> => {
+    const stale = await cacheGet<T>(staleKey)
+    if (stale !== undefined) {
+      cacheMetricsCallback?.({
+        type: "counter", name: "badge.cache", value: 1,
+        tags: { provider, result: "stale" },
+      })
+      return stale
+    }
+    return null
+  }
+
+  // 2. Provider backed off — don't hammer it, serve last-known-good.
+  if (isBackedOff(provider)) {
+    cacheMetricsCallback?.({
+      type: "counter", name: "badge.backoff", value: 1,
+      tags: { provider },
+    })
+    return serveStale()
+  }
+
+  // 3. Fetch.
+  let data: T | null = null
+  try {
+    data = await fetcher()
+  } catch (err) {
+    if (err instanceof Response && (err.status === 429 || err.status === 503)) {
+      recordBackoff(provider)
+    }
+    data = null
+  }
+
+  if (data !== null) {
+    clearBackoff(provider)
+    // Refresh both the short-lived and the long-lived copy.
+    await cacheSet(freshKey, data, freshTtl)
+    await cacheSet(staleKey, data, staleTtl)
+    return data
+  }
+
+  // 4. Fetch failed — fall back to last-known-good rather than failing.
+  return serveStale()
+}
+
+/**
  * Record a fetch response status for backoff tracking.
  * Call this from provider fetch helpers when they get a response.
  */

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -419,11 +419,20 @@ export async function cachedFetch<T>(
  * Only non-null results are cached; a genuine miss with no prior good value
  * still returns `null` (caller decides how to render / cache that).
  *
+ * A fetched result may be a "terminal error" — a real value that nonetheless
+ * represents a definitive error state (e.g. GitHub 404 → "invalid
+ * repository"). Pass `opts.isError` to mark these: they are cached only
+ * briefly (`opts.errorTtl`) so repeated requests don't re-hit the upstream,
+ * but they are NEVER written to the long-lived stale store and never
+ * overwrite an existing good value — so they self-heal quickly and can't be
+ * served later as a fake last-known-good.
+ *
  * @param provider - provider name (e.g. "github")
  * @param key - unique cache key for this request
  * @param fetcher - async function that fetches the data
  * @param freshTtl - fresh-copy TTL in seconds (default 300)
  * @param staleTtl - last-known-good TTL in seconds (default 7 days)
+ * @param opts - optional terminal-error handling
  */
 export async function cachedFetchStale<T>(
   provider: string,
@@ -431,6 +440,7 @@ export async function cachedFetchStale<T>(
   fetcher: () => Promise<T | null>,
   freshTtl: number = 300,
   staleTtl: number = 60 * 60 * 24 * 7,
+  opts?: { isError?: (data: T) => boolean; errorTtl?: number },
 ): Promise<T | null> {
   const freshKey = cacheKey(provider, key)
   const staleKey = cacheKey(provider, "stale", key)
@@ -493,9 +503,16 @@ export async function cachedFetchStale<T>(
 
   if (data !== null) {
     clearBackoff(provider)
-    // Refresh both the short-lived and the long-lived copy.
-    await cacheSet(freshKey, data, freshTtl)
-    await cacheSet(staleKey, data, staleTtl)
+    if (opts?.isError?.(data)) {
+      // Terminal error verdict: cache briefly so we don't re-hit the upstream
+      // on every request, but never persist it as last-known-good and never
+      // clobber an existing good value — so it self-heals fast.
+      await cacheSet(freshKey, data, opts.errorTtl ?? 60)
+    } else {
+      // Good value: refresh both the short-lived and the long-lived copy.
+      await cacheSet(freshKey, data, freshTtl)
+      await cacheSet(staleKey, data, staleTtl)
+    }
     return data
   }
 

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -269,6 +269,52 @@ export function setCacheMetricsCallback(cb: typeof cacheMetricsCallback): void {
   cacheMetricsCallback = cb
 }
 
+// ---------------------------------------------------------------------------
+// Provider alerts (Sentry issues, not just metrics)
+// ---------------------------------------------------------------------------
+
+/**
+ * A provider-level alert worth surfacing as a Sentry issue (not just a
+ * metric counter). Examples: an upstream rate limit (429), or a badge that
+ * could not be served at all because the upstream failed and there was no
+ * last-known-good value to fall back to.
+ *
+ * `reason` and `message` are kept stable so Sentry groups recurring alerts
+ * into a single issue; `context` carries the variable detail (path, url).
+ */
+export interface ProviderAlert {
+  /** Provider name, e.g. "github". */
+  provider: string
+  /** What went wrong — used for triage and Sentry grouping. */
+  reason: "rate_limit" | "unavailable" | "badge_unavailable"
+  /** HTTP status, when applicable (e.g. 429, 503). */
+  status?: number
+  /** Stable human-readable summary (avoid per-request detail here). */
+  message: string
+  /** Variable context (badge path, url) — not used for grouping. */
+  context?: Record<string, string>
+}
+
+let providerAlertCallback: ((alert: ProviderAlert) => void) | null = null
+
+/**
+ * Register a callback to receive provider alerts. Apps wire this to
+ * Sentry.captureMessage (or any alerting backend); core stays
+ * dependency-free. Call once at app startup.
+ */
+export function setProviderAlertCallback(cb: ((alert: ProviderAlert) => void) | null): void {
+  providerAlertCallback = cb
+}
+
+/** Emit a provider alert. No-op if no callback is registered; never throws. */
+export function reportProviderAlert(alert: ProviderAlert): void {
+  try {
+    providerAlertCallback?.(alert)
+  } catch {
+    // Alerting must never break a badge response.
+  }
+}
+
 export async function cachedFetch<T>(
   provider: string,
   key: string,
@@ -377,7 +423,10 @@ export async function cachedFetchStale<T>(
     tags: { provider, result: "miss" },
   })
 
-  // Helper: serve last-known-good if we have it.
+  // Helper: serve last-known-good if we have it, otherwise surface that the
+  // badge could not be served at all (upstream failed and there is no cached
+  // value to fall back to) so it shows up in Sentry rather than silently
+  // rendering "not found".
   const serveStale = async (): Promise<T | null> => {
     const stale = await cacheGet<T>(staleKey)
     if (stale !== undefined) {
@@ -387,6 +436,12 @@ export async function cachedFetchStale<T>(
       })
       return stale
     }
+    reportProviderAlert({
+      provider,
+      reason: "badge_unavailable",
+      message: `${provider} badge unavailable (upstream failed, no cached value)`,
+      context: { key },
+    })
     return null
   }
 

--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -12,28 +12,11 @@
 import type { BadgeData } from "../badges/types"
 import { formatCount } from "../format"
 import { pickToken, invalidateToken } from "../token-pool"
-import { isBackedOff, recordBackoff, clearBackoff, reportProviderAlert } from "../cache"
+import { isBackedOff, recordBackoff, clearBackoff } from "../cache"
 
 // ---------------------------------------------------------------------------
 // Fetch helper
 // ---------------------------------------------------------------------------
-
-/**
- * Surface a GitHub rate-limit / unavailability to Sentry. Only fires on the
- * request that actually trips the limit — once backed off, githubFetch short
- * -circuits before reaching here, so this stays roughly one alert per backoff
- * cycle rather than one per blocked request.
- */
-function alertRateLimited(status: number): void {
-  reportProviderAlert({
-    provider: "github",
-    reason: status === 429 ? "rate_limit" : "unavailable",
-    status,
-    message: status === 429
-      ? "GitHub API rate limited (429)"
-      : `GitHub API unavailable (${status})`,
-  })
-}
 
 async function githubFetch(url: string, revalidate: number = 3600): Promise<Response | null> {
   if (isBackedOff("github")) return null
@@ -46,10 +29,9 @@ async function githubFetch(url: string, revalidate: number = 3600): Promise<Resp
     }
     const response = await fetch(url, { headers, next: { revalidate } })
 
-    // Track rate limits
+    // Track rate limits — recordBackoff also surfaces the Sentry alert.
     if (response.status === 429 || response.status === 503) {
-      recordBackoff("github")
-      alertRateLimited(response.status)
+      recordBackoff("github", response.status)
       return null
     }
 
@@ -141,8 +123,7 @@ export async function githubRepoExists(owner: string, repo: string): Promise<boo
     })
     if (response.status === 404) return false
     if (response.status === 429 || response.status === 503) {
-      recordBackoff("github")
-      alertRateLimited(response.status)
+      recordBackoff("github", response.status)
       return null
     }
     if (response.ok) {

--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -12,11 +12,28 @@
 import type { BadgeData } from "../badges/types"
 import { formatCount } from "../format"
 import { pickToken, invalidateToken } from "../token-pool"
-import { isBackedOff, recordBackoff, clearBackoff } from "../cache"
+import { isBackedOff, recordBackoff, clearBackoff, reportProviderAlert } from "../cache"
 
 // ---------------------------------------------------------------------------
 // Fetch helper
 // ---------------------------------------------------------------------------
+
+/**
+ * Surface a GitHub rate-limit / unavailability to Sentry. Only fires on the
+ * request that actually trips the limit — once backed off, githubFetch short
+ * -circuits before reaching here, so this stays roughly one alert per backoff
+ * cycle rather than one per blocked request.
+ */
+function alertRateLimited(status: number): void {
+  reportProviderAlert({
+    provider: "github",
+    reason: status === 429 ? "rate_limit" : "unavailable",
+    status,
+    message: status === 429
+      ? "GitHub API rate limited (429)"
+      : `GitHub API unavailable (${status})`,
+  })
+}
 
 async function githubFetch(url: string, revalidate: number = 3600): Promise<Response | null> {
   if (isBackedOff("github")) return null
@@ -32,6 +49,7 @@ async function githubFetch(url: string, revalidate: number = 3600): Promise<Resp
     // Track rate limits
     if (response.status === 429 || response.status === 503) {
       recordBackoff("github")
+      alertRateLimited(response.status)
       return null
     }
 
@@ -94,6 +112,47 @@ async function resolveRepo(owner: string, repo: string): Promise<{ owner: string
   const [o, r] = fullName.split("/")
   if (!o || !r) return null
   return { owner: o, repo: r }
+}
+
+/**
+ * Definitively decide whether a repo exists, so a genuine bad/typo'd repo can
+ * render "invalid repository" instead of a generic transient "not found".
+ *
+ * Returns:
+ *   - `false` — GitHub says the repo does not exist (404)
+ *   - `true`  — the repo exists (2xx)
+ *   - `null`  — couldn't tell (rate limit, backoff, network, other status);
+ *               caller should treat this as transient, not as "invalid"
+ *
+ * Uses a HEAD request (no body) and is only called on the failure path, so it
+ * costs an extra call only when a badge would otherwise have failed.
+ */
+export async function githubRepoExists(owner: string, repo: string): Promise<boolean | null> {
+  if (isBackedOff("github")) return null
+  try {
+    const token = await pickToken()
+    const response = await fetch(`https://api.github.com/repos/${owner}/${repo}`, {
+      method: "HEAD",
+      headers: {
+        Accept: "application/vnd.github.v3+json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      next: { revalidate: 3600 },
+    })
+    if (response.status === 404) return false
+    if (response.status === 429 || response.status === 503) {
+      recordBackoff("github")
+      alertRateLimited(response.status)
+      return null
+    }
+    if (response.ok) {
+      clearBackoff("github")
+      return true
+    }
+    return null
+  } catch {
+    return null
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -5,7 +5,7 @@
  * GitHub REST API client. Uses the token pool for distributed rate limiting.
  * Supports: stars, forks, watchers, branches, releases, tags, license,
  *           contributors, checks, issues, PRs, milestones, commits,
- *           last-commit, assets-dl, dependents, dependabot,
+ *           last-commit, assets-dl, dependabot,
  *           followers, user-stars.
  */
 

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -155,6 +155,7 @@ import { getLiberapayReceiving, getLiberapayPatrons, getLiberapayGoal } from "./
 import { getMatrixMembers } from "./providers/matrix"
 import { getWeblateTranslation, getWeblateLanguages } from "./providers/weblate"
 import { getShipperClubMember } from "./providers/shipperclub"
+import { cachedFetchStale } from "./cache"
 
 /** Response format. */
 type Format = "svg" | "png" | "gif" | "json" | "shields"
@@ -198,11 +199,29 @@ function parseGradient(raw: string | null): string | undefined {
   return `linear-gradient(${angle}deg, ${stops})`
 }
 
-/** Cache headers for responses. */
+/** Cache headers for successful badge responses. */
 const CACHE_HEADERS = {
   "Cache-Control":
     "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400",
 }
+
+/**
+ * Cache headers for error / "not found" responses.
+ *
+ * Deliberately short-lived with no long `stale-while-revalidate` window:
+ * an error is almost always transient (rate limit, backoff, upstream blip),
+ * so it must self-heal on the next request rather than being pinned at the
+ * CDN/browser for an hour the way a success is. A genuine 404 just gets
+ * re-checked every minute, which is cheap.
+ */
+const ERROR_CACHE_HEADERS = {
+  "Cache-Control":
+    "public, max-age=60, s-maxage=60, stale-while-revalidate=120",
+}
+
+/** GitHub last-known-good cache tuning (see cachedFetchStale). */
+const GITHUB_FRESH_TTL = 300 // 5 min fresh copy
+const GITHUB_STALE_TTL = 60 * 60 * 24 * 7 // 7 day last-known-good fallback
 
 /**
  * Parse the format from the last URL segment.
@@ -253,6 +272,149 @@ function parseFormat(segments: string[]): {
 /**
  * Route the request to the appropriate provider.
  */
+/**
+ * Resolve a GitHub badge from the path segments after the "github" provider.
+ * `rest` is `segments.slice(1)` (e.g. ["stars", "owner", "repo"] or
+ * ["owner", "repo", "stars"]). Returns the live badge data, or null when the
+ * upstream call fails / the path is malformed — the caller (cachedFetchStale)
+ * supplies the last-known-good fallback for the failure case.
+ */
+async function resolveGitHubBadge(
+  rest: string[],
+  searchParams: URLSearchParams,
+): Promise<BadgeData | null> {
+  // User-level endpoints (2 segments: topic + username)
+  const userTopics = new Set(["followers", "user-stars"])
+  if (rest.length >= 2 && userTopics.has(rest[0])) {
+    const username = rest[1]
+    switch (rest[0]) {
+      case "followers":  return getGitHubFollowers(username)
+      case "user-stars": return getGitHubUserStars(username)
+      default: return null
+    }
+  }
+
+  if (rest.length < 3) return null
+
+  // Detect format: is rest[0] a known topic or an owner?
+  const knownTopics = new Set([
+    "stars", "forks", "watchers", "branches", "releases", "tags", "tag",
+    "license", "release", "contributors", "ci", "checks",
+    "issues", "open-issues", "closed-issues", "label-issues",
+    "prs", "open-prs", "closed-prs", "merged-prs",
+    "milestones", "commits", "last-commit",
+    "assets-dl", "dt",
+    "downloads", "downloads-all", "downloads-asset",
+    "dependents-repo", "dependents-pkg", "dependabot",
+  ])
+
+  let topic: string
+  let owner: string
+  let repo: string
+  let extra: string[] // remaining segments after owner/repo
+
+  if (knownTopics.has(rest[0])) {
+    // /github/{topic}/{owner}/{repo}/...
+    topic = rest[0]
+    owner = rest[1]
+    repo = rest[2]
+    extra = rest.slice(3)
+  } else {
+    // /github/{owner}/{repo}/{topic}/...
+    owner = rest[0]
+    repo = rest[1]
+    topic = rest[2]
+    extra = rest.slice(3)
+  }
+
+  switch (topic) {
+    // Repo metadata
+    case "stars":       return getGitHubStars(owner, repo)
+    case "forks":       return getGitHubForks(owner, repo)
+    case "watchers":    return getGitHubWatchers(owner, repo)
+    case "license":     return getGitHubLicense(owner, repo)
+    case "branches":    return getGitHubBranches(owner, repo)
+    case "releases":    return getGitHubReleases(owner, repo)
+    case "tags":        return getGitHubTags(owner, repo)
+    case "tag":         return getGitHubLatestTag(owner, repo)
+    case "contributors": return getGitHubContributors(owner, repo)
+    case "dependabot":  return getGitHubDependabot(owner, repo)
+
+    // Release (optional channel: stable)
+    case "release":     return getGitHubRelease(owner, repo, extra[0])
+
+    // CI (Actions)
+    case "ci":
+      return getGitHubCI(owner, repo,
+        searchParams.get("workflow") ?? undefined,
+        searchParams.get("branch") ?? undefined)
+
+    // Checks
+    case "checks":
+      return getGitHubChecks(owner, repo,
+        extra[0], // ref (branch/tag)
+        extra.slice(1).join("/") || undefined) // check_name
+
+    // Issues
+    case "issues":
+    case "open-issues":
+    case "closed-issues":
+      return getGitHubIssues(owner, repo, topic)
+
+    case "label-issues":
+      return getGitHubLabelIssues(owner, repo,
+        extra[0] || "",
+        extra[1]) // open|closed
+
+    // PRs
+    case "prs":
+    case "open-prs":
+    case "closed-prs":
+    case "merged-prs":
+      return getGitHubPRs(owner, repo, topic)
+
+    // Milestones
+    case "milestones":
+      return getGitHubMilestone(owner, repo, extra[0] || "1")
+
+    // Commits
+    case "commits":     return getGitHubCommits(owner, repo, extra[0])
+    case "last-commit": return getGitHubLastCommit(owner, repo, extra[0])
+
+    // Downloads (legacy)
+    case "assets-dl":
+    case "dt":
+      return getGitHubAssetsDl(owner, repo, extra[0])
+
+    // Downloads — granular
+    // /github/downloads/{owner}/{repo}              → all assets, all releases
+    // /github/downloads/{owner}/{repo}/latest       → all assets, latest release
+    // /github/downloads/{owner}/{repo}/{tag}        → all assets, specific tag
+    // /github/downloads-all/{owner}/{repo}          → all assets, all releases (alias)
+    // /github/downloads-all/{owner}/{repo}/latest   → all assets, latest release
+    // /github/downloads-all/{owner}/{repo}/{tag}    → all assets, specific tag
+    case "downloads":
+    case "downloads-all": {
+      if (!extra[0]) return getGitHubDownloadsAllAssetsAllReleases(owner, repo)
+      if (extra[0] === "latest") return getGitHubDownloadsAllAssetsLatest(owner, repo)
+      return getGitHubDownloadsAllAssetsTag(owner, repo, extra[0])
+    }
+
+    // /github/downloads-asset/{owner}/{repo}/{assetName}           → specific asset, all releases
+    // /github/downloads-asset/{owner}/{repo}/{assetName}/latest    → specific asset, latest release
+    // /github/downloads-asset/{owner}/{repo}/{assetName}/{tag}     → specific asset, specific tag
+    case "downloads-asset": {
+      if (!extra[0]) return null
+      const assetName = extra[0]
+      if (!extra[1]) return getGitHubDownloadsAssetAllReleases(owner, repo, assetName)
+      if (extra[1] === "latest") return getGitHubDownloadsAssetLatest(owner, repo, assetName)
+      return getGitHubDownloadsAssetTag(owner, repo, extra[1], assetName)
+    }
+
+    default: return null
+  }
+}
+
 async function fetchBadgeData(
   segments: string[],
   searchParams: URLSearchParams
@@ -316,137 +478,22 @@ async function fetchBadgeData(
     // Support both: /github/stars/owner/repo AND /github/owner/repo/stars
     case "github": {
       const rest = segments.slice(1)
+      if (rest.length < 2) return null
 
-      // User-level endpoints (2 segments: topic + username)
-      const userTopics = new Set(["followers", "user-stars"])
-      if (rest.length >= 2 && userTopics.has(rest[0])) {
-        const username = rest[1]
-        switch (rest[0]) {
-          case "followers":  return getGitHubFollowers(username)
-          case "user-stars": return getGitHubUserStars(username)
-          default: return null
-        }
-      }
-
-      if (rest.length < 3) return null
-
-      // Detect format: is rest[0] a known topic or an owner?
-      const knownTopics = new Set([
-        "stars", "forks", "watchers", "branches", "releases", "tags", "tag",
-        "license", "release", "contributors", "ci", "checks",
-        "issues", "open-issues", "closed-issues", "label-issues",
-        "prs", "open-prs", "closed-prs", "merged-prs",
-        "milestones", "commits", "last-commit",
-        "assets-dl", "dt",
-        "downloads", "downloads-all", "downloads-asset",
-        "dependents-repo", "dependents-pkg", "dependabot",
-      ])
-
-      let topic: string
-      let owner: string
-      let repo: string
-      let extra: string[] // remaining segments after owner/repo
-
-      if (knownTopics.has(rest[0])) {
-        // /github/{topic}/{owner}/{repo}/...
-        topic = rest[0]
-        owner = rest[1]
-        repo = rest[2]
-        extra = rest.slice(3)
-      } else {
-        // /github/{owner}/{repo}/{topic}/...
-        owner = rest[0]
-        repo = rest[1]
-        topic = rest[2]
-        extra = rest.slice(3)
-      }
-
-      switch (topic) {
-        // Repo metadata
-        case "stars":       return getGitHubStars(owner, repo)
-        case "forks":       return getGitHubForks(owner, repo)
-        case "watchers":    return getGitHubWatchers(owner, repo)
-        case "license":     return getGitHubLicense(owner, repo)
-        case "branches":    return getGitHubBranches(owner, repo)
-        case "releases":    return getGitHubReleases(owner, repo)
-        case "tags":        return getGitHubTags(owner, repo)
-        case "tag":         return getGitHubLatestTag(owner, repo)
-        case "contributors": return getGitHubContributors(owner, repo)
-        case "dependabot":  return getGitHubDependabot(owner, repo)
-
-        // Release (optional channel: stable)
-        case "release":     return getGitHubRelease(owner, repo, extra[0])
-
-        // CI (Actions)
-        case "ci":
-          return getGitHubCI(owner, repo,
-            searchParams.get("workflow") ?? undefined,
-            searchParams.get("branch") ?? undefined)
-
-        // Checks
-        case "checks":
-          return getGitHubChecks(owner, repo,
-            extra[0], // ref (branch/tag)
-            extra.slice(1).join("/") || undefined) // check_name
-
-        // Issues
-        case "issues":
-        case "open-issues":
-        case "closed-issues":
-          return getGitHubIssues(owner, repo, topic)
-
-        case "label-issues":
-          return getGitHubLabelIssues(owner, repo,
-            extra[0] || "",
-            extra[1]) // open|closed
-
-        // PRs
-        case "prs":
-        case "open-prs":
-        case "closed-prs":
-        case "merged-prs":
-          return getGitHubPRs(owner, repo, topic)
-
-        // Milestones
-        case "milestones":
-          return getGitHubMilestone(owner, repo, extra[0] || "1")
-
-        // Commits
-        case "commits":     return getGitHubCommits(owner, repo, extra[0])
-        case "last-commit": return getGitHubLastCommit(owner, repo, extra[0])
-
-        // Downloads (legacy)
-        case "assets-dl":
-        case "dt":
-          return getGitHubAssetsDl(owner, repo, extra[0])
-
-        // Downloads — granular
-        // /github/downloads/{owner}/{repo}              → all assets, all releases
-        // /github/downloads/{owner}/{repo}/latest       → all assets, latest release
-        // /github/downloads/{owner}/{repo}/{tag}        → all assets, specific tag
-        // /github/downloads-all/{owner}/{repo}          → all assets, all releases (alias)
-        // /github/downloads-all/{owner}/{repo}/latest   → all assets, latest release
-        // /github/downloads-all/{owner}/{repo}/{tag}    → all assets, specific tag
-        case "downloads":
-        case "downloads-all": {
-          if (!extra[0]) return getGitHubDownloadsAllAssetsAllReleases(owner, repo)
-          if (extra[0] === "latest") return getGitHubDownloadsAllAssetsLatest(owner, repo)
-          return getGitHubDownloadsAllAssetsTag(owner, repo, extra[0])
-        }
-
-        // /github/downloads-asset/{owner}/{repo}/{assetName}           → specific asset, all releases
-        // /github/downloads-asset/{owner}/{repo}/{assetName}/latest    → specific asset, latest release
-        // /github/downloads-asset/{owner}/{repo}/{assetName}/{tag}     → specific asset, specific tag
-        case "downloads-asset": {
-          if (!extra[0]) return null
-          const assetName = extra[0]
-          if (!extra[1]) return getGitHubDownloadsAssetAllReleases(owner, repo, assetName)
-          if (extra[1] === "latest") return getGitHubDownloadsAssetLatest(owner, repo, assetName)
-          return getGitHubDownloadsAssetTag(owner, repo, extra[1], assetName)
-        }
-
-        default: return null
-      }
+      // Wrap GitHub resolution in a last-known-good cache. A transient
+      // upstream failure (rate limit, 429/503 backoff, network blip, empty
+      // token pool) then serves the previous good value instead of
+      // collapsing the badge into a red "not found".
+      const wf = searchParams.get("workflow")
+      const br = searchParams.get("branch")
+      const ghKey = rest.join("/") + (wf ? `|wf=${wf}` : "") + (br ? `|br=${br}` : "")
+      return cachedFetchStale(
+        "github",
+        ghKey,
+        () => resolveGitHubBadge(rest, searchParams),
+        GITHUB_FRESH_TTL,
+        GITHUB_STALE_TTL,
+      )
     }
 
     // /discord/{serverId} or /discord/{topic}/{inviteCode}
@@ -1424,22 +1471,24 @@ async function handleBadgeGroup(
   if (badgePaths.length === 0) {
     if (format === "svg") {
       return new Response(await renderErrorBadge("group", "no badges specified"), {
-        headers: { "Content-Type": "image/svg+xml", ...CACHE_HEADERS },
+        headers: { "Content-Type": "image/svg+xml", ...ERROR_CACHE_HEADERS },
       })
     }
-    return Response.json({ error: "no badges specified" }, { status: 400 })
+    return Response.json({ error: "no badges specified" }, { status: 400, headers: ERROR_CACHE_HEADERS })
   }
 
   // JSON: return array of badge data
   if (format === "json") {
+    let hadError = false
     const results = await Promise.all(
       badgePaths.map(async (bp) => {
         const segs = bp.split("/").filter(Boolean)
         const data = await fetchBadgeData(segs, searchParams)
+        if (!data) hadError = true
         return data || { label: segs[0] || "error", value: "not found" }
       })
     )
-    return Response.json(results, { headers: CACHE_HEADERS })
+    return Response.json(results, { headers: hadError ? ERROR_CACHE_HEADERS : CACHE_HEADERS })
   }
 
   // SVG/PNG: resolve each segment
@@ -1466,6 +1515,13 @@ async function handleBadgeGroup(
       return { segs, data }
     })
   )
+
+  // If any segment fell back to "not found", treat the whole group as an
+  // error response so the failure self-heals quickly instead of being
+  // pinned at the CDN for an hour.
+  const groupCacheHeaders = allData.some(({ data }) => !data)
+    ? ERROR_CACHE_HEADERS
+    : CACHE_HEADERS
 
   // Resolve each segment with its icon
   const segments: GroupSegment[] = await Promise.all(
@@ -1601,12 +1657,12 @@ async function handleBadgeGroup(
     const resvg = new Resvg(svg)
     const png = resvg.render().asPng()
     return new Response(Buffer.from(png), {
-      headers: { "Content-Type": "image/png", ...CACHE_HEADERS },
+      headers: { "Content-Type": "image/png", ...groupCacheHeaders },
     })
   }
 
   return new Response(svg, {
-    headers: { "Content-Type": "image/svg+xml", ...CACHE_HEADERS },
+    headers: { "Content-Type": "image/svg+xml", ...groupCacheHeaders },
   })
 }
 
@@ -1640,10 +1696,10 @@ export async function handleBadgeGET(
     if (format === "svg" || format === "png" || format === "gif") {
       return new Response(
         await renderErrorBadge(cleanSegments[0] || "error", "error"),
-        { headers: { "Content-Type": "image/svg+xml", ...CACHE_HEADERS } }
+        { headers: { "Content-Type": "image/svg+xml", ...ERROR_CACHE_HEADERS } }
       )
     }
-    return Response.json({ error: "internal error" }, { status: 500 })
+    return Response.json({ error: "internal error" }, { status: 500, headers: ERROR_CACHE_HEADERS })
   }
 }
 
@@ -1661,10 +1717,10 @@ async function handleBadgeGETInner(
   if (cleanSegments.length === 0) {
     if (format === "svg") {
       return new Response(await renderErrorBadge("error", "invalid url"), {
-        headers: { "Content-Type": "image/svg+xml", ...CACHE_HEADERS },
+        headers: { "Content-Type": "image/svg+xml", ...ERROR_CACHE_HEADERS },
       })
     }
-    return Response.json({ error: "invalid url" }, { status: 400 })
+    return Response.json({ error: "invalid url" }, { status: 400, headers: ERROR_CACHE_HEADERS })
   }
 
   // ---------------------------------------------------------------------------
@@ -1702,13 +1758,13 @@ async function handleBadgeGETInner(
       return new Response(
         await renderErrorBadge(cleanSegments[0] || "error", "not found"),
         {
-          headers: { "Content-Type": "image/svg+xml", ...CACHE_HEADERS },
+          headers: { "Content-Type": "image/svg+xml", ...ERROR_CACHE_HEADERS },
         }
       )
     }
     return Response.json(
       { error: "not found" },
-      { status: 404, headers: CACHE_HEADERS }
+      { status: 404, headers: ERROR_CACHE_HEADERS }
     )
   }
 

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -106,6 +106,7 @@ import {
   getGitHubDownloadsAssetTag,
   getGitHubFollowers,
   getGitHubUserStars,
+  githubRepoExists,
 } from "./providers/github"
 import { getDiscordOnline, getDiscordByInvite } from "./providers/discord"
 import { parseStaticBadgeContent, getDynamicJsonBadge, getFlagBadge } from "./providers/badge"
@@ -327,6 +328,7 @@ async function resolveGitHubBadge(
     extra = rest.slice(3)
   }
 
+  const result: BadgeData | null = await (async (): Promise<BadgeData | null> => {
   switch (topic) {
     // Repo metadata
     case "stars":       return getGitHubStars(owner, repo)
@@ -413,6 +415,26 @@ async function resolveGitHubBadge(
 
     default: return null
   }
+  })()
+
+  if (result !== null) return result
+
+  // The topic resolver returned nothing. Definitively distinguish a genuine
+  // bad/typo'd repo from a transient upstream blip: a real 404 renders
+  // "invalid repository" (a clear, terminal state), while anything we can't
+  // confirm stays null so the caller serves last-known-good / a short-lived
+  // "not found" that self-heals.
+  const exists = await githubRepoExists(owner, repo)
+  if (exists === false) {
+    return {
+      label: "github",
+      value: "invalid repository",
+      color: "failure",
+      link: `https://github.com/${owner}/${repo}`,
+    }
+  }
+
+  return null
 }
 
 async function fetchBadgeData(

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -223,6 +223,7 @@ const ERROR_CACHE_HEADERS = {
 /** GitHub last-known-good cache tuning (see cachedFetchStale). */
 const GITHUB_FRESH_TTL = 300 // 5 min fresh copy
 const GITHUB_STALE_TTL = 60 * 60 * 24 * 7 // 7 day last-known-good fallback
+const GITHUB_ERROR_TTL = 60 // "invalid repository" verdict — short, self-healing
 
 /**
  * Parse the format from the last URL segment.
@@ -306,7 +307,7 @@ async function resolveGitHubBadge(
     "milestones", "commits", "last-commit",
     "assets-dl", "dt",
     "downloads", "downloads-all", "downloads-asset",
-    "dependents-repo", "dependents-pkg", "dependabot",
+    "dependabot",
   ])
 
   let topic: string
@@ -431,6 +432,9 @@ async function resolveGitHubBadge(
       value: "invalid repository",
       color: "failure",
       link: `https://github.com/${owner}/${repo}`,
+      // Terminal error: short-cached, never persisted as last-known-good, and
+      // served with short cache headers so it self-heals if the repo appears.
+      error: true,
     }
   }
 
@@ -515,6 +519,10 @@ async function fetchBadgeData(
         () => resolveGitHubBadge(rest, searchParams),
         GITHUB_FRESH_TTL,
         GITHUB_STALE_TTL,
+        // An "invalid repository" verdict is a terminal error, not a value:
+        // cache it briefly and never persist it as last-known-good, so a repo
+        // that later becomes available self-heals quickly.
+        { isError: (d) => d.error === true, errorTtl: GITHUB_ERROR_TTL },
       )
     }
 
@@ -1453,7 +1461,7 @@ function getDefaultLogoSlug(segments: string[]): { simpleIcon?: string; reactIco
       "license","release","contributors","ci","checks","issues","open-issues","closed-issues",
       "label-issues","prs","open-prs","closed-prs","merged-prs","milestones","commits",
       "last-commit","assets-dl","dt","downloads","downloads-all","downloads-asset",
-      "dependents-repo","dependents-pkg","dependabot"])
+      "dependabot"])
     const topic = knownTopics.has(rest[0]) ? rest[0] : rest[2]
 
     if (topic === "stars") return { reactIcon: "GoStarFill" }
@@ -1790,9 +1798,14 @@ async function handleBadgeGETInner(
     )
   }
 
+  // A terminal-error verdict (e.g. a genuine 404 → "invalid repository")
+  // renders a real badge but must not be cached like a success — short
+  // headers let it self-heal quickly instead of being pinned at the CDN.
+  const dataCacheHeaders = data.error ? ERROR_CACHE_HEADERS : CACHE_HEADERS
+
   // JSON response
   if (format === "json") {
-    return Response.json(data, { headers: CACHE_HEADERS })
+    return Response.json(data, { headers: dataCacheHeaders })
   }
 
   // Shields.io compatible JSON
@@ -1804,7 +1817,7 @@ async function handleBadgeGETInner(
         message: data.value,
         color: data.color || "blue",
       },
-      { headers: CACHE_HEADERS }
+      { headers: dataCacheHeaders }
     )
   }
 
@@ -2124,13 +2137,13 @@ async function handleBadgeGETInner(
         })
       }
       return new Response(Buffer.from(gif), {
-        headers: { "Content-Type": "image/gif", ...CACHE_HEADERS },
+        headers: { "Content-Type": "image/gif", ...dataCacheHeaders },
       })
     }
     // Animation not applicable (e.g. pulse/glow requested but no status dot).
     // Fall back to the static SVG so the badge never breaks.
     return new Response(baseSvg, {
-      headers: { "Content-Type": "image/svg+xml", ...CACHE_HEADERS },
+      headers: { "Content-Type": "image/svg+xml", ...dataCacheHeaders },
     })
   }
 
@@ -2210,7 +2223,7 @@ async function handleBadgeGETInner(
     return new Response(Buffer.from(png), {
       headers: {
         "Content-Type": "image/png",
-        ...CACHE_HEADERS,
+        ...dataCacheHeaders,
       },
     })
   }
@@ -2219,7 +2232,7 @@ async function handleBadgeGETInner(
   return new Response(svg, {
     headers: {
       "Content-Type": "image/svg+xml",
-      ...CACHE_HEADERS,
+      ...dataCacheHeaders,
     },
   })
 }

--- a/packages/engine/sentry.server.config.ts
+++ b/packages/engine/sentry.server.config.ts
@@ -9,7 +9,7 @@
 
 import * as Sentry from "@sentry/nextjs"
 import { nodeProfilingIntegration } from "@sentry/profiling-node"
-import { setCacheMetricsCallback } from "@shieldcn/core/cache"
+import { setCacheMetricsCallback, setProviderAlertCallback } from "@shieldcn/core/cache"
 
 const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN
 
@@ -31,6 +31,23 @@ if (dsn) {
     Sentry.metrics.count(metric.name, metric.value, {
       attributes: metric.tags,
       unit: "none",
+    })
+  })
+
+  // Wire provider alerts to Sentry issues so a rate limit (429) or a badge
+  // that can't be served at all surfaces as an alertable error, not just a
+  // metric counter. Stable `message` per reason keeps recurring alerts in a
+  // single issue.
+  setProviderAlertCallback((alert) => {
+    Sentry.captureMessage(alert.message, {
+      level: alert.reason === "rate_limit" ? "warning" : "error",
+      tags: {
+        area: "badge",
+        provider: alert.provider,
+        reason: alert.reason,
+        ...(alert.status ? { status: String(alert.status) } : {}),
+      },
+      extra: alert.context ?? {},
     })
   })
 }

--- a/packages/web/sentry.server.config.ts
+++ b/packages/web/sentry.server.config.ts
@@ -9,7 +9,7 @@
 
 import * as Sentry from "@sentry/nextjs"
 import { nodeProfilingIntegration } from "@sentry/profiling-node"
-import { setCacheMetricsCallback } from "@shieldcn/core/cache"
+import { setCacheMetricsCallback, setProviderAlertCallback } from "@shieldcn/core/cache"
 
 const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN
 
@@ -33,6 +33,23 @@ if (dsn) {
     Sentry.metrics.count(metric.name, metric.value, {
       attributes: metric.tags,
       unit: "none",
+    })
+  })
+
+  // Wire provider alerts to Sentry issues so a rate limit (429) or a badge
+  // that can't be served at all surfaces as an alertable error — not just a
+  // metric. `message` is stable per reason so recurring alerts group into a
+  // single issue; the variable detail rides along in tags/extra.
+  setProviderAlertCallback((alert) => {
+    Sentry.captureMessage(alert.message, {
+      level: alert.reason === "rate_limit" ? "warning" : "error",
+      tags: {
+        area: "badge",
+        provider: alert.provider,
+        reason: alert.reason,
+        ...(alert.status ? { status: String(alert.status) } : {}),
+      },
+      extra: alert.context ?? {},
     })
   })
 }


### PR DESCRIPTION
## Problem

Badges that depend on a third-party API intermittently rendered a red **"not found"** and stayed broken — the single worst outcome for user trust. Root causes:

1. **Errors were cached like successes** → a momentary blip got pinned at the CDN for an hour.
2. **No last-known-good fallback** → a failed live fetch collapsed straight to "not found".
3. **Only GitHub got hardened initially** → every *other* API provider (npm, pypi, docker, crates, discord, vscode, …) still broke on a transient blip.
4. **No observability** and **no distinction** between a transient failure and a genuinely invalid resource.

## Changes

### Resilience — now across *all* ~44 API-backed providers
A single clear fetcher contract in `cachedFetchStale`:
- **throws** → TRANSIENT (network / 429 / 5xx / parse) → serve **last-known-good**, back off, alert if nothing cached.
- **returns `null`** → DEFINITIVE negative (upstream answered; resource absent) → short-lived "not found", **never** serve stale, **never** alert (a typo'd package can't alert-storm or show someone else's value).
- **returns value** → success (cached fresh + 7-day last-known-good).

Wired through the shared path so it covers everything at once:
- `provider-fetch` (`providerFetch`/`providerFetchText`) — throw on 429/5xx, null on other non-2xx, 7-day stale window.
- `vscode` (custom POST) moved onto the same contract.
- `github` — `githubFetch` throws on transient / returns null only on definitive negatives, so its stale fallback actually triggers.
- Short-lived `ERROR_CACHE_HEADERS` on every error/"not found" response; group responses use them when any segment is unresolved.

### Observability (Sentry)
- Provider-alert channel in core (`setProviderAlertCallback` / `reportProviderAlert`), wired in web + engine to `Sentry.captureMessage`.
- **Rate limits / outages for every provider** — centralized in `recordBackoff` (the chokepoint all providers funnel through), fired once per backoff cycle.
- **Badge actually breaks** → `badge_unavailable` alert only when a transient failure has no last-known-good to serve.

### Correctness / hardening
- **GitHub 403 rate limits**: GitHub signals primary limits as `403` with `x-ratelimit-remaining: 0` (not only `429`). Detect both so a rate limit is treated as transient (backoff + stale) instead of masquerading as "not found". `handleUpstreamStatus` now backs off on any 5xx.
- A genuine GitHub **404 renders `invalid repository`** (terminal error: cached briefly, never persisted as last-known-good, short cache headers — self-heals in ~60s).
- Removed dead `dependents-repo` / `dependents-pkg` GitHub topics (registered but never implemented → would have alert-stormed).

## Tests
- `tsc --noEmit` clean on core + engine.
- Core suite: **55 passing**, including a new `provider-fetch` suite (5xx→stale, 404→null, 2xx→data) and cache-layer tests for the throw=transient / null=definitive contract, terminal-error non-persistence, and once-per-cycle rate-limit alerts.

## Notes
- `degraded_stale` (served stale on failure) stays a metric counter, not a Sentry issue — the badge still renders a value.
- Possible follow-up: token-pool health (an empty/invalid pool is what triggers the unauthenticated rate-limit cascade), and bundling the resvg WASM so PNG rendering never depends on a runtime CDN fetch.

## Commits
1. GitHub badges resilient to transient failures (error headers + last-known-good).
2. Sentry alerts on GitHub rate limits + "invalid repository" for 404s.
3. Extend provider alerts to all providers (centralized in `recordBackoff`).
4. Address review — invalid-repo caching as terminal error + remove dead topics.
5. Make all API-backed badges resilient (throw=transient / null=definitive contract) + GitHub 403 rate-limit detection.

https://claude.ai/code/session_01B5fH9ZzdStYYtWcF6QNpgw