### PR TITLE
fix(badges): harden rendering against upstream failures and bad input

### DIFF
--- a/packages/core/src/badges/render-group.tsx
+++ b/packages/core/src/badges/render-group.tsx
@@ -16,6 +16,7 @@ import { readFileSync, existsSync } from "node:fs"
 import { join, dirname } from "node:path"
 import { fileURLToPath } from "node:url"
 import type { BadgeConfig } from "./types"
+import { sanitizeBadgeText } from "./render"
 import {
   darkMode,
   lightMode,
@@ -200,8 +201,8 @@ function resolveSegment(
   const dotSize = Math.round(bz.fontSize * 0.5)
 
   return {
-    label: seg.label,
-    value: seg.value,
+    label: sanitizeBadgeText(seg.label),
+    value: sanitizeBadgeText(seg.value),
     fontFamily,
     height: bz.height,
     paddingX: bz.paddingX,

--- a/packages/core/src/badges/render.test.ts
+++ b/packages/core/src/badges/render.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest"
+import { sanitizeBadgeText } from "./render"
+
+describe("sanitizeBadgeText", () => {
+  it("passes normal text through unchanged", () => {
+    expect(sanitizeBadgeText("v19.1.0")).toBe("v19.1.0")
+    expect(sanitizeBadgeText("")).toBe("")
+  })
+
+  it("coerces non-strings so a provider bug can't paint 'undefined'", () => {
+    expect(sanitizeBadgeText(undefined)).toBe("")
+    expect(sanitizeBadgeText(null)).toBe("")
+    expect(sanitizeBadgeText(42)).toBe("42")
+    expect(sanitizeBadgeText(false)).toBe("false")
+  })
+
+  it("truncates pathologically long text", () => {
+    const long = "a".repeat(10_000)
+    const result = sanitizeBadgeText(long)
+    expect(result.length).toBe(256)
+    expect(result.endsWith("…")).toBe(true)
+  })
+})

--- a/packages/core/src/badges/render.tsx
+++ b/packages/core/src/badges/render.tsx
@@ -214,6 +214,20 @@ interface ResolvedBadge {
 // Resolve: variant × theme × overrides → ResolvedBadge
 // ---------------------------------------------------------------------------
 
+/**
+ * Hard cap on badge text length. Provider data and /badge/... path segments
+ * are user-controlled; an unbounded string would render a megabyte-wide SVG.
+ * Also coerces non-strings so a provider bug can never crash Satori or paint
+ * a literal "undefined" into the badge.
+ */
+const MAX_TEXT_LENGTH = 256
+
+export function sanitizeBadgeText(input: unknown): string {
+  if (input === null || input === undefined) return ""
+  const s = typeof input === "string" ? input : String(input)
+  return s.length > MAX_TEXT_LENGTH ? `${s.slice(0, MAX_TEXT_LENGTH - 1)}…` : s
+}
+
 function resolve(config: BadgeConfig): ResolvedBadge {
   const mode = config.mode === "light" ? lightMode : darkMode
   const bs = getButtonStyle(config.style, mode, config.brandColor)
@@ -321,8 +335,8 @@ function resolve(config: BadgeConfig): ResolvedBadge {
   }
 
   return {
-    label: config.label,
-    value: config.value,
+    label: sanitizeBadgeText(config.label),
+    value: sanitizeBadgeText(config.value),
     fontFamily,
     height,
     paddingX,
@@ -466,10 +480,14 @@ function inlineDataUriImages(svg: string): string {
       return match
     }
 
-    // Extract viewBox from inner SVG
+    // Extract viewBox from inner SVG. Guard against malformed values (a
+    // user-supplied ?logo= data URI can carry a garbage viewBox) — a NaN or
+    // zero dimension would otherwise produce scale(NaN) and a broken badge.
     const vbMatch = innerSvg.match(/viewBox="([^"]+)"/)
     const viewBox = vbMatch ? vbMatch[1].split(/\s+/).map(Number) : [0, 0, 24, 24]
-    const [, , vbWidth, vbHeight] = viewBox
+    let [, , vbWidth, vbHeight] = viewBox
+    if (!Number.isFinite(vbWidth) || vbWidth <= 0) vbWidth = 24
+    if (!Number.isFinite(vbHeight) || vbHeight <= 0) vbHeight = 24
 
     // Extract any <g transform="..."> wrapper from inner SVG (e.g. rotation)
     const gTransformMatch = innerSvg.match(/<g\s+transform="([^"]+)">/)

--- a/packages/core/src/badges/themes.test.ts
+++ b/packages/core/src/badges/themes.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest"
+import { resolveColor, applyColorOverrides, themes } from "./themes"
+
+describe("resolveColor", () => {
+  it("resolves named colors to hex", () => {
+    expect(resolveColor("brightgreen")).toBe("44cc11")
+    expect(resolveColor("red")).toBe("dc2626")
+    expect(resolveColor("BLUE")).toBe("2563eb")
+  })
+
+  it("accepts hex with or without #", () => {
+    expect(resolveColor("ff6b6b")).toBe("ff6b6b")
+    expect(resolveColor("#ff6b6b")).toBe("ff6b6b")
+    expect(resolveColor("FF6B6B")).toBe("ff6b6b")
+    expect(resolveColor("ff6b6b80")).toBe("ff6b6b80")
+  })
+
+  it("expands short hex so luminance math sees full channels", () => {
+    expect(resolveColor("fff")).toBe("ffffff")
+    expect(resolveColor("#abc")).toBe("aabbcc")
+    expect(resolveColor("abcd")).toBe("aabbccdd")
+  })
+
+  it("rejects anything invalid", () => {
+    expect(resolveColor("not-a-color")).toBeUndefined()
+    expect(resolveColor("zzz")).toBeUndefined()
+    expect(resolveColor("12345")).toBeUndefined() // 5 hex digits is not a CSS color
+    expect(resolveColor("1234567")).toBeUndefined()
+    expect(resolveColor("")).toBeUndefined()
+    expect(resolveColor(undefined)).toBeUndefined()
+    expect(resolveColor(null)).toBeUndefined()
+    expect(resolveColor('"><script>')).toBeUndefined()
+  })
+})
+
+describe("applyColorOverrides", () => {
+  const base = themes.zinc
+
+  it("applies a valid color override", () => {
+    const result = applyColorOverrides(base, { color: "ff6b6b" })
+    expect(result.labelBg).toBe("#ff6b6b")
+    expect(result.valueBg).toBe("#ff6b6b")
+  })
+
+  it("resolves named color overrides", () => {
+    const result = applyColorOverrides(base, { color: "brightgreen" })
+    expect(result.labelBg).toBe("#44cc11")
+  })
+
+  it("drops invalid overrides instead of passing garbage to the renderer", () => {
+    const result = applyColorOverrides(base, { color: "not-a-color", labelColor: "zzz" })
+    expect(result).toEqual(base)
+  })
+
+  it("picks dark text on light backgrounds", () => {
+    const result = applyColorOverrides(base, { color: "ffffff" })
+    expect(result.valueFg).toBe("#18181b")
+  })
+})

--- a/packages/core/src/badges/themes.ts
+++ b/packages/core/src/badges/themes.ts
@@ -160,6 +160,57 @@ export const themes: Record<ThemeName, ResolvedColors> = {
 /** Default theme. */
 export const DEFAULT_THEME: ThemeName = "zinc"
 
+// ---------------------------------------------------------------------------
+// User-supplied color validation
+// ---------------------------------------------------------------------------
+
+/** Named color map (subset matching shields.io / badge-maker). */
+export const NAMED_COLORS: Record<string, string> = {
+  brightgreen: "44cc11",
+  green: "16a34a",
+  yellow: "d97706",
+  yellowgreen: "a3e635",
+  orange: "ea580c",
+  red: "dc2626",
+  blue: "2563eb",
+  grey: "6b7280",
+  gray: "6b7280",
+  lightgrey: "9ca3af",
+  lightgray: "9ca3af",
+  critical: "dc2626",
+  important: "ea580c",
+  success: "16a34a",
+  informational: "2563eb",
+  inactive: "9ca3af",
+  // CSS named colors (common subset)
+  black: "000000",
+  white: "ffffff",
+  purple: "9333ea",
+  violet: "7c3aed",
+  pink: "ec4899",
+  cyan: "0891b2",
+  teal: "0d9488",
+  lime: "84cc16",
+  indigo: "6366f1",
+}
+
+/**
+ * Resolve a user-supplied color string to a normalized hex value (without #).
+ * Accepts named colors and 3/4/6/8-digit hex (with or without #). Short hex
+ * is expanded (abc → aabbcc) so downstream luminance math sees full channels.
+ * Returns undefined for anything invalid — callers must drop the override
+ * rather than pass garbage into the renderer.
+ */
+export function resolveColor(color: string | undefined | null): string | undefined {
+  if (!color) return undefined
+  const lower = color.toLowerCase().trim()
+  if (NAMED_COLORS[lower]) return NAMED_COLORS[lower]
+  const hex = lower.replace(/^#/, "")
+  if (!/^([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/.test(hex)) return undefined
+  if (hex.length <= 4) return hex.split("").map(c => c + c).join("")
+  return hex
+}
+
 /**
  * Resolve a theme name to hex colors.
  * Falls back to the default theme for unknown names.
@@ -197,16 +248,20 @@ export function applyColorOverrides(
   overrides: { color?: string; labelColor?: string }
 ): ResolvedColors {
   const result = { ...colors }
-  if (overrides.color) {
-    const hex = `#${overrides.color}`
+  // Validate before use — an unvalidated ?color= would flow straight into
+  // the SVG and break the render for anything that isn't a clean hex value.
+  const color = resolveColor(overrides.color)
+  if (color) {
+    const hex = `#${color}`
     const textColor = isLightColor(hex) ? "#18181b" : "#ffffff"
     result.labelBg = hex
     result.valueBg = hex
     result.valueFg = textColor
     result.labelFg = textColor
   }
-  if (overrides.labelColor) {
-    const hex = `#${overrides.labelColor}`
+  const labelColor = resolveColor(overrides.labelColor)
+  if (labelColor) {
+    const hex = `#${labelColor}`
     const textColor = isLightColor(hex) ? "#18181b" : "#ffffff"
     result.labelBg = hex
     result.labelFg = textColor

--- a/packages/core/src/badges/twemoji.ts
+++ b/packages/core/src/badges/twemoji.ts
@@ -15,6 +15,7 @@
  */
 
 import { cacheGet, cacheSet } from "../cache"
+import { raceTimeout } from "../provider-fetch"
 
 // Pinned release of jdecked/twemoji. Bump deliberately; @latest would risk a
 // silent upstream change breaking cached codepoint → asset mappings.
@@ -104,9 +105,10 @@ export async function resolveTwemojiSvg(logo: string): Promise<string | null> {
   if (cached !== undefined) return cached || null
 
   try {
-    const res = await fetch(`${TWEMOJI_BASE}/${codepoint}.svg`, {
+    const res = await raceTimeout(fetch(`${TWEMOJI_BASE}/${codepoint}.svg`, {
       headers: { Accept: "image/svg+xml", "User-Agent": "shieldcn/1.0" },
-    })
+    }))
+    if (!res) return null
     if (!res.ok) {
       // Cache the miss briefly so a bad emoji doesn't hammer the CDN.
       await cacheSet(cacheKeyId, "", 60 * 10)

--- a/packages/core/src/provider-fetch.ts
+++ b/packages/core/src/provider-fetch.ts
@@ -12,6 +12,25 @@
 
 import { cachedFetch, handleUpstreamStatus } from "./cache"
 
+/**
+ * Hard cap on upstream latency. A hung upstream must fail fast so the badge
+ * route can fall back instead of hanging until the platform kills the request
+ * (README image proxies time out and show a broken image). Implemented as a
+ * race rather than an AbortSignal so the `next: { revalidate }` fetch cache
+ * behavior is untouched.
+ */
+export const UPSTREAM_TIMEOUT_MS = 8_000
+
+/** Resolve to `null` if `promise` takes longer than `ms`. */
+export function raceTimeout<T>(promise: Promise<T>, ms: number = UPSTREAM_TIMEOUT_MS): Promise<T | null> {
+  // Swallow the late rejection if the timeout wins the race.
+  promise.catch(() => {})
+  return Promise.race([
+    promise,
+    new Promise<null>(resolve => setTimeout(() => resolve(null), ms)),
+  ])
+}
+
 interface ProviderFetchOptions {
   /** Provider name (e.g. "npm", "discord"). Used for backoff + budgets. */
   provider: string
@@ -40,19 +59,25 @@ export async function providerFetch<T = Record<string, unknown>>(
     provider,
     cacheKey,
     async () => {
-      const response = await fetch(url, {
+      const response = await raceTimeout(fetch(url, {
         headers: {
           Accept: "application/json",
           "User-Agent": "shieldcn/1.0",
           ...headers,
         },
         next: { revalidate: revalidate ?? ttl },
-      })
+      }))
+      if (!response) return null
 
       handleUpstreamStatus(provider, response.status)
 
       if (!response.ok) return null
-      return response.json() as Promise<T>
+      try {
+        return await (response.json() as Promise<T>)
+      } catch {
+        // Truncated / malformed body — treat as a transient failure.
+        return null
+      }
     },
     ttl,
   )
@@ -71,18 +96,23 @@ export async function providerFetchText(
     provider,
     cacheKey,
     async () => {
-      const response = await fetch(url, {
+      const response = await raceTimeout(fetch(url, {
         headers: {
           "User-Agent": "shieldcn/1.0",
           ...headers,
         },
         next: { revalidate: revalidate ?? ttl },
-      })
+      }))
+      if (!response) return null
 
       handleUpstreamStatus(provider, response.status)
 
       if (!response.ok) return null
-      return response.text()
+      try {
+        return await response.text()
+      } catch {
+        return null
+      }
     },
     ttl,
   )

--- a/packages/core/src/providers/badge.ts
+++ b/packages/core/src/providers/badge.ts
@@ -13,6 +13,8 @@
 
 import type { BadgeData } from "../badges/types"
 import { JSONPath } from "jsonpath-plus"
+import { resolveColor } from "../badges/themes"
+import { raceTimeout } from "../provider-fetch"
 import flagNames from "../badges/flags.json"
 
 // Country flags come from `country-flag-icons` (catamphetamine), 3x2 aspect.
@@ -59,54 +61,6 @@ export async function getFlagBadge(code: string): Promise<BadgeData | null> {
     value: name,
     link: `${FLAG_CDN_BASE}/${cdnCode}.svg`,
   }
-}
-
-// ---------------------------------------------------------------------------
-// Named color map (subset matching shields.io / badge-maker)
-// ---------------------------------------------------------------------------
-
-const NAMED_COLORS: Record<string, string> = {
-  brightgreen: "44cc11",
-  green: "16a34a",
-  yellow: "d97706",
-  yellowgreen: "a3e635",
-  orange: "ea580c",
-  red: "dc2626",
-  blue: "2563eb",
-  grey: "6b7280",
-  gray: "6b7280",
-  lightgrey: "9ca3af",
-  lightgray: "9ca3af",
-  critical: "dc2626",
-  important: "ea580c",
-  success: "16a34a",
-  informational: "2563eb",
-  inactive: "9ca3af",
-  // CSS named colors (common subset)
-  black: "000000",
-  white: "ffffff",
-  purple: "9333ea",
-  violet: "7c3aed",
-  pink: "ec4899",
-  cyan: "0891b2",
-  teal: "0d9488",
-  lime: "84cc16",
-  indigo: "6366f1",
-}
-
-/**
- * Resolve a color string to a hex value (without #).
- * Accepts: named colors, hex (with or without #), or returns undefined.
- */
-function resolveColor(color: string | undefined): string | undefined {
-  if (!color) return undefined
-  const lower = color.toLowerCase()
-  if (NAMED_COLORS[lower]) return NAMED_COLORS[lower]
-  // Strip leading # if present
-  const hex = lower.replace(/^#/, "")
-  // Validate hex: 3, 4, 6, or 8 hex chars
-  if (/^[0-9a-f]{3,8}$/i.test(hex)) return hex
-  return undefined
 }
 
 // ---------------------------------------------------------------------------
@@ -211,19 +165,31 @@ export async function getDynamicJsonBadge(
   if (!jsonUrl || !query) return null
 
   try {
-    const response = await fetch(jsonUrl, {
+    const response = await raceTimeout(fetch(jsonUrl, {
       next: { revalidate: 300 },
       headers: {
         Accept: "application/json",
         "User-Agent": "shieldcn/1.0",
       },
-    })
+    }))
+    if (!response) {
+      return {
+        label: searchParams.get("label") || "error",
+        value: "timeout",
+        color: "red",
+        // Failure verdicts are still informative badges, but they must carry
+        // short error cache headers so they self-heal instead of being pinned
+        // at the CDN for an hour like a success.
+        error: true,
+      }
+    }
 
     if (!response.ok) {
       return {
         label: searchParams.get("label") || "error",
         value: `${response.status}`,
         color: "red",
+        error: true,
       }
     }
 
@@ -235,10 +201,12 @@ export async function getDynamicJsonBadge(
         label: searchParams.get("label") || "custom",
         value: "not found",
         color: "red",
+        error: true,
       }
     }
 
-    let value = String(results[0])
+    const first = results[0]
+    let value = typeof first === "object" && first !== null ? JSON.stringify(first) : String(first)
     const prefix = searchParams.get("prefix") || ""
     const suffix = searchParams.get("suffix") || ""
     value = `${prefix}${value}${suffix}`
@@ -252,6 +220,7 @@ export async function getDynamicJsonBadge(
       label: searchParams.get("label") || "error",
       value: "fetch failed",
       color: "red",
+      error: true,
     }
   }
 }

--- a/packages/core/src/providers/chocolatey.ts
+++ b/packages/core/src/providers/chocolatey.ts
@@ -56,9 +56,12 @@ export async function getChocolateyDownloads(pkg: string): Promise<BadgeData | n
   const downloads = extractXmlValue(xml, "DownloadCount")
   if (!downloads) return null
 
+  const count = parseInt(downloads, 10)
+  if (!Number.isFinite(count)) return null
+
   return {
     label: "downloads",
-    value: formatCount(parseInt(downloads)),
+    value: formatCount(count),
     link: `https://community.chocolatey.org/packages/${pkg}`,
   }
 }

--- a/packages/core/src/providers/cocoapods.ts
+++ b/packages/core/src/providers/cocoapods.ts
@@ -42,24 +42,12 @@ export async function getCocoaPodsVersion(pod: string): Promise<BadgeData | null
 // ---------------------------------------------------------------------------
 
 export async function getCocoaPodsLicense(pod: string): Promise<BadgeData | null> {
+  // The trunk API doesn't expose license info; just confirm the pod exists
+  // and point at its page. (A previous version also fetched the CDN spec
+  // index here, but every branch returned the same badge — dead weight and a
+  // hang risk for zero signal.)
   const data = await podFetch(pod)
   if (!data) return null
-
-  // Fetch the spec for license info
-  try {
-    const r = await fetch(
-      `https://cdn.cocoapods.org/all_pods_versions_${pod.charAt(0).toLowerCase()}_${pod.charAt(1).toLowerCase()}_${pod.charAt(2).toLowerCase()}.txt`,
-      { next: { revalidate: 86400 } }
-    )
-    // Fallback: just return the pod page
-    if (!r.ok) {
-      return {
-        label: "license",
-        value: "see pod",
-        link: `https://cocoapods.org/pods/${pod}`,
-      }
-    }
-  } catch { /* ignore */ }
 
   return {
     label: "license",

--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -13,35 +13,61 @@ import type { BadgeData } from "../badges/types"
 import { formatCount } from "../format"
 import { pickToken, invalidateToken } from "../token-pool"
 import { isBackedOff, recordBackoff, clearBackoff } from "../cache"
+import { raceTimeout } from "../provider-fetch"
 
 // ---------------------------------------------------------------------------
 // Fetch helper
 // ---------------------------------------------------------------------------
+
+/**
+ * True when a response is a rate limit. GitHub signals primary and secondary
+ * rate limits as 403 (with an exhausted quota header or a Retry-After), not
+ * just 429 — a plain 403 (e.g. a blocked repo) is NOT a rate limit.
+ */
+function isRateLimitResponse(response: Response): boolean {
+  if (response.status === 429) return true
+  return (
+    response.status === 403 &&
+    (response.headers.get("x-ratelimit-remaining") === "0" ||
+      response.headers.get("retry-after") !== null)
+  )
+}
 
 async function githubFetch(url: string, revalidate: number = 3600): Promise<Response | null> {
   if (isBackedOff("github")) return null
 
   try {
     const token = await pickToken()
-    const headers: HeadersInit = {
-      Accept: "application/vnd.github.v3+json",
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    }
-    const response = await fetch(url, { headers, next: { revalidate } })
+    const doFetch = (auth?: string) =>
+      raceTimeout(
+        fetch(url, {
+          headers: {
+            Accept: "application/vnd.github.v3+json",
+            ...(auth ? { Authorization: `Bearer ${auth}` } : {}),
+          },
+          next: { revalidate },
+        }),
+      )
 
-    // Track rate limits — recordBackoff also surfaces the Sentry alert.
-    if (response.status === 429 || response.status === 503) {
+    let response = await doFetch(token)
+    if (!response) return null
+
+    // A 401 means the pooled token was revoked — drop it from the pool and
+    // retry once unauthenticated. The retry goes through the same status
+    // checks below; it must never be returned unvetted.
+    if (response.status === 401 && token) {
+      await invalidateToken(token)
+      response = await doFetch()
+      if (!response) return null
+    }
+
+    // Track rate limits (429, or 403 with exhausted quota) and outages —
+    // recordBackoff also surfaces the Sentry alert.
+    if (isRateLimitResponse(response) || response.status === 503) {
       recordBackoff("github", response.status)
       return null
     }
 
-    if (response.status === 401 && token) {
-      await invalidateToken(token)
-      return fetch(url, {
-        headers: { Accept: "application/vnd.github.v3+json" },
-        next: { revalidate },
-      })
-    }
     if (!response.ok) return null
     clearBackoff("github")
     return response
@@ -53,18 +79,24 @@ async function githubFetch(url: string, revalidate: number = 3600): Promise<Resp
 async function githubJson(url: string, revalidate?: number): Promise<Record<string, unknown> | null> {
   const r = await githubFetch(url, revalidate)
   if (!r) return null
-  return r.json()
+  try {
+    return await r.json()
+  } catch {
+    // Truncated / malformed body — treat as a transient failure.
+    return null
+  }
 }
 
 function link(owner: string, repo: string, path = ""): string {
   return `https://github.com/${owner}/${repo}${path}`
 }
 
-function relDate(iso: string): string {
+function relDate(iso: string): string | null {
   const d = new Date(iso)
+  if (isNaN(d.getTime())) return null
   const now = new Date()
   const days = Math.floor((now.getTime() - d.getTime()) / 86_400_000)
-  if (days === 0) return "today"
+  if (days <= 0) return "today"
   if (days === 1) return "yesterday"
   if (days < 30) return `${days}d ago`
   const months = Math.floor(days / 30)
@@ -110,19 +142,32 @@ async function resolveRepo(owner: string, repo: string): Promise<{ owner: string
  * costs an extra call only when a badge would otherwise have failed.
  */
 export async function githubRepoExists(owner: string, repo: string): Promise<boolean | null> {
+  return githubHeadExists(`https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`)
+}
+
+/**
+ * HEAD-probe a GitHub API URL and definitively classify it:
+ * `true` (2xx), `false` (404), or `null` for anything we can't be sure about
+ * (rate limit, backoff, network, other status) — callers must treat `null`
+ * as transient, never as "does not exist".
+ */
+async function githubHeadExists(url: string): Promise<boolean | null> {
   if (isBackedOff("github")) return null
   try {
     const token = await pickToken()
-    const response = await fetch(`https://api.github.com/repos/${owner}/${repo}`, {
-      method: "HEAD",
-      headers: {
-        Accept: "application/vnd.github.v3+json",
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
-      next: { revalidate: 3600 },
-    })
+    const response = await raceTimeout(
+      fetch(url, {
+        method: "HEAD",
+        headers: {
+          Accept: "application/vnd.github.v3+json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        next: { revalidate: 3600 },
+      }),
+    )
+    if (!response) return null
     if (response.status === 404) return false
-    if (response.status === 429 || response.status === 503) {
+    if (isRateLimitResponse(response) || response.status === 503) {
       recordBackoff("github", response.status)
       return null
     }
@@ -171,13 +216,19 @@ export async function getGitHubLicense(owner: string, repo: string): Promise<Bad
 // ---------------------------------------------------------------------------
 
 async function countPages(url: string): Promise<number | null> {
-  // GitHub returns Link header with last page for paginated endpoints
-  const r = await githubFetch(`${url}?per_page=1`)
+  // GitHub returns Link header with last page for paginated endpoints.
+  // The URL may already carry a query string (e.g. commits?sha=branch).
+  const sep = url.includes("?") ? "&" : "?"
+  const r = await githubFetch(`${url}${sep}per_page=1`)
   if (!r) return null
   const linkHeader = r.headers.get("link")
   if (!linkHeader) {
-    const data = await r.json()
-    return Array.isArray(data) ? data.length : 0
+    try {
+      const data = await r.json()
+      return Array.isArray(data) ? data.length : 0
+    } catch {
+      return null
+    }
   }
   const match = linkHeader.match(/page=(\d+)>;\s*rel="last"/)
   return match ? parseInt(match[1]) : 1
@@ -204,6 +255,7 @@ export async function getGitHubTags(owner: string, repo: string): Promise<BadgeD
 export async function getGitHubLatestTag(owner: string, repo: string): Promise<BadgeData | null> {
   const d = await githubJson(`https://api.github.com/repos/${owner}/${repo}/tags?per_page=1`)
   if (!d || !Array.isArray(d) || d.length === 0) return null
+  if (typeof d[0]?.name !== "string") return null
   return { label: "tag", value: d[0].name, link: link(owner, repo, "/tags") }
 }
 
@@ -217,8 +269,8 @@ export async function getGitHubRelease(owner: string, repo: string, channel?: st
     const d = await githubJson(`https://api.github.com/repos/${owner}/${repo}/releases?per_page=20`)
     if (!d || !Array.isArray(d)) return null
     const stable = d.find((r: Record<string, unknown>) => !r.prerelease && !r.draft)
-    if (!stable) return null
-    return { label: "release", value: stable.tag_name as string, color: "blue", link: stable.html_url as string }
+    if (!stable || typeof stable.tag_name !== "string") return null
+    return { label: "release", value: stable.tag_name, color: "blue", link: typeof stable.html_url === "string" ? stable.html_url : link(owner, repo, "/releases") }
   }
   const d = await githubJson(`https://api.github.com/repos/${owner}/${repo}/releases/latest`)
   if (!d || typeof d.tag_name !== "string") return null
@@ -375,13 +427,13 @@ export async function getGitHubPRs(owner: string, repo: string, filter: string):
 export async function getGitHubMilestone(
   owner: string, repo: string, milestoneNumber: string
 ): Promise<BadgeData | null> {
-  const d = await githubJson(`https://api.github.com/repos/${owner}/${repo}/milestones/${milestoneNumber}`)
-  if (!d) return null
-  const open = d.open_issues as number
-  const closed = d.closed_issues as number
+  const d = await githubJson(`https://api.github.com/repos/${owner}/${repo}/milestones/${encodeURIComponent(milestoneNumber)}`)
+  if (!d || typeof d.title !== "string" || typeof d.open_issues !== "number" || typeof d.closed_issues !== "number") return null
+  const open = d.open_issues
+  const closed = d.closed_issues
   const total = open + closed
   const pct = total > 0 ? Math.round((closed / total) * 100) : 0
-  return { label: d.title as string, value: `${pct}%`, link: link(owner, repo, `/milestone/${milestoneNumber}`) }
+  return { label: d.title, value: `${pct}%`, link: link(owner, repo, `/milestone/${milestoneNumber}`) }
 }
 
 // ---------------------------------------------------------------------------
@@ -396,12 +448,15 @@ export async function getGitHubCommits(owner: string, repo: string, ref?: string
 }
 
 export async function getGitHubLastCommit(owner: string, repo: string, ref?: string): Promise<BadgeData | null> {
-  const branch = ref ? `?sha=${encodeURIComponent(ref)}` : ""
-  const d = await githubJson(`https://api.github.com/repos/${owner}/${repo}/commits${branch}&per_page=1`.replace("&", "?").replace("??", "?"), 600)
+  const params = new URLSearchParams({ per_page: "1" })
+  if (ref) params.set("sha", ref)
+  const d = await githubJson(`https://api.github.com/repos/${owner}/${repo}/commits?${params}`, 600)
   if (!d || !Array.isArray(d) || d.length === 0) return null
   const date = d[0].commit?.author?.date || d[0].commit?.committer?.date
-  if (!date) return null
-  return { label: "last commit", value: relDate(date), link: link(owner, repo, `/commits${ref ? `/${ref}` : ""}`) }
+  if (typeof date !== "string") return null
+  const rel = relDate(date)
+  if (rel === null) return null
+  return { label: "last commit", value: rel, link: link(owner, repo, `/commits${ref ? `/${ref}` : ""}`) }
 }
 
 // ---------------------------------------------------------------------------
@@ -414,9 +469,9 @@ export async function getGitHubAssetsDl(owner: string, repo: string, tag?: strin
     : `https://api.github.com/repos/${owner}/${repo}/releases/latest`
   const d = await githubJson(url)
   if (!d) return null
-  const assets = d.assets as Record<string, unknown>[]
-  if (!assets) return null
-  const total = assets.reduce((sum: number, a) => sum + ((a.download_count as number) || 0), 0)
+  const assets = d.assets
+  if (!Array.isArray(assets)) return null
+  const total = assets.reduce((sum: number, a) => sum + (typeof a.download_count === "number" ? a.download_count : 0), 0)
   return { label: "downloads", value: formatCount(total), link: link(owner, repo, "/releases") }
 }
 
@@ -432,12 +487,16 @@ export async function getGitHubDownloadsAllAssetsAllReleases(owner: string, repo
   while (true) {
     const url = `https://api.github.com/repos/${owner}/${repo}/releases?per_page=${perPage}&page=${page}`
     const d = await githubJson(url)
-    if (!d || !Array.isArray(d) || d.length === 0) break
+    // A failed page (rate limit, backoff, network) must fail the whole badge:
+    // a partial sum — or a flat 0 — would otherwise be persisted as
+    // last-known-good for days, clobbering the real count.
+    if (!d || !Array.isArray(d)) return null
+    if (d.length === 0) break
     for (const release of d) {
       const assets = release.assets as Record<string, unknown>[] | undefined
       if (assets) {
         for (const a of assets) {
-          total += (a.download_count as number) || 0
+          total += typeof a.download_count === "number" ? a.download_count : 0
         }
       }
     }
@@ -455,8 +514,8 @@ export async function getGitHubDownloadsAllAssetsAllReleases(owner: string, repo
 export async function getGitHubDownloadsAllAssetsLatest(owner: string, repo: string): Promise<BadgeData | null> {
   const d = await githubJson(`https://api.github.com/repos/${owner}/${repo}/releases/latest`)
   if (!d) return null
-  const assets = d.assets as Record<string, unknown>[] | undefined
-  if (!assets) return null
+  const assets = d.assets
+  if (!Array.isArray(assets)) return null
   const total = assets.reduce((sum: number, a) => sum + ((a.download_count as number) || 0), 0)
   const tag = d.tag_name as string | undefined
   return { label: `downloads@${tag ?? "latest"}`, value: formatCount(total), link: link(owner, repo, "/releases/latest") }
@@ -469,8 +528,8 @@ export async function getGitHubDownloadsAllAssetsLatest(owner: string, repo: str
 export async function getGitHubDownloadsAllAssetsTag(owner: string, repo: string, tag: string): Promise<BadgeData | null> {
   const d = await githubJson(`https://api.github.com/repos/${owner}/${repo}/releases/tags/${encodeURIComponent(tag)}`)
   if (!d) return null
-  const assets = d.assets as Record<string, unknown>[] | undefined
-  if (!assets) return null
+  const assets = d.assets
+  if (!Array.isArray(assets)) return null
   const total = assets.reduce((sum: number, a) => sum + ((a.download_count as number) || 0), 0)
   return { label: `downloads@${tag}`, value: formatCount(total), link: link(owner, repo, `/releases/tag/${tag}`) }
 }
@@ -486,13 +545,16 @@ export async function getGitHubDownloadsAssetAllReleases(owner: string, repo: st
   while (true) {
     const url = `https://api.github.com/repos/${owner}/${repo}/releases?per_page=${perPage}&page=${page}`
     const d = await githubJson(url)
-    if (!d || !Array.isArray(d) || d.length === 0) break
+    // A failed page must fail the whole badge — see
+    // getGitHubDownloadsAllAssetsAllReleases for why.
+    if (!d || !Array.isArray(d)) return null
+    if (d.length === 0) break
     for (const release of d) {
       const assets = release.assets as Record<string, unknown>[] | undefined
       if (assets) {
         for (const a of assets) {
           if ((a.name as string) === assetName) {
-            total += (a.download_count as number) || 0
+            total += typeof a.download_count === "number" ? a.download_count : 0
           }
         }
       }
@@ -511,8 +573,8 @@ export async function getGitHubDownloadsAssetAllReleases(owner: string, repo: st
 export async function getGitHubDownloadsAssetLatest(owner: string, repo: string, assetName: string): Promise<BadgeData | null> {
   const d = await githubJson(`https://api.github.com/repos/${owner}/${repo}/releases/latest`)
   if (!d) return null
-  const assets = d.assets as Record<string, unknown>[] | undefined
-  if (!assets) return null
+  const assets = d.assets
+  if (!Array.isArray(assets)) return null
   const asset = assets.find(a => (a.name as string) === assetName)
   if (!asset) return { label: `downloads [${assetName}]`, value: "0", link: link(owner, repo, "/releases/latest") }
   const count = (asset.download_count as number) || 0
@@ -527,8 +589,8 @@ export async function getGitHubDownloadsAssetLatest(owner: string, repo: string,
 export async function getGitHubDownloadsAssetTag(owner: string, repo: string, tag: string, assetName: string): Promise<BadgeData | null> {
   const d = await githubJson(`https://api.github.com/repos/${owner}/${repo}/releases/tags/${encodeURIComponent(tag)}`)
   if (!d) return null
-  const assets = d.assets as Record<string, unknown>[] | undefined
-  if (!assets) return null
+  const assets = d.assets
+  if (!Array.isArray(assets)) return null
   const asset = assets.find(a => (a.name as string) === assetName)
   if (!asset) return { label: `downloads@${tag} [${assetName}]`, value: "0", link: link(owner, repo, `/releases/tag/${tag}`) }
   const count = (asset.download_count as number) || 0
@@ -540,14 +602,20 @@ export async function getGitHubDownloadsAssetTag(owner: string, repo: string, ta
 // ---------------------------------------------------------------------------
 
 export async function getGitHubDependabot(owner: string, repo: string): Promise<BadgeData | null> {
-  // Check if dependabot.yml exists
-  const r = await githubFetch(`https://api.github.com/repos/${owner}/${repo}/contents/.github/dependabot.yml`)
-  if (r) return { label: "dependabot", value: "enabled", color: "success" }
+  // Check if dependabot.yml exists. A definitive 404 on both spellings means
+  // "not configured"; anything indeterminate (rate limit, backoff, network)
+  // must return null so the route serves last-known-good instead of flipping
+  // a configured repo to "not found" during an outage.
+  const yml = await githubHeadExists(`https://api.github.com/repos/${owner}/${repo}/contents/.github/dependabot.yml`)
+  if (yml === true) return { label: "dependabot", value: "enabled", color: "success" }
 
-  const r2 = await githubFetch(`https://api.github.com/repos/${owner}/${repo}/contents/.github/dependabot.yaml`)
-  if (r2) return { label: "dependabot", value: "enabled", color: "success" }
+  const yaml = await githubHeadExists(`https://api.github.com/repos/${owner}/${repo}/contents/.github/dependabot.yaml`)
+  if (yaml === true) return { label: "dependabot", value: "enabled", color: "success" }
 
-  return { label: "dependabot", value: "not found", color: "cancelled" }
+  if (yml === false && yaml === false) {
+    return { label: "dependabot", value: "not found", color: "cancelled" }
+  }
+  return null
 }
 
 // ---------------------------------------------------------------------------
@@ -570,7 +638,12 @@ export async function getGitHubUserStars(username: string): Promise<BadgeData | 
     `https://api.github.com/users/${username}/repos?per_page=100&sort=stars&type=owner`,
   )
   if (!repos) return null
-  const list = await repos.json() as Array<{ stargazers_count: number; fork: boolean }>
+  let list: Array<{ stargazers_count: number; fork: boolean }>
+  try {
+    list = await repos.json()
+  } catch {
+    return null
+  }
   if (!Array.isArray(list)) return null
   const total = list.reduce(
     (sum, r) => sum + (r.fork ? 0 : (r.stargazers_count ?? 0)),

--- a/packages/core/src/providers/gitlab.ts
+++ b/packages/core/src/providers/gitlab.ts
@@ -120,18 +120,20 @@ export async function getGitLabMergeRequests(owner: string, repo: string, state:
 // ---------------------------------------------------------------------------
 
 export async function getGitLabPipeline(owner: string, repo: string, branch?: string): Promise<BadgeData | null> {
-  const branchParam = branch ? `?ref=${encodeURIComponent(branch)}` : ""
+  const params = new URLSearchParams({ per_page: "1", order_by: "id", sort: "desc" })
+  if (branch) params.set("ref", branch)
   const data = await providerFetch<unknown[]>({
     provider: "gitlab",
     cacheKey: `pipeline:${owner}/${repo}:${branch ?? "default"}`,
-    url: `https://gitlab.com/api/v4/projects/${encodeProject(owner, repo)}/pipelines${branchParam}&per_page=1&order_by=id&sort=desc`,
+    url: `https://gitlab.com/api/v4/projects/${encodeProject(owner, repo)}/pipelines?${params}`,
     ttl: 300,
   })
   if (!data || !Array.isArray(data) || data.length === 0) return null
 
   const pipeline = data[0] as Record<string, unknown>
-  const status = pipeline.status as string
-  const ref = pipeline.ref as string
+  const status = pipeline.status
+  if (typeof status !== "string") return null
+  const ref = typeof pipeline.ref === "string" ? pipeline.ref : undefined
 
   const statusMap: Record<string, string> = {
     success: "passing",

--- a/packages/core/src/providers/liberapay.ts
+++ b/packages/core/src/providers/liberapay.ts
@@ -78,7 +78,8 @@ export async function getLiberapayGoal(username: string): Promise<BadgeData | nu
   const receiving = data.receiving as Record<string, string> | undefined
   const receivingAmount = receiving?.amount ? parseFloat(receiving.amount) : 0
   const goalAmount = amount ? parseFloat(amount) : 0
-  const pct = goalAmount > 0 ? Math.round((receivingAmount / goalAmount) * 100) : 0
+  const rawPct = goalAmount > 0 ? Math.round((receivingAmount / goalAmount) * 100) : 0
+  const pct = Number.isFinite(rawPct) ? rawPct : 0
 
   return {
     label: "goal",

--- a/packages/core/src/providers/sonar.ts
+++ b/packages/core/src/providers/sonar.ts
@@ -29,9 +29,17 @@ async function sonarFetch(
 function getMeasureValue(data: Record<string, unknown>, metric: string): string | undefined {
   const component = data.component as Record<string, unknown> | undefined
   const measures = component?.measures as Array<Record<string, string>> | undefined
-  if (!measures) return undefined
+  if (!Array.isArray(measures)) return undefined
   const m = measures.find(m => m.metric === metric)
   return m?.value
+}
+
+/** Parse a measure value as a number; undefined (never NaN) when not numeric. */
+function getMeasureNumber(data: Record<string, unknown>, metric: string): number | undefined {
+  const value = getMeasureValue(data, metric)
+  if (value === undefined) return undefined
+  const n = parseFloat(value)
+  return Number.isFinite(n) ? n : undefined
 }
 
 function ratingToLetter(value: string): string {
@@ -75,12 +83,12 @@ export async function getSonarQualityGate(component: string, server?: string): P
 export async function getSonarBugs(component: string, server?: string): Promise<BadgeData | null> {
   const data = await sonarFetch(component, "bugs", server)
   if (!data) return null
-  const value = getMeasureValue(data, "bugs")
+  const value = getMeasureNumber(data, "bugs")
   if (value === undefined) return null
 
   return {
     label: "bugs",
-    value: formatCount(parseInt(value)),
+    value: formatCount(value),
     link: `https://${server ?? "sonarcloud.io"}/project/issues?id=${component}&resolved=false&types=BUG`,
   }
 }
@@ -92,12 +100,12 @@ export async function getSonarBugs(component: string, server?: string): Promise<
 export async function getSonarVulnerabilities(component: string, server?: string): Promise<BadgeData | null> {
   const data = await sonarFetch(component, "vulnerabilities", server)
   if (!data) return null
-  const value = getMeasureValue(data, "vulnerabilities")
+  const value = getMeasureNumber(data, "vulnerabilities")
   if (value === undefined) return null
 
   return {
     label: "vulnerabilities",
-    value: formatCount(parseInt(value)),
+    value: formatCount(value),
     link: `https://${server ?? "sonarcloud.io"}/project/issues?id=${component}&resolved=false&types=VULNERABILITY`,
   }
 }
@@ -109,12 +117,12 @@ export async function getSonarVulnerabilities(component: string, server?: string
 export async function getSonarCodeSmells(component: string, server?: string): Promise<BadgeData | null> {
   const data = await sonarFetch(component, "code_smells", server)
   if (!data) return null
-  const value = getMeasureValue(data, "code_smells")
+  const value = getMeasureNumber(data, "code_smells")
   if (value === undefined) return null
 
   return {
     label: "code smells",
-    value: formatCount(parseInt(value)),
+    value: formatCount(value),
     link: `https://${server ?? "sonarcloud.io"}/project/issues?id=${component}&resolved=false&types=CODE_SMELL`,
   }
 }
@@ -126,10 +134,9 @@ export async function getSonarCodeSmells(component: string, server?: string): Pr
 export async function getSonarCoverage(component: string, server?: string): Promise<BadgeData | null> {
   const data = await sonarFetch(component, "coverage", server)
   if (!data) return null
-  const value = getMeasureValue(data, "coverage")
-  if (value === undefined) return null
+  const pct = getMeasureNumber(data, "coverage")
+  if (pct === undefined) return null
 
-  const pct = parseFloat(value)
   let color: string | undefined
   if (pct >= 80) color = "green"
   else if (pct >= 60) color = "yellow"
@@ -151,12 +158,12 @@ export async function getSonarCoverage(component: string, server?: string): Prom
 export async function getSonarDuplicatedLines(component: string, server?: string): Promise<BadgeData | null> {
   const data = await sonarFetch(component, "duplicated_lines_density", server)
   if (!data) return null
-  const value = getMeasureValue(data, "duplicated_lines_density")
+  const value = getMeasureNumber(data, "duplicated_lines_density")
   if (value === undefined) return null
 
   return {
     label: "duplicated lines",
-    value: `${parseFloat(value)}%`,
+    value: `${value}%`,
     link: `https://${server ?? "sonarcloud.io"}/component_measures?id=${component}&metric=duplicated_lines_density`,
   }
 }

--- a/packages/core/src/providers/tokscale.ts
+++ b/packages/core/src/providers/tokscale.ts
@@ -92,7 +92,7 @@ function profileLink(username: string): string {
 
 export async function getTokscaleTokens(username: string): Promise<BadgeData | null> {
   const data = await fetchUserProfile(username)
-  if (!data) return { label: "tokscale", value: "not found" }
+  if (!data) return null
   return {
     label: "tokens",
     value: formatTokens(data.stats.totalTokens),
@@ -102,7 +102,7 @@ export async function getTokscaleTokens(username: string): Promise<BadgeData | n
 
 export async function getTokscaleCost(username: string): Promise<BadgeData | null> {
   const data = await fetchUserProfile(username)
-  if (!data) return { label: "tokscale", value: "not found" }
+  if (!data) return null
   return {
     label: "cost",
     value: formatCost(data.stats.totalCost),
@@ -112,7 +112,7 @@ export async function getTokscaleCost(username: string): Promise<BadgeData | nul
 
 export async function getTokscaleRank(username: string): Promise<BadgeData | null> {
   const data = await fetchUserProfile(username)
-  if (!data) return { label: "tokscale", value: "not found" }
+  if (!data) return null
   return {
     label: "rank",
     value: `#${data.user.rank}`,
@@ -122,7 +122,7 @@ export async function getTokscaleRank(username: string): Promise<BadgeData | nul
 
 export async function getTokscaleActiveDays(username: string): Promise<BadgeData | null> {
   const data = await fetchUserProfile(username)
-  if (!data) return { label: "tokscale", value: "not found" }
+  if (!data) return null
   return {
     label: "active days",
     value: `${data.stats.activeDays}`,

--- a/packages/core/src/providers/vscode.ts
+++ b/packages/core/src/providers/vscode.ts
@@ -9,6 +9,7 @@
 import type { BadgeData } from "../badges/types"
 import { formatCount } from "../format"
 import { cachedFetch, handleUpstreamStatus } from "../cache"
+import { raceTimeout } from "../provider-fetch"
 
 interface VSCodeExtension {
   results: Array<{
@@ -24,7 +25,7 @@ async function vscodeFetch(publisher: string, extension: string): Promise<VSCode
     "vscode",
     `ext:${publisher}:${extension}`,
     async () => {
-      const r = await fetch("https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery", {
+      const r = await raceTimeout(fetch("https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -37,17 +38,24 @@ async function vscodeFetch(publisher: string, extension: string): Promise<VSCode
           flags: 914,
         }),
         next: { revalidate: 3600 },
-      })
+      }))
+      if (!r) return null
       handleUpstreamStatus("vscode", r.status)
       if (!r.ok) return null
-      return r.json()
+      try {
+        return await r.json()
+      } catch {
+        return null
+      }
     },
     3600,
   )
 }
 
-function getStat(stats: Array<{ statisticName: string; value: number }>, name: string): number {
-  return stats.find(s => s.statisticName === name)?.value ?? 0
+function getStat(stats: Array<{ statisticName: string; value: number }> | undefined, name: string): number {
+  if (!Array.isArray(stats)) return 0
+  const value = stats.find(s => s.statisticName === name)?.value
+  return typeof value === "number" && Number.isFinite(value) ? value : 0
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -10,7 +10,7 @@ import { renderBadge, renderBadgeBase, renderErrorBadge } from "./badges/render"
 import { parseAnimate } from "./badges/animate"
 import { renderGif } from "./badges/gif"
 import { renderBadgeGroup, type GroupSegment, type GroupConfig } from "./badges/render-group"
-import { resolveTheme, applyColorOverrides, statusColors } from "./badges/themes"
+import { resolveTheme, applyColorOverrides, statusColors, resolveColor } from "./badges/themes"
 import { getSimpleIcon } from "./badges/simple-icons"
 import { isTwemojiLogo, resolveTwemojiSvg } from "./badges/twemoji"
 import { getProviderBrandColor } from "./badges/brand-colors"
@@ -157,6 +157,7 @@ import { getMatrixMembers } from "./providers/matrix"
 import { getWeblateTranslation, getWeblateLanguages } from "./providers/weblate"
 import { getShipperClubMember } from "./providers/shipperclub"
 import { cachedFetchStale } from "./cache"
+import { raceTimeout } from "./provider-fetch"
 
 /** Response format. */
 type Format = "svg" | "png" | "gif" | "json" | "shields"
@@ -233,6 +234,7 @@ function parseFormat(segments: string[]): {
   cleanSegments: string[]
 } {
   const last = segments[segments.length - 1]
+  if (!last) return { format: "svg", cleanSegments: [] }
 
   // /provider/.../shields.json
   if (last === "shields.json") {
@@ -1366,23 +1368,38 @@ async function fetchBadgeData(
       const endpointUrl = `https://${rest.join("/")}`
 
       try {
-        const response = await fetch(endpointUrl, {
+        const response = await raceTimeout(fetch(endpointUrl, {
           headers: { Accept: "application/json", "User-Agent": "shieldcn/1.0" },
           next: { revalidate: 300 },
-        })
+        }))
+        // Failure verdicts carry `error: true` so they get short error cache
+        // headers and self-heal instead of being pinned at the CDN like a
+        // success.
+        if (!response) {
+          return { label: "endpoint", value: "timeout", color: "red", error: true }
+        }
         if (!response.ok) {
-          return { label: "endpoint", value: `${response.status}`, color: "red" }
+          return { label: "endpoint", value: `${response.status}`, color: "red", error: true }
         }
         const data = await response.json()
 
-        // Support both badgen format (subject/status) and our format (label/value)
-        const label = data.label || data.subject || "badge"
-        const value = data.value || data.status || data.message || "unknown"
-        const color = data.color || undefined
+        // Support both badgen format (subject/status) and our format
+        // (label/value). The endpoint is arbitrary user-supplied JSON — coerce
+        // to strings so an object can never paint "[object Object]" or crash
+        // the renderer, and accept legitimate falsy values like 0.
+        const asText = (v: unknown): string | undefined => {
+          if (v === null || v === undefined) return undefined
+          if (typeof v === "string") return v || undefined
+          if (typeof v === "number" || typeof v === "boolean") return String(v)
+          return undefined
+        }
+        const label = asText(data.label) ?? asText(data.subject) ?? "badge"
+        const value = asText(data.value) ?? asText(data.status) ?? asText(data.message) ?? "unknown"
+        const color = typeof data.color === "string" ? data.color : undefined
 
         return { label, value, color } as BadgeData
       } catch {
-        return { label: "endpoint", value: "error", color: "red" }
+        return { label: "endpoint", value: "error", color: "red", error: true }
       }
     }
 
@@ -1528,13 +1545,12 @@ async function handleBadgeGroup(
   const theme = searchParams.get("theme") ?? undefined
   const fontParam = searchParams.get("font") ?? undefined
   const font = (fontParam && ["inter", "geist", "geist-mono", "jetbrains-mono", "fira-code", "roboto", "space-grotesk"].includes(fontParam) ? fontParam : undefined) as GroupConfig["font"]
-  const logoColor = searchParams.get("logoColor") ?? undefined
+  const logoColor = resolveColor(searchParams.get("logoColor"))
 
-
-  const hasThemeOverride = !!(theme || searchParams.get("color") || searchParams.get("labelColor"))
+  const colorOverride = resolveColor(searchParams.get("color"))
+  const labelColorOverride = resolveColor(searchParams.get("labelColor"))
+  const hasThemeOverride = !!(theme || colorOverride || labelColorOverride)
   let colors = resolveTheme(theme)
-  const colorOverride = searchParams.get("color") ?? undefined
-  const labelColorOverride = searchParams.get("labelColor") ?? undefined
   colors = applyColorOverrides(colors, { color: colorOverride, labelColor: labelColorOverride })
 
   // Fetch all badge data in parallel
@@ -1836,7 +1852,7 @@ async function handleBadgeGETInner(
   const fontParam = searchParams.get("font") ?? undefined
   const font = (fontParam && ["inter", "geist", "geist-mono", "jetbrains-mono", "fira-code", "roboto", "space-grotesk"].includes(fontParam) ? fontParam : undefined) as BadgeConfig["font"]
   const logoParam = searchParams.get("logo")
-  const logoColor = searchParams.get("logoColor") ?? undefined
+  const logoColor = resolveColor(searchParams.get("logoColor"))
 
   // Flag badges: fetch the full-color flag SVG to render as a left inset.
   // Default to the `secondary` variant so the flag chip sits on a soft surface.
@@ -1849,29 +1865,31 @@ async function handleBadgeGETInner(
     // data.link is the resolved flag CDN URL (set by getFlagBadge).
     if (data.link) {
       try {
-        const flagRes = await fetch(data.link, {
+        const flagRes = await raceTimeout(fetch(data.link, {
           next: { revalidate: 86400 },
           headers: { Accept: "image/svg+xml", "User-Agent": "shieldcn/1.0" },
-        })
-        if (flagRes.ok) flagSvg = await flagRes.text()
+        }))
+        if (flagRes?.ok) flagSvg = await flagRes.text()
       } catch {
         // No flag art — fall back to a normal text badge.
       }
     }
   }
 
-  // Resolve colors
+  // Resolve colors. User-supplied color params are validated (named → hex,
+  // invalid → dropped) so garbage can never reach the renderer.
   const isStaticBadge = cleanSegments[0] === "badge" || cleanSegments[0] === "https"
-  const hasThemeOverride = !!(theme || searchParams.get("color") || searchParams.get("labelColor") || (isStaticBadge && data.color))
-  let colors = resolveTheme(theme)
 
   // Color overrides:
-  // 1. ?color= query param always wins (user-specified hex)
+  // 1. ?color= query param always wins (user-specified hex or named color)
   // 2. For static badges (/badge/...), data.color is a resolved hex from the path
   // 3. For provider badges, data.color is a status keyword — handled by statusColor
-  const colorOverride = searchParams.get("color")
-    ?? (isStaticBadge && data.color ? data.color : undefined)
-  const labelColorOverride = searchParams.get("labelColor") ?? undefined
+  const colorOverride = resolveColor(searchParams.get("color"))
+    ?? (isStaticBadge ? resolveColor(data.color) : undefined)
+  const labelColorOverride = resolveColor(searchParams.get("labelColor"))
+
+  const hasThemeOverride = !!(theme || colorOverride || labelColorOverride)
+  let colors = resolveTheme(theme)
 
   colors = applyColorOverrides(colors, {
     color: colorOverride,
@@ -2041,12 +2059,26 @@ async function handleBadgeGETInner(
   // Override label if provided
   const label = searchParams.get("label") || data.label
 
-  // Parse configurable layout params
+  // Parse configurable layout params. Each is clamped to a sane range — an
+  // unbounded ?height=1e9 would otherwise balloon the Satori render, and
+  // negative values break layout.
+  const NUM_BOUNDS: Record<string, [number, number]> = {
+    labelOpacity: [0, 1],
+    height: [8, 240],
+    fontSize: [5, 120],
+    radius: [0, 120],
+    padX: [0, 120],
+    iconSize: [0, 120],
+    gap: [0, 60],
+    labelGap: [0, 60],
+  }
   function num(key: string): number | undefined {
     const v = searchParams.get(key)
     if (v === null) return undefined
     const n = parseFloat(v)
-    return isNaN(n) ? undefined : n
+    if (!Number.isFinite(n)) return undefined
+    const [min, max] = NUM_BOUNDS[key] ?? [0, 1000]
+    return Math.min(max, Math.max(min, n))
   }
 
   // Parse gradient
@@ -2084,8 +2116,8 @@ async function handleBadgeGETInner(
     flagSvg,
     emojiSvg,
     animate,
-    valueColor: searchParams.get("valueColor") ?? undefined,
-    labelTextColor: searchParams.get("labelTextColor") ?? undefined,
+    valueColor: resolveColor(searchParams.get("valueColor")),
+    labelTextColor: resolveColor(searchParams.get("labelTextColor")),
     labelOpacity: num("labelOpacity"),
     height: num("height"),
     fontSize: num("fontSize"),

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -156,7 +156,7 @@ import { getLiberapayReceiving, getLiberapayPatrons, getLiberapayGoal } from "./
 import { getMatrixMembers } from "./providers/matrix"
 import { getWeblateTranslation, getWeblateLanguages } from "./providers/weblate"
 import { getShipperClubMember } from "./providers/shipperclub"
-import { cachedFetchStale } from "./cache"
+import { cachedFetchStale, isBackedOff } from "./cache"
 import { raceTimeout } from "./provider-fetch"
 
 /** Response format. */
@@ -440,7 +440,27 @@ async function resolveGitHubBadge(
     }
   }
 
+  // The existence probe couldn't reach GitHub either (rate limit, backoff,
+  // network) — the failure is definitely transient, not a bad repo. Say so
+  // honestly: a red "not found" on a valid repo reads as "your badge URL is
+  // wrong" and destroys trust. Marked error:true → 60s cache, never
+  // persisted as last-known-good.
+  if (exists === null) {
+    return GITHUB_UNAVAILABLE
+  }
+
   return null
+}
+
+/**
+ * Transient-failure verdict for GitHub badges with no last-known-good value.
+ * Gray (not red), short-cached, self-heals as soon as the upstream recovers.
+ */
+const GITHUB_UNAVAILABLE: BadgeData = {
+  label: "github",
+  value: "unavailable",
+  color: "cancelled",
+  error: true,
 }
 
 async function fetchBadgeData(
@@ -515,7 +535,7 @@ async function fetchBadgeData(
       const wf = searchParams.get("workflow")
       const br = searchParams.get("branch")
       const ghKey = rest.join("/") + (wf ? `|wf=${wf}` : "") + (br ? `|br=${br}` : "")
-      return cachedFetchStale(
+      const ghData = await cachedFetchStale(
         "github",
         ghKey,
         () => resolveGitHubBadge(rest, searchParams),
@@ -526,6 +546,15 @@ async function fetchBadgeData(
         // that later becomes available self-heals quickly.
         { isError: (d) => d.error === true, errorTtl: GITHUB_ERROR_TTL },
       )
+      if (ghData !== null) return ghData
+
+      // No data and no last-known-good. When GitHub is in a backoff window
+      // the fetcher was never called, so the transient-failure verdict from
+      // resolveGitHubBadge never got a chance to run — produce it here so a
+      // brand-new badge during an outage reads "unavailable" (gray, 60s),
+      // not "not found" (red, implies the badge URL is wrong).
+      if (isBackedOff("github")) return GITHUB_UNAVAILABLE
+      return null
     }
 
     // /discord/{serverId} or /discord/{topic}/{inviteCode}
@@ -1562,10 +1591,11 @@ async function handleBadgeGroup(
     })
   )
 
-  // If any segment fell back to "not found", treat the whole group as an
-  // error response so the failure self-heals quickly instead of being
-  // pinned at the CDN for an hour.
-  const groupCacheHeaders = allData.some(({ data }) => !data)
+  // If any segment fell back to "not found" or carries a terminal-error
+  // verdict (e.g. "unavailable"), treat the whole group as an error response
+  // so the failure self-heals quickly instead of being pinned at the CDN
+  // for an hour.
+  const groupCacheHeaders = allData.some(({ data }) => !data || data.error)
     ? ERROR_CACHE_HEADERS
     : CACHE_HEADERS
 


### PR DESCRIPTION
GitHub provider (the main API-dependent badge source):
- Detect 403 rate limits (x-ratelimit-remaining: 0 / Retry-After), not just
  429/503 — GitHub signals primary and secondary limits as 403, so a
  rate-limited pool previously kept getting hammered with no backoff and
  badges degraded to "not found"
- Vet the unauthenticated 401-retry response through the same status checks
  instead of returning it raw (error bodies could flow into badge values)
- Fix /github/last-commit/{owner}/{repo}/{branch}: the URL-building hack
  produced "commits?sha=X?per_page=1", breaking branch-scoped last-commit
- Fail downloads/downloads-asset (all releases) on any failed page instead
  of rendering "0" — a transient blip could persist a bogus 0 as the 7-day
  last-known-good value, clobbering the real count
- Only render dependabot "not found" on a definitive 404 of both spellings;
  transient failures now fall back to last-known-good
- Validate milestone/tag/release fields so undefined/NaN never reach text
- Guard JSON parsing and invalid dates; share the repo-exists HEAD probe

All providers:
- Add an 8s upstream timeout (race-based, leaves Next fetch caching intact)
  to providerFetch/providerFetchText, GitHub, VS Code, twemoji, flags, the
  https proxy, and dynamic JSON badges — a hung upstream no longer hangs
  the badge until the platform kills the request
- Guard JSON body parsing in the shared fetch helpers
- tokscale: return null on fetch failure instead of a fake "not found"
  badge that was cached as a success for an hour
- sonar: numeric measure guards — non-numeric values rendered "NaN%"
- gitlab: fix pipeline URL missing "?" when no branch is set (the default
  pipeline badge was broken); validate status/ref fields
- chocolatey/liberapay/vscode: NaN and missing-field guards
- cocoapods: drop a dead CDN fetch whose every branch returned the same badge
- https proxy + dynamic JSON badges: mark failure verdicts error:true so
  they get short error cache headers and self-heal instead of being pinned
  at the CDN; coerce arbitrary endpoint JSON to strings (no more
  "[object Object]", falsy 0 values now render)

Render pipeline:
- Validate all user color params (color, labelColor, logoColor, valueColor,
  labelTextColor) through a shared resolver: named colors now work
  everywhere, short hex is expanded, garbage is dropped instead of reaching
  the SVG
- Clamp numeric layout params (height, fontSize, padX, ...) to sane ranges
- Truncate badge text at 256 chars and coerce non-strings so a provider bug
  can never paint "undefined" or balloon the SVG
- Guard malformed viewBox in user-supplied logo SVGs (scale(NaN))
- Guard parseFormat against empty path segments

Adds tests for color resolution and text sanitization.

https://claude.ai/code/session_019og7QYLUhEsszoq3266W7X