### PR TITLE
feat(badges): add skills.sh badge support

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ See the [docs](https://shieldcn.dev/docs) for full endpoint details, interactive
 | **Weblate** | translation %, language count | `/weblate/translation/{server}/{project}/{component}` |
 | **Modrinth** | downloads, followers, version, game versions | `/modrinth/downloads/{slug}` |
 | **Tokscale** | tokens, cost, rank, active days | `/tokscale/{username}` |
+| **skills.sh** | skill installs, rank, trending, hot, audit | `/skills/installs/{owner}/{repo}/{skill}` |
 | **Country Flags** | “built in {country}” with a flag chip (265 countries/regions) | `/flag/{code}` |
 
 ### Custom badges

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ See the [docs](https://shieldcn.dev/docs) for full endpoint details, interactive
 | **Weblate** | translation %, language count | `/weblate/translation/{server}/{project}/{component}` |
 | **Modrinth** | downloads, followers, version, game versions | `/modrinth/downloads/{slug}` |
 | **Tokscale** | tokens, cost, rank, active days | `/tokscale/{username}` |
-| **skills.sh** | skill installs, rank, trending, hot, audit | `/skills/installs/{owner}/{repo}/{skill}` |
+| **skills.sh** | skill installs, rank, trending, hot | `/skills/installs/{owner}/{repo}/{skill}` |
 | **Country Flags** | “built in {country}” with a flag chip (265 countries/regions) | `/flag/{code}` |
 
 ### Custom badges

--- a/packages/core/src/badges/brand-colors.ts
+++ b/packages/core/src/badges/brand-colors.ts
@@ -40,6 +40,7 @@ export const providerBrandColors: Record<string, string> = {
   codecov: "F01F7A",
   wakatime: "000000",
   tokscale: "0073FF",
+  skills: "000000",
   indiedevs: "818CF8",
   openpanel: "2564EB",
   gitlab: "FC6D26",

--- a/packages/core/src/badges/registry.ts
+++ b/packages/core/src/badges/registry.ts
@@ -455,14 +455,13 @@ export const REGISTRY: BadgeProvider[] = [
   },
   {
     provider: "skills",
-    description: "skills.sh agent skill installs, rank, and audits.",
+    description: "skills.sh agent skill installs and leaderboard rank.",
     defaultTopic: "installs",
     topics: [
-      t("installs", "Skill installs", ["installs", "vercel-labs", "agent-skills", "frontend-design"]),
-      t("rank", "All-time leaderboard rank", ["rank", "vercel-labs", "agent-skills", "frontend-design"]),
-      t("trending", "Trending rank", ["trending", "vercel-labs", "agent-skills", "frontend-design"]),
-      t("hot", "Hot rank", ["hot", "vercel-labs", "agent-skills", "frontend-design"]),
-      state("audit", "Security audit status", ["audit", "vercel-labs", "agent-skills", "frontend-design"]),
+      t("installs", "Skill installs", ["installs", "vercel-labs", "agent-skills", "vercel-react-best-practices"]),
+      t("rank", "All-time leaderboard rank", ["rank", "vercel-labs", "agent-skills", "vercel-react-best-practices"]),
+      t("trending", "Trending rank", ["trending", "vercel-labs", "agent-skills", "vercel-react-best-practices"]),
+      t("hot", "Hot rank", ["hot", "vercel-labs", "agent-skills", "vercel-react-best-practices"]),
     ],
   },
   {

--- a/packages/core/src/badges/registry.ts
+++ b/packages/core/src/badges/registry.ts
@@ -454,6 +454,18 @@ export const REGISTRY: BadgeProvider[] = [
     ],
   },
   {
+    provider: "skills",
+    description: "skills.sh agent skill installs, rank, and audits.",
+    defaultTopic: "installs",
+    topics: [
+      t("installs", "Skill installs", ["installs", "vercel-labs", "agent-skills", "frontend-design"]),
+      t("rank", "All-time leaderboard rank", ["rank", "vercel-labs", "agent-skills", "frontend-design"]),
+      t("trending", "Trending rank", ["trending", "vercel-labs", "agent-skills", "frontend-design"]),
+      t("hot", "Hot rank", ["hot", "vercel-labs", "agent-skills", "frontend-design"]),
+      state("audit", "Security audit status", ["audit", "vercel-labs", "agent-skills", "frontend-design"]),
+    ],
+  },
+  {
     provider: "indiedevs",
     description: "IndieDevs membership badge.",
     freeform: true,

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -166,6 +166,7 @@ const PROVIDER_BUDGETS: Record<string, { max: number; refillRate: number }> = {
   cocoapods:     { max: 20, refillRate: 2 },
   maven:         { max: 20, refillRate: 2 },
   jsr:           { max: 30, refillRate: 3 },
+  skills:        { max: 10, refillRate: 1 },      // skills.sh: 60 req/min unauthenticated
   // github is handled by the token pool, not budgeted here
 }
 

--- a/packages/core/src/providers/skills.test.ts
+++ b/packages/core/src/providers/skills.test.ts
@@ -1,0 +1,98 @@
+/**
+ * shieldcn
+ * lib/providers/skills.test
+ *
+ * Verifies the skills.sh provider against the public leaderboard envelope
+ * (`/api/skills/{view}/{page}` → { skills: [{ source, skillId, name, installs }], hasMore }).
+ * Real field names confirmed from the upstream API and many cached dumps.
+ *
+ * NOTE: leaderboard pages are cached module-globally by `{view}:{page}` (shared
+ * across every skills badge — the intended optimization), so this file uses one
+ * consistent board per view; cache hits across tests then stay correct.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { getSkillsInstalls, getSkillsRank, getSkillsTrending, getSkillsHot } from "./skills"
+
+interface PageSkill {
+  source: string
+  skillId: string
+  name: string
+  installs: number
+}
+
+const s = (source: string, skillId: string, installs: number): PageSkill =>
+  ({ source, skillId, name: skillId, installs })
+
+// A single stable board, mirroring the real top of the all-time leaderboard.
+const ALL_TIME: PageSkill[][] = [
+  [
+    s("vercel-labs/agent-skills", "vercel-react-best-practices", 389226), // pos 1
+    s("vercel-labs/agent-skills", "web-design-guidelines", 96576),        // pos 2
+  ],
+  [
+    s("remotion-dev/skills", "remotion-best-practices", 17700),           // pos 3
+    s("anthropics/skills", "frontend-design", 6900),                      // pos 4
+  ],
+]
+
+const TRENDING: PageSkill[][] = [[s("vercel-labs/agent-skills", "vercel-react-best-practices", 5)]]
+const HOT: PageSkill[][] = [
+  [s("x/y", "a", 9)],
+  [s("vercel-labs/agent-skills", "vercel-react-best-practices", 5)], // pos 2
+]
+
+beforeEach(() => {
+  const board: Record<string, PageSkill[][]> = { "all-time": ALL_TIME, trending: TRENDING, hot: HOT }
+  vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+    const m = url.match(/\/api\/skills\/([^/]+)\/(\d+)$/)
+    if (!m) return new Response("not found", { status: 404 })
+    const [, view, pageStr] = m
+    const pages = board[view] ?? []
+    const page = pages[Number(pageStr)] ?? []
+    const hasMore = Number(pageStr) < pages.length - 1
+    return new Response(JSON.stringify({ skills: page, hasMore }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  }))
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("skills.sh provider", () => {
+  it("reads installs from the all-time board (formatted)", async () => {
+    const data = await getSkillsInstalls("vercel-labs", "agent-skills", "vercel-react-best-practices")
+    expect(data?.label).toBe("installs")
+    expect(data?.value).toBe("389.2k")
+    expect(data?.link).toBe("https://www.skills.sh/vercel-labs/agent-skills/vercel-react-best-practices")
+  })
+
+  it("ranks the top skill #1", async () => {
+    const data = await getSkillsRank("vercel-labs", "agent-skills", "vercel-react-best-practices")
+    expect(data?.label).toBe("skill rank")
+    expect(data?.value).toBe("#1")
+  })
+
+  it("computes 1-based rank across pages and matches by source + skillId", async () => {
+    // frontend-design lives under anthropics/skills at the 4th position overall.
+    const data = await getSkillsRank("anthropics", "skills", "frontend-design")
+    expect(data?.value).toBe("#4")
+  })
+
+  it("returns null when a skill isn't on the board", async () => {
+    const data = await getSkillsInstalls("nope", "nope", "missing-skill-xyz")
+    expect(data).toBeNull()
+  })
+
+  it("reads trending and hot positions from their own boards", async () => {
+    const trending = await getSkillsTrending("vercel-labs", "agent-skills", "vercel-react-best-practices")
+    expect(trending?.label).toBe("trending")
+    expect(trending?.value).toBe("#1")
+    const hot = await getSkillsHot("vercel-labs", "agent-skills", "vercel-react-best-practices")
+    expect(hot?.label).toBe("hot")
+    expect(hot?.value).toBe("#2")
+  })
+})

--- a/packages/core/src/providers/skills.ts
+++ b/packages/core/src/providers/skills.ts
@@ -3,8 +3,12 @@
  * lib/providers/skills
  *
  * skills.sh API client — the open agent skills directory by Vercel.
- * Supports: installs, rank, trending, hot, audit.
+ * Supports: installs, rank, trending, hot.
  * API: https://www.skills.sh/docs/api
+ *
+ * Uses the public leaderboard endpoint `/api/skills/{view}/{page}` which needs
+ * no authentication. A skill is addressed as {owner}/{repo}/{skill}, matching
+ * the upstream `source` ("owner/repo") plus `skillId`.
  */
 
 import type { BadgeData } from "../badges/types"
@@ -18,42 +22,32 @@ import { providerFetch } from "../provider-fetch"
 interface SkillsShSkill {
   id?: string
   source?: string
-  slug?: string
   skillId?: string
+  slug?: string
   name?: string
   installs?: number
 }
 
-/** Leaderboard responses have shipped under several envelope keys — accept all. */
-interface SkillsShList {
-  data?: SkillsShSkill[]
+/** Leaderboard page. Field names vary slightly across skills.sh tiers. */
+interface SkillsShPage {
   skills?: SkillsShSkill[]
+  data?: SkillsShSkill[]
   results?: SkillsShSkill[]
-  pagination?: { hasMore?: boolean }
   hasMore?: boolean
+  pagination?: { hasMore?: boolean }
 }
 
-interface SkillsShAudit {
-  audits?: Array<{
-    provider?: string
-    status?: string
-    riskLevel?: string
-  }>
-}
+type View = "all-time" | "trending" | "hot"
 
 // ---------------------------------------------------------------------------
 // Fetch helpers
 // ---------------------------------------------------------------------------
 
-// Use the www host directly — skills.sh redirects to www and the
-// Authorization header can be dropped on the hop.
-const API_BASE = "https://www.skills.sh/api/v1"
+// Canonical host — skills.sh redirects to www, so target www directly.
+const API_BASE = "https://www.skills.sh/api"
 
-const PER_PAGE = 100
-/** All-time rank scan depth: 10 pages × 100 = top 1000. */
-const RANK_MAX_PAGES = 10
-/** Trending/hot scan depth: 5 pages × 100 = top 500. */
-const VIEW_MAX_PAGES = 5
+/** How many leaderboard pages to scan before giving up on a skill. */
+const MAX_PAGES = 5
 
 /** Optional API key raises the skills.sh rate limit (60 → 600 req/min). */
 function authHeaders(): HeadersInit {
@@ -61,74 +55,64 @@ function authHeaders(): HeadersInit {
   return key ? { Authorization: `Bearer ${key}` } : {}
 }
 
-async function fetchSkillDetail(owner: string, repo: string, skill: string): Promise<SkillsShSkill | null> {
-  return providerFetch<SkillsShSkill>({
-    provider: "skills",
-    cacheKey: `detail:${owner}/${repo}/${skill}`,
-    url: `${API_BASE}/skills/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${encodeURIComponent(skill)}`,
-    headers: authHeaders(),
-    ttl: 1800,
-  })
-}
-
-async function fetchLeaderboardPage(view: string, page: number): Promise<SkillsShList | null> {
-  return providerFetch<SkillsShList>({
+async function fetchLeaderboardPage(view: View, page: number): Promise<SkillsShPage | null> {
+  return providerFetch<SkillsShPage>({
     provider: "skills",
     cacheKey: `board:${view}:${page}`,
-    url: `${API_BASE}/skills?view=${view}&page=${page}&per_page=${PER_PAGE}`,
+    url: `${API_BASE}/skills/${view}/${page}`,
     headers: authHeaders(),
     ttl: 1800,
   })
 }
 
-async function fetchAudit(owner: string, repo: string, skill: string): Promise<SkillsShAudit | null> {
-  return providerFetch<SkillsShAudit>({
-    provider: "skills",
-    cacheKey: `audit:${owner}/${repo}/${skill}`,
-    url: `${API_BASE}/skills/audit/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${encodeURIComponent(skill)}`,
-    headers: authHeaders(),
-    ttl: 3600,
-  })
-}
-
-function listSkills(page: SkillsShList): SkillsShSkill[] {
-  return page.data ?? page.skills ?? page.results ?? []
+function pageSkills(page: SkillsShPage): SkillsShSkill[] {
+  return page.skills ?? page.data ?? page.results ?? []
 }
 
 function matchesSkill(item: SkillsShSkill, owner: string, repo: string, skill: string): boolean {
-  const id = `${owner}/${repo}/${skill}`
-  if (item.id === id) return true
-  return item.source === `${owner}/${repo}` && (item.slug ?? item.skillId) === skill
+  const source = `${owner}/${repo}`
+  if (item.id === `${source}/${skill}`) return true
+  if (item.source !== source) return false
+  return (item.skillId ?? item.slug ?? item.name) === skill
+}
+
+interface ScanHit {
+  /** 1-based position on the leaderboard. */
+  rank: number
+  installs: number | null
 }
 
 /**
- * Find a skill's 1-based position on a leaderboard view by scanning pages.
- * Pages are cached and shared across all rank badges, so a warm scan is free.
+ * Scan a leaderboard view for a skill, returning its position and install
+ * count. Pages are cached (30 min) and shared across every skills badge, so a
+ * warm scan costs nothing. Stops as soon as the skill is found.
  */
-async function findRank(
-  view: string,
+async function scanLeaderboard(
+  view: View,
   owner: string,
   repo: string,
-  skill: string,
-  maxPages: number
-): Promise<number | null> {
+  skill: string
+): Promise<ScanHit | null> {
   let position = 0
-  for (let page = 0; page < maxPages; page++) {
+  for (let page = 0; page < MAX_PAGES; page++) {
     const data = await fetchLeaderboardPage(view, page)
-    if (!data) return null
-    const items = listSkills(data)
+    if (!data) break
+    const items = pageSkills(data)
+    if (items.length === 0) break
     for (const item of items) {
       position++
-      if (matchesSkill(item, owner, repo, skill)) return position
+      if (matchesSkill(item, owner, repo, skill)) {
+        return { rank: position, installs: typeof item.installs === "number" ? item.installs : null }
+      }
     }
     const hasMore = data.pagination?.hasMore ?? data.hasMore
-    if (items.length < PER_PAGE || hasMore === false) break
+    if (hasMore === false) break
   }
   return null
 }
 
 function skillLink(owner: string, repo: string, skill: string): string {
-  return `https://skills.sh/${owner}/${repo}/${skill}`
+  return `https://www.skills.sh/${owner}/${repo}/${skill}`
 }
 
 // ---------------------------------------------------------------------------
@@ -136,68 +120,41 @@ function skillLink(owner: string, repo: string, skill: string): string {
 // ---------------------------------------------------------------------------
 
 export async function getSkillsInstalls(owner: string, repo: string, skill: string): Promise<BadgeData | null> {
-  const data = await fetchSkillDetail(owner, repo, skill)
-  if (!data || typeof data.installs !== "number") return null
+  const hit = await scanLeaderboard("all-time", owner, repo, skill)
+  if (!hit || hit.installs === null) return null
   return {
     label: "installs",
-    value: formatCount(data.installs),
+    value: formatCount(hit.installs),
     link: skillLink(owner, repo, skill),
   }
 }
 
 export async function getSkillsRank(owner: string, repo: string, skill: string): Promise<BadgeData | null> {
-  const rank = await findRank("all-time", owner, repo, skill, RANK_MAX_PAGES)
-  if (rank !== null) {
-    return {
-      label: "skill rank",
-      value: `#${rank}`,
-      link: skillLink(owner, repo, skill),
-    }
-  }
-  // Outside the scanned top — still a real badge if the skill exists.
-  const detail = await fetchSkillDetail(owner, repo, skill)
-  if (!detail) return null
+  const hit = await scanLeaderboard("all-time", owner, repo, skill)
+  if (!hit) return null
   return {
     label: "skill rank",
-    value: `${RANK_MAX_PAGES * PER_PAGE}+`,
+    value: `#${hit.rank}`,
     link: skillLink(owner, repo, skill),
   }
 }
 
 export async function getSkillsTrending(owner: string, repo: string, skill: string): Promise<BadgeData | null> {
-  const rank = await findRank("trending", owner, repo, skill, VIEW_MAX_PAGES)
-  if (rank === null) return null
+  const hit = await scanLeaderboard("trending", owner, repo, skill)
+  if (!hit) return null
   return {
     label: "trending",
-    value: `#${rank}`,
+    value: `#${hit.rank}`,
     link: skillLink(owner, repo, skill),
   }
 }
 
 export async function getSkillsHot(owner: string, repo: string, skill: string): Promise<BadgeData | null> {
-  const rank = await findRank("hot", owner, repo, skill, VIEW_MAX_PAGES)
-  if (rank === null) return null
+  const hit = await scanLeaderboard("hot", owner, repo, skill)
+  if (!hit) return null
   return {
     label: "hot",
-    value: `#${rank}`,
-    link: skillLink(owner, repo, skill),
-  }
-}
-
-export async function getSkillsAudit(owner: string, repo: string, skill: string): Promise<BadgeData | null> {
-  const data = await fetchAudit(owner, repo, skill)
-  if (!data?.audits || data.audits.length === 0) return null
-
-  const statuses = data.audits.map((a) => a.status)
-  const value = statuses.includes("fail") ? "failed"
-    : statuses.includes("warn") ? "warning"
-    : "passed"
-  const color = value === "failed" ? "red" : value === "warning" ? "amber" : "green"
-
-  return {
-    label: "audit",
-    value,
-    color,
+    value: `#${hit.rank}`,
     link: skillLink(owner, repo, skill),
   }
 }

--- a/packages/core/src/providers/skills.ts
+++ b/packages/core/src/providers/skills.ts
@@ -1,0 +1,203 @@
+/**
+ * shieldcn
+ * lib/providers/skills
+ *
+ * skills.sh API client — the open agent skills directory by Vercel.
+ * Supports: installs, rank, trending, hot, audit.
+ * API: https://www.skills.sh/docs/api
+ */
+
+import type { BadgeData } from "../badges/types"
+import { formatCount } from "../format"
+import { providerFetch } from "../provider-fetch"
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface SkillsShSkill {
+  id?: string
+  source?: string
+  slug?: string
+  skillId?: string
+  name?: string
+  installs?: number
+}
+
+/** Leaderboard responses have shipped under several envelope keys — accept all. */
+interface SkillsShList {
+  data?: SkillsShSkill[]
+  skills?: SkillsShSkill[]
+  results?: SkillsShSkill[]
+  pagination?: { hasMore?: boolean }
+  hasMore?: boolean
+}
+
+interface SkillsShAudit {
+  audits?: Array<{
+    provider?: string
+    status?: string
+    riskLevel?: string
+  }>
+}
+
+// ---------------------------------------------------------------------------
+// Fetch helpers
+// ---------------------------------------------------------------------------
+
+// Use the www host directly — skills.sh redirects to www and the
+// Authorization header can be dropped on the hop.
+const API_BASE = "https://www.skills.sh/api/v1"
+
+const PER_PAGE = 100
+/** All-time rank scan depth: 10 pages × 100 = top 1000. */
+const RANK_MAX_PAGES = 10
+/** Trending/hot scan depth: 5 pages × 100 = top 500. */
+const VIEW_MAX_PAGES = 5
+
+/** Optional API key raises the skills.sh rate limit (60 → 600 req/min). */
+function authHeaders(): HeadersInit {
+  const key = process.env.SKILLS_SH_API_KEY
+  return key ? { Authorization: `Bearer ${key}` } : {}
+}
+
+async function fetchSkillDetail(owner: string, repo: string, skill: string): Promise<SkillsShSkill | null> {
+  return providerFetch<SkillsShSkill>({
+    provider: "skills",
+    cacheKey: `detail:${owner}/${repo}/${skill}`,
+    url: `${API_BASE}/skills/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${encodeURIComponent(skill)}`,
+    headers: authHeaders(),
+    ttl: 1800,
+  })
+}
+
+async function fetchLeaderboardPage(view: string, page: number): Promise<SkillsShList | null> {
+  return providerFetch<SkillsShList>({
+    provider: "skills",
+    cacheKey: `board:${view}:${page}`,
+    url: `${API_BASE}/skills?view=${view}&page=${page}&per_page=${PER_PAGE}`,
+    headers: authHeaders(),
+    ttl: 1800,
+  })
+}
+
+async function fetchAudit(owner: string, repo: string, skill: string): Promise<SkillsShAudit | null> {
+  return providerFetch<SkillsShAudit>({
+    provider: "skills",
+    cacheKey: `audit:${owner}/${repo}/${skill}`,
+    url: `${API_BASE}/skills/audit/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${encodeURIComponent(skill)}`,
+    headers: authHeaders(),
+    ttl: 3600,
+  })
+}
+
+function listSkills(page: SkillsShList): SkillsShSkill[] {
+  return page.data ?? page.skills ?? page.results ?? []
+}
+
+function matchesSkill(item: SkillsShSkill, owner: string, repo: string, skill: string): boolean {
+  const id = `${owner}/${repo}/${skill}`
+  if (item.id === id) return true
+  return item.source === `${owner}/${repo}` && (item.slug ?? item.skillId) === skill
+}
+
+/**
+ * Find a skill's 1-based position on a leaderboard view by scanning pages.
+ * Pages are cached and shared across all rank badges, so a warm scan is free.
+ */
+async function findRank(
+  view: string,
+  owner: string,
+  repo: string,
+  skill: string,
+  maxPages: number
+): Promise<number | null> {
+  let position = 0
+  for (let page = 0; page < maxPages; page++) {
+    const data = await fetchLeaderboardPage(view, page)
+    if (!data) return null
+    const items = listSkills(data)
+    for (const item of items) {
+      position++
+      if (matchesSkill(item, owner, repo, skill)) return position
+    }
+    const hasMore = data.pagination?.hasMore ?? data.hasMore
+    if (items.length < PER_PAGE || hasMore === false) break
+  }
+  return null
+}
+
+function skillLink(owner: string, repo: string, skill: string): string {
+  return `https://skills.sh/${owner}/${repo}/${skill}`
+}
+
+// ---------------------------------------------------------------------------
+// Badge functions
+// ---------------------------------------------------------------------------
+
+export async function getSkillsInstalls(owner: string, repo: string, skill: string): Promise<BadgeData | null> {
+  const data = await fetchSkillDetail(owner, repo, skill)
+  if (!data || typeof data.installs !== "number") return null
+  return {
+    label: "installs",
+    value: formatCount(data.installs),
+    link: skillLink(owner, repo, skill),
+  }
+}
+
+export async function getSkillsRank(owner: string, repo: string, skill: string): Promise<BadgeData | null> {
+  const rank = await findRank("all-time", owner, repo, skill, RANK_MAX_PAGES)
+  if (rank !== null) {
+    return {
+      label: "skill rank",
+      value: `#${rank}`,
+      link: skillLink(owner, repo, skill),
+    }
+  }
+  // Outside the scanned top — still a real badge if the skill exists.
+  const detail = await fetchSkillDetail(owner, repo, skill)
+  if (!detail) return null
+  return {
+    label: "skill rank",
+    value: `${RANK_MAX_PAGES * PER_PAGE}+`,
+    link: skillLink(owner, repo, skill),
+  }
+}
+
+export async function getSkillsTrending(owner: string, repo: string, skill: string): Promise<BadgeData | null> {
+  const rank = await findRank("trending", owner, repo, skill, VIEW_MAX_PAGES)
+  if (rank === null) return null
+  return {
+    label: "trending",
+    value: `#${rank}`,
+    link: skillLink(owner, repo, skill),
+  }
+}
+
+export async function getSkillsHot(owner: string, repo: string, skill: string): Promise<BadgeData | null> {
+  const rank = await findRank("hot", owner, repo, skill, VIEW_MAX_PAGES)
+  if (rank === null) return null
+  return {
+    label: "hot",
+    value: `#${rank}`,
+    link: skillLink(owner, repo, skill),
+  }
+}
+
+export async function getSkillsAudit(owner: string, repo: string, skill: string): Promise<BadgeData | null> {
+  const data = await fetchAudit(owner, repo, skill)
+  if (!data?.audits || data.audits.length === 0) return null
+
+  const statuses = data.audits.map((a) => a.status)
+  const value = statuses.includes("fail") ? "failed"
+    : statuses.includes("warn") ? "warning"
+    : "passed"
+  const color = value === "failed" ? "red" : value === "warning" ? "amber" : "green"
+
+  return {
+    label: "audit",
+    value,
+    color,
+    link: skillLink(owner, repo, skill),
+  }
+}

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -136,7 +136,7 @@ import { getCocoaPodsVersion } from "./providers/cocoapods"
 import { getCodecovCoverage } from "./providers/codecov"
 import { getWakaTimeCodingTime } from "./providers/wakatime"
 import { getTokscaleTokens, getTokscaleCost, getTokscaleRank, getTokscaleActiveDays, getTokscaleStats } from "./providers/tokscale"
-import { getSkillsInstalls, getSkillsRank, getSkillsTrending, getSkillsHot, getSkillsAudit } from "./providers/skills"
+import { getSkillsInstalls, getSkillsRank, getSkillsTrending, getSkillsHot } from "./providers/skills"
 import { getIndieDevsUser } from "./providers/indiedevs"
 import { getGitLabStars, getGitLabForks, getGitLabIssues, getGitLabPipeline, getGitLabLicense, getGitLabLastCommit, getGitLabContributors, getGitLabRelease } from "./providers/gitlab"
 import { getCondaVersion, getCondaDownloads, getCondaPlatform } from "./providers/conda"
@@ -1061,12 +1061,12 @@ async function fetchBadgeData(
     }
 
     // /skills/{topic}/{owner}/{repo}/{skill}
-    // e.g. /skills/installs/vercel-labs/agent-skills/frontend-design
+    // e.g. /skills/installs/vercel-labs/agent-skills/vercel-react-best-practices
     case "skills": {
       const rest = segments.slice(1)
       if (rest.length === 0) return null
 
-      const skillTopics = new Set(["installs", "rank", "trending", "hot", "audit"])
+      const skillTopics = new Set(["installs", "rank", "trending", "hot"])
       if (skillTopics.has(rest[0])) {
         if (rest.length < 4) return null
         const [topic, owner, repo, skill] = rest
@@ -1075,7 +1075,6 @@ async function fetchBadgeData(
           case "rank": return getSkillsRank(owner, repo, skill)
           case "trending": return getSkillsTrending(owner, repo, skill)
           case "hot": return getSkillsHot(owner, repo, skill)
-          case "audit": return getSkillsAudit(owner, repo, skill)
           default: return null
         }
       }

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -136,6 +136,7 @@ import { getCocoaPodsVersion } from "./providers/cocoapods"
 import { getCodecovCoverage } from "./providers/codecov"
 import { getWakaTimeCodingTime } from "./providers/wakatime"
 import { getTokscaleTokens, getTokscaleCost, getTokscaleRank, getTokscaleActiveDays, getTokscaleStats } from "./providers/tokscale"
+import { getSkillsInstalls, getSkillsRank, getSkillsTrending, getSkillsHot, getSkillsAudit } from "./providers/skills"
 import { getIndieDevsUser } from "./providers/indiedevs"
 import { getGitLabStars, getGitLabForks, getGitLabIssues, getGitLabPipeline, getGitLabLicense, getGitLabLastCommit, getGitLabContributors, getGitLabRelease } from "./providers/gitlab"
 import { getCondaVersion, getCondaDownloads, getCondaPlatform } from "./providers/conda"
@@ -1059,6 +1060,31 @@ async function fetchBadgeData(
       return getTokscaleTokens(rest[0])
     }
 
+    // /skills/{topic}/{owner}/{repo}/{skill}
+    // e.g. /skills/installs/vercel-labs/agent-skills/frontend-design
+    case "skills": {
+      const rest = segments.slice(1)
+      if (rest.length === 0) return null
+
+      const skillTopics = new Set(["installs", "rank", "trending", "hot", "audit"])
+      if (skillTopics.has(rest[0])) {
+        if (rest.length < 4) return null
+        const [topic, owner, repo, skill] = rest
+        switch (topic) {
+          case "installs": return getSkillsInstalls(owner, repo, skill)
+          case "rank": return getSkillsRank(owner, repo, skill)
+          case "trending": return getSkillsTrending(owner, repo, skill)
+          case "hot": return getSkillsHot(owner, repo, skill)
+          case "audit": return getSkillsAudit(owner, repo, skill)
+          default: return null
+        }
+      }
+
+      // Default: /skills/{owner}/{repo}/{skill} → installs
+      if (rest.length < 3) return null
+      return getSkillsInstalls(rest[0], rest[1], rest[2])
+    }
+
     // /indiedevs/{username}
     // e.g. /indiedevs/jalco
     case "indiedevs": {
@@ -1479,6 +1505,7 @@ function getDefaultLogoSlug(segments: string[]): { simpleIcon?: string; reactIco
   if (provider === "wakatime") return { simpleIcon: "wakatime" }
   if (provider === "reddit") return { simpleIcon: "reddit" }
   if (provider === "tokscale") return { reactIcon: "GoRocket" }
+  if (provider === "skills") return { simpleIcon: "vercel" }
   if (provider === "indiedevs") return { simpleIcon: "indiedevs" }
   if (provider === "gitlab") return { simpleIcon: "gitlab" }
   if (provider === "conda") return { simpleIcon: "anaconda" }

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -42,7 +42,11 @@ export default async function Home() {
                 <span className="inline-flex items-baseline">
                   <code className="rounded-md border border-border bg-muted px-2 py-0.5 font-mono text-[0.85em]">readme</code>
                 </span>{" "}
-                craves.
+                and{" "}
+                <span className="inline-flex items-baseline">
+                  <code className="rounded-md border border-border bg-muted px-2 py-0.5 font-mono text-[0.85em]">SKILL.md</code>
+                </span>{" "}
+                crave.
               </h1>
 
               <HeroSubtext />

--- a/packages/web/components/sidebar.tsx
+++ b/packages/web/components/sidebar.tsx
@@ -145,6 +145,7 @@ const docsNav: NavGroup[] = [
       { title: "Weblate", href: "/docs/badges/weblate" },
       { title: "Modrinth", href: "/docs/badges/modrinth" },
       { title: "Tokscale", href: "/docs/badges/tokscale" },
+      { title: "skills.sh", href: "/docs/badges/skills" },
       { title: "Country Flags", href: "/docs/badges/flag" },
     ],
   },

--- a/packages/web/components/site-announcement.tsx
+++ b/packages/web/components/site-announcement.tsx
@@ -11,8 +11,8 @@ export function SiteAnnouncement() {
     <Announcement>
       <AnnouncementBadge>New</AnnouncementBadge>
       <AnnouncementContent asChild>
-        <Link href="/docs/customization/fonts" className="hover:underline underline-offset-4">
-          New: 4 fonts — JetBrains Mono, Fira Code, Roboto, Space Grotesk
+        <Link href="/docs/badges/skills" className="hover:underline underline-offset-4">
+          New: skills.sh badges — skill installs, rank &amp; audits
           <ArrowRight className="size-3" />
         </Link>
       </AnnouncementContent>

--- a/packages/web/content/docs/api-reference.mdx
+++ b/packages/web/content/docs/api-reference.mdx
@@ -85,10 +85,9 @@ Static badges — no API token required.
 |----------|-------------|
 | `/skills/{owner}/{repo}/{skill}.svg` | All-time install count (default) |
 | `/skills/installs/{owner}/{repo}/{skill}.svg` | All-time install count |
-| `/skills/rank/{owner}/{repo}/{skill}.svg` | All-time leaderboard rank (top 1000) |
-| `/skills/trending/{owner}/{repo}/{skill}.svg` | Trending leaderboard rank (top 500) |
-| `/skills/hot/{owner}/{repo}/{skill}.svg` | Hot (last 24h) leaderboard rank (top 500) |
-| `/skills/audit/{owner}/{repo}/{skill}.svg` | Security audit status (passed / warning / failed) |
+| `/skills/rank/{owner}/{repo}/{skill}.svg` | All-time leaderboard rank |
+| `/skills/trending/{owner}/{repo}/{skill}.svg` | Trending leaderboard rank |
+| `/skills/hot/{owner}/{repo}/{skill}.svg` | Hot (last 24h) leaderboard rank |
 
 ### Country Flags
 

--- a/packages/web/content/docs/api-reference.mdx
+++ b/packages/web/content/docs/api-reference.mdx
@@ -79,6 +79,17 @@ Static badges — no API token required.
 | `/tokscale/active-days/{username}.svg` | Days with AI activity |
 | `/tokscale/stats.svg` | Global user count |
 
+### skills.sh
+
+| Endpoint | Description |
+|----------|-------------|
+| `/skills/{owner}/{repo}/{skill}.svg` | All-time install count (default) |
+| `/skills/installs/{owner}/{repo}/{skill}.svg` | All-time install count |
+| `/skills/rank/{owner}/{repo}/{skill}.svg` | All-time leaderboard rank (top 1000) |
+| `/skills/trending/{owner}/{repo}/{skill}.svg` | Trending leaderboard rank (top 500) |
+| `/skills/hot/{owner}/{repo}/{skill}.svg` | Hot (last 24h) leaderboard rank (top 500) |
+| `/skills/audit/{owner}/{repo}/{skill}.svg` | Security audit status (passed / warning / failed) |
+
 ### Country Flags
 
 | Endpoint | Description |

--- a/packages/web/content/docs/badges/meta.json
+++ b/packages/web/content/docs/badges/meta.json
@@ -46,6 +46,7 @@
     "weblate",
     "modrinth",
     "tokscale",
+    "skills",
     "flag",
     "group",
     "static",

--- a/packages/web/content/docs/badges/skills/index.mdx
+++ b/packages/web/content/docs/badges/skills/index.mdx
@@ -1,0 +1,195 @@
+---
+title: skills.sh
+description: Badges for skills.sh — agent skill installs, leaderboard rank, trending, hot, and security audits.
+badge: "/skills/installs/vercel-labs/agent-skills/frontend-design.svg?variant=branded"
+---
+
+Display live stats from [skills.sh](https://skills.sh), the open agent skills directory by Vercel. Show how many times your skill has been installed, where it sits on the leaderboard, and whether it passes security audits.
+
+<BadgePreviewGroup>
+  <BadgePreviewCard src="/skills/installs/vercel-labs/agent-skills/frontend-design.svg?variant=branded" alt="installs" description="Installs (branded)" />
+  <BadgePreviewCard src="/skills/rank/vercel-labs/agent-skills/frontend-design.svg?variant=secondary" alt="rank" description="All-time rank" />
+  <BadgePreviewCard src="/skills/trending/vercel-labs/agent-skills/frontend-design.svg?variant=branded" alt="trending" description="Trending rank (branded)" />
+  <BadgePreviewCard src="/skills/hot/vercel-labs/agent-skills/frontend-design.svg?variant=outline" alt="hot" description="Hot rank" />
+  <BadgePreviewCard src="/skills/audit/vercel-labs/agent-skills/frontend-design.svg?variant=outline" alt="audit" description="Security audit" />
+  <BadgePreviewCard src="/skills/installs/jal-co/shieldcn/shieldcn-badges.svg?variant=secondary" alt="shieldcn skill installs" description="Installs" />
+</BadgePreviewGroup>
+
+## Available badges
+
+| Badge | Endpoint | Description |
+|-------|----------|-------------|
+| Installs | `/skills/installs/{owner}/{repo}/{skill}` | All-time install count |
+| Rank | `/skills/rank/{owner}/{repo}/{skill}` | All-time leaderboard position |
+| Trending | `/skills/trending/{owner}/{repo}/{skill}` | Position on the trending leaderboard |
+| Hot | `/skills/hot/{owner}/{repo}/{skill}` | Position on the hot (last 24h) leaderboard |
+| Audit | `/skills/audit/{owner}/{repo}/{skill}` | Security audit status (passed / warning / failed) |
+
+The default endpoint `/skills/{owner}/{repo}/{skill}` returns the install count.
+
+## Quick examples
+
+<CodeLine language="markdown" code='![installs](https://shieldcn.dev/skills/installs/vercel-labs/agent-skills/frontend-design.svg)' />
+
+<CodeLine language="markdown" code='![skill rank](https://shieldcn.dev/skills/rank/vercel-labs/agent-skills/frontend-design.svg?variant=branded)' />
+
+<CodeLine language="markdown" code='![trending](https://shieldcn.dev/skills/trending/vercel-labs/agent-skills/frontend-design.svg)' />
+
+<CodeLine language="markdown" code='![audit](https://shieldcn.dev/skills/audit/vercel-labs/agent-skills/frontend-design.svg)' />
+
+## Finding your skill
+
+Skills are addressed as `{owner}/{repo}/{skill}` — the GitHub repository that hosts the skill plus the skill's slug:
+
+1. Publish a `SKILL.md` in a public GitHub repo (see the [skills.sh docs](https://www.skills.sh/docs)).
+2. The skill is indexed automatically after its first `npx skills add {owner}/{repo}` install.
+3. Find your skill page at `https://skills.sh/{owner}/{repo}/{skill}` — the badge path uses the same three segments.
+
+## Data source
+
+Uses the official [skills.sh API](https://www.skills.sh/docs/api). No API key required (a `SKILLS_SH_API_KEY` env var raises the rate limit when self-hosting). Install counts and ranks are cached 30 minutes, audits 1 hour. Rank scans the top 1000 skills — skills outside it show `1000+`. Trending and hot cover the top 500 and return a not-found badge when the skill isn't currently listed.
+
+## Endpoint details
+
+Use these sections when you need the exact URL shape or a focused example for a
+specific badge type.
+
+### Skill Installs
+
+This section covers the `skills/installs` badge endpoint.
+
+Show the all-time install count for a skill.
+
+<BadgeSandbox
+  endpoint="/skills/installs/:owner/:repo/:skill.svg"
+  pathParams={[
+    { name: "owner", label: "GitHub owner", placeholder: "vercel-labs", required: true },
+    { name: "repo", label: "Repository", placeholder: "agent-skills", required: true },
+    { name: "skill", label: "Skill slug", placeholder: "frontend-design", required: true },
+  ]}
+  defaults={{ owner: "vercel-labs", repo: "agent-skills", skill: "frontend-design" }}
+/>
+
+### URL format
+
+<CodeLine language="bash" code="/skills/installs/{owner}/{repo}/{skill}.svg" hideCopy />
+
+<CodeLine language="bash" code="/skills/{owner}/{repo}/{skill}.svg" hideCopy />
+
+Both formats return the same badge. The default endpoint shows the install count.
+
+### Examples
+
+<BadgePreviewGroup>
+  <BadgePreviewCard src="/skills/installs/vercel-labs/agent-skills/frontend-design.svg" alt="installs" description="Default variant" />
+  <BadgePreviewCard src="/skills/installs/vercel-labs/agent-skills/frontend-design.svg?variant=branded" alt="installs branded" description="Branded variant" />
+  <BadgePreviewCard src="/skills/installs/vercel-labs/agent-skills/frontend-design.svg?variant=secondary" alt="installs secondary" description="Secondary variant" />
+  <BadgePreviewCard src="/skills/installs/vercel-labs/agent-skills/frontend-design.svg?variant=outline" alt="installs outline" description="Outline variant" />
+</BadgePreviewGroup>
+
+### Copy-paste examples
+
+<BadgePreview src="/skills/installs/vercel-labs/agent-skills/frontend-design.svg" alt="skill installs" description="Default — all-time install count" />
+
+<BadgePreview src="/skills/installs/vercel-labs/agent-skills/frontend-design.svg?variant=branded" alt="skill installs" description="Branded — Vercel black with the ▲ logo" />
+
+### Skill Rank
+
+This section covers the `skills/rank` badge endpoint.
+
+Show the skill's position on the all-time skills.sh leaderboard. Covers the top 1000 — skills below that show `1000+`.
+
+<BadgeSandbox
+  endpoint="/skills/rank/:owner/:repo/:skill.svg"
+  pathParams={[
+    { name: "owner", label: "GitHub owner", placeholder: "vercel-labs", required: true },
+    { name: "repo", label: "Repository", placeholder: "agent-skills", required: true },
+    { name: "skill", label: "Skill slug", placeholder: "frontend-design", required: true },
+  ]}
+  defaults={{ owner: "vercel-labs", repo: "agent-skills", skill: "frontend-design" }}
+/>
+
+### URL format
+
+<CodeLine language="bash" code="/skills/rank/{owner}/{repo}/{skill}.svg" hideCopy />
+
+### Examples
+
+<BadgePreviewGroup>
+  <BadgePreviewCard src="/skills/rank/vercel-labs/agent-skills/frontend-design.svg" alt="rank" description="Default variant" />
+  <BadgePreviewCard src="/skills/rank/vercel-labs/agent-skills/frontend-design.svg?variant=branded" alt="rank branded" description="Branded variant" />
+  <BadgePreviewCard src="/skills/rank/vercel-labs/agent-skills/frontend-design.svg?variant=secondary" alt="rank secondary" description="Secondary variant" />
+  <BadgePreviewCard src="/skills/rank/vercel-labs/agent-skills/frontend-design.svg?variant=outline" alt="rank outline" description="Outline variant" />
+</BadgePreviewGroup>
+
+### Copy-paste examples
+
+<BadgePreview src="/skills/rank/vercel-labs/agent-skills/frontend-design.svg" alt="skill rank" description="Default — all-time leaderboard position" />
+
+<BadgePreview src="/skills/rank/vercel-labs/agent-skills/frontend-design.svg?variant=branded" alt="skill rank" description="Branded — Vercel black background" />
+
+### Trending & Hot
+
+These sections cover the `skills/trending` and `skills/hot` badge endpoints.
+
+Show the skill's position on the trending or hot (last 24h) leaderboards. Both cover the top 500 — a skill that isn't currently listed returns a not-found badge, so these work best for skills that are actively climbing.
+
+<BadgeSandbox
+  endpoint="/skills/trending/:owner/:repo/:skill.svg"
+  pathParams={[
+    { name: "owner", label: "GitHub owner", placeholder: "vercel-labs", required: true },
+    { name: "repo", label: "Repository", placeholder: "agent-skills", required: true },
+    { name: "skill", label: "Skill slug", placeholder: "frontend-design", required: true },
+  ]}
+  defaults={{ owner: "vercel-labs", repo: "agent-skills", skill: "frontend-design" }}
+/>
+
+### URL format
+
+<CodeLine language="bash" code="/skills/trending/{owner}/{repo}/{skill}.svg" hideCopy />
+
+<CodeLine language="bash" code="/skills/hot/{owner}/{repo}/{skill}.svg" hideCopy />
+
+### Examples
+
+<BadgePreviewGroup>
+  <BadgePreviewCard src="/skills/trending/vercel-labs/agent-skills/frontend-design.svg?variant=branded" alt="trending branded" description="Trending (branded)" />
+  <BadgePreviewCard src="/skills/trending/vercel-labs/agent-skills/frontend-design.svg?variant=secondary" alt="trending secondary" description="Trending (secondary)" />
+  <BadgePreviewCard src="/skills/hot/vercel-labs/agent-skills/frontend-design.svg?variant=outline" alt="hot outline" description="Hot (outline)" />
+  <BadgePreviewCard src="/skills/hot/vercel-labs/agent-skills/frontend-design.svg" alt="hot" description="Hot (default)" />
+</BadgePreviewGroup>
+
+### Skill Audit
+
+This section covers the `skills/audit` badge endpoint.
+
+Show the skill's security audit status. skills.sh runs audits from providers like Socket, Snyk, and Gen Agent Trust Hub after a skill's first install. The badge aggregates all audit results: `passed` (green), `warning` (amber), or `failed` (red).
+
+<BadgeSandbox
+  endpoint="/skills/audit/:owner/:repo/:skill.svg"
+  pathParams={[
+    { name: "owner", label: "GitHub owner", placeholder: "vercel-labs", required: true },
+    { name: "repo", label: "Repository", placeholder: "agent-skills", required: true },
+    { name: "skill", label: "Skill slug", placeholder: "frontend-design", required: true },
+  ]}
+  defaults={{ owner: "vercel-labs", repo: "agent-skills", skill: "frontend-design" }}
+/>
+
+### URL format
+
+<CodeLine language="bash" code="/skills/audit/{owner}/{repo}/{skill}.svg" hideCopy />
+
+### Examples
+
+<BadgePreviewGroup>
+  <BadgePreviewCard src="/skills/audit/vercel-labs/agent-skills/frontend-design.svg" alt="audit" description="Default variant" />
+  <BadgePreviewCard src="/skills/audit/vercel-labs/agent-skills/frontend-design.svg?variant=secondary" alt="audit secondary" description="Secondary variant" />
+  <BadgePreviewCard src="/skills/audit/vercel-labs/agent-skills/frontend-design.svg?variant=outline" alt="audit outline" description="Outline variant" />
+  <BadgePreviewCard src="/skills/audit/vercel-labs/agent-skills/frontend-design.svg?statusDot=true" alt="audit dot" description="With status dot" />
+</BadgePreviewGroup>
+
+### Copy-paste examples
+
+<BadgePreview src="/skills/audit/vercel-labs/agent-skills/frontend-design.svg" alt="skill audit" description="Default — aggregated audit verdict, color-coded" />
+
+<BadgePreview src="/skills/audit/vercel-labs/agent-skills/frontend-design.svg?variant=outline&statusDot=true" alt="skill audit" description="Outline with a status dot — reads like a CI badge" />

--- a/packages/web/content/docs/badges/skills/index.mdx
+++ b/packages/web/content/docs/badges/skills/index.mdx
@@ -1,18 +1,18 @@
 ---
 title: skills.sh
-description: Badges for skills.sh — agent skill installs, leaderboard rank, trending, hot, and security audits.
-badge: "/skills/installs/vercel-labs/agent-skills/frontend-design.svg?variant=branded"
+description: Badges for skills.sh — agent skill installs and leaderboard rank, trending, and hot positions.
+badge: "/skills/installs/vercel-labs/agent-skills/vercel-react-best-practices.svg?variant=branded"
 ---
 
-Display live stats from [skills.sh](https://skills.sh), the open agent skills directory by Vercel. Show how many times your skill has been installed, where it sits on the leaderboard, and whether it passes security audits.
+Display live stats from [skills.sh](https://www.skills.sh), the open agent skills directory by Vercel. Show how many times your skill has been installed and where it sits on the leaderboard.
 
 <BadgePreviewGroup>
-  <BadgePreviewCard src="/skills/installs/vercel-labs/agent-skills/frontend-design.svg?variant=branded" alt="installs" description="Installs (branded)" />
-  <BadgePreviewCard src="/skills/rank/vercel-labs/agent-skills/frontend-design.svg?variant=secondary" alt="rank" description="All-time rank" />
-  <BadgePreviewCard src="/skills/trending/vercel-labs/agent-skills/frontend-design.svg?variant=branded" alt="trending" description="Trending rank (branded)" />
-  <BadgePreviewCard src="/skills/hot/vercel-labs/agent-skills/frontend-design.svg?variant=outline" alt="hot" description="Hot rank" />
-  <BadgePreviewCard src="/skills/audit/vercel-labs/agent-skills/frontend-design.svg?variant=outline" alt="audit" description="Security audit" />
-  <BadgePreviewCard src="/skills/installs/jal-co/shieldcn/shieldcn-badges.svg?variant=secondary" alt="shieldcn skill installs" description="Installs" />
+  <BadgePreviewCard src="/skills/installs/vercel-labs/agent-skills/vercel-react-best-practices.svg?variant=branded" alt="installs" description="Installs (branded)" />
+  <BadgePreviewCard src="/skills/rank/vercel-labs/agent-skills/vercel-react-best-practices.svg?variant=secondary" alt="rank" description="All-time rank" />
+  <BadgePreviewCard src="/skills/trending/vercel-labs/agent-skills/vercel-react-best-practices.svg?variant=branded" alt="trending" description="Trending rank (branded)" />
+  <BadgePreviewCard src="/skills/hot/vercel-labs/agent-skills/vercel-react-best-practices.svg?variant=outline" alt="hot" description="Hot rank" />
+  <BadgePreviewCard src="/skills/installs/vercel-labs/agent-skills/web-design-guidelines.svg?variant=secondary" alt="web design guidelines installs" description="Installs" />
+  <BadgePreviewCard src="/skills/rank/anthropics/skills/frontend-design.svg?variant=outline" alt="frontend design rank" description="Rank" />
 </BadgePreviewGroup>
 
 ## Available badges
@@ -23,31 +23,30 @@ Display live stats from [skills.sh](https://skills.sh), the open agent skills di
 | Rank | `/skills/rank/{owner}/{repo}/{skill}` | All-time leaderboard position |
 | Trending | `/skills/trending/{owner}/{repo}/{skill}` | Position on the trending leaderboard |
 | Hot | `/skills/hot/{owner}/{repo}/{skill}` | Position on the hot (last 24h) leaderboard |
-| Audit | `/skills/audit/{owner}/{repo}/{skill}` | Security audit status (passed / warning / failed) |
 
 The default endpoint `/skills/{owner}/{repo}/{skill}` returns the install count.
 
 ## Quick examples
 
-<CodeLine language="markdown" code='![installs](https://shieldcn.dev/skills/installs/vercel-labs/agent-skills/frontend-design.svg)' />
+<CodeLine language="markdown" code='![installs](https://shieldcn.dev/skills/installs/vercel-labs/agent-skills/vercel-react-best-practices.svg)' />
 
-<CodeLine language="markdown" code='![skill rank](https://shieldcn.dev/skills/rank/vercel-labs/agent-skills/frontend-design.svg?variant=branded)' />
+<CodeLine language="markdown" code='![skill rank](https://shieldcn.dev/skills/rank/vercel-labs/agent-skills/vercel-react-best-practices.svg?variant=branded)' />
 
-<CodeLine language="markdown" code='![trending](https://shieldcn.dev/skills/trending/vercel-labs/agent-skills/frontend-design.svg)' />
+<CodeLine language="markdown" code='![trending](https://shieldcn.dev/skills/trending/vercel-labs/agent-skills/vercel-react-best-practices.svg)' />
 
-<CodeLine language="markdown" code='![audit](https://shieldcn.dev/skills/audit/vercel-labs/agent-skills/frontend-design.svg)' />
+<CodeLine language="markdown" code='![hot](https://shieldcn.dev/skills/hot/vercel-labs/agent-skills/vercel-react-best-practices.svg)' />
 
 ## Finding your skill
 
-Skills are addressed as `{owner}/{repo}/{skill}` — the GitHub repository that hosts the skill plus the skill's slug:
+Skills are addressed as `{owner}/{repo}/{skill}` — the GitHub repository that hosts the skill (`owner/repo`, the skills.sh `source`) plus the skill's slug:
 
 1. Publish a `SKILL.md` in a public GitHub repo (see the [skills.sh docs](https://www.skills.sh/docs)).
 2. The skill is indexed automatically after its first `npx skills add {owner}/{repo}` install.
-3. Find your skill page at `https://skills.sh/{owner}/{repo}/{skill}` — the badge path uses the same three segments.
+3. Find your skill page at `https://www.skills.sh/{owner}/{repo}/{skill}` — the badge path uses the same three segments. For example, `https://www.skills.sh/vercel-labs/agent-skills/vercel-react-best-practices` → `/skills/installs/vercel-labs/agent-skills/vercel-react-best-practices.svg`.
 
 ## Data source
 
-Uses the official [skills.sh API](https://www.skills.sh/docs/api). No API key required (a `SKILLS_SH_API_KEY` env var raises the rate limit when self-hosting). Install counts and ranks are cached 30 minutes, audits 1 hour. Rank scans the top 1000 skills — skills outside it show `1000+`. Trending and hot cover the top 500 and return a not-found badge when the skill isn't currently listed.
+Uses the public [skills.sh leaderboard API](https://www.skills.sh/docs/api) (`/api/skills/{view}/{page}`). No API key required — a `SKILLS_SH_API_KEY` env var raises the rate limit when self-hosting. Leaderboard pages are cached 30 minutes and shared across all badges. Rank and installs read the all-time leaderboard; trending and hot read their respective boards. Skills outside the top of a board return a not-found badge, so these work best for skills that are actively ranking.
 
 ## Endpoint details
 
@@ -65,9 +64,9 @@ Show the all-time install count for a skill.
   pathParams={[
     { name: "owner", label: "GitHub owner", placeholder: "vercel-labs", required: true },
     { name: "repo", label: "Repository", placeholder: "agent-skills", required: true },
-    { name: "skill", label: "Skill slug", placeholder: "frontend-design", required: true },
+    { name: "skill", label: "Skill slug", placeholder: "vercel-react-best-practices", required: true },
   ]}
-  defaults={{ owner: "vercel-labs", repo: "agent-skills", skill: "frontend-design" }}
+  defaults={{ owner: "vercel-labs", repo: "agent-skills", skill: "vercel-react-best-practices" }}
 />
 
 ### URL format
@@ -81,32 +80,32 @@ Both formats return the same badge. The default endpoint shows the install count
 ### Examples
 
 <BadgePreviewGroup>
-  <BadgePreviewCard src="/skills/installs/vercel-labs/agent-skills/frontend-design.svg" alt="installs" description="Default variant" />
-  <BadgePreviewCard src="/skills/installs/vercel-labs/agent-skills/frontend-design.svg?variant=branded" alt="installs branded" description="Branded variant" />
-  <BadgePreviewCard src="/skills/installs/vercel-labs/agent-skills/frontend-design.svg?variant=secondary" alt="installs secondary" description="Secondary variant" />
-  <BadgePreviewCard src="/skills/installs/vercel-labs/agent-skills/frontend-design.svg?variant=outline" alt="installs outline" description="Outline variant" />
+  <BadgePreviewCard src="/skills/installs/vercel-labs/agent-skills/vercel-react-best-practices.svg" alt="installs" description="Default variant" />
+  <BadgePreviewCard src="/skills/installs/vercel-labs/agent-skills/vercel-react-best-practices.svg?variant=branded" alt="installs branded" description="Branded variant" />
+  <BadgePreviewCard src="/skills/installs/vercel-labs/agent-skills/vercel-react-best-practices.svg?variant=secondary" alt="installs secondary" description="Secondary variant" />
+  <BadgePreviewCard src="/skills/installs/vercel-labs/agent-skills/vercel-react-best-practices.svg?variant=outline" alt="installs outline" description="Outline variant" />
 </BadgePreviewGroup>
 
 ### Copy-paste examples
 
-<BadgePreview src="/skills/installs/vercel-labs/agent-skills/frontend-design.svg" alt="skill installs" description="Default — all-time install count" />
+<BadgePreview src="/skills/installs/vercel-labs/agent-skills/vercel-react-best-practices.svg" alt="skill installs" description="Default — all-time install count" />
 
-<BadgePreview src="/skills/installs/vercel-labs/agent-skills/frontend-design.svg?variant=branded" alt="skill installs" description="Branded — Vercel black with the ▲ logo" />
+<BadgePreview src="/skills/installs/vercel-labs/agent-skills/vercel-react-best-practices.svg?variant=branded" alt="skill installs" description="Branded — Vercel black with the ▲ logo" />
 
 ### Skill Rank
 
 This section covers the `skills/rank` badge endpoint.
 
-Show the skill's position on the all-time skills.sh leaderboard. Covers the top 1000 — skills below that show `1000+`.
+Show the skill's position on the all-time skills.sh leaderboard.
 
 <BadgeSandbox
   endpoint="/skills/rank/:owner/:repo/:skill.svg"
   pathParams={[
     { name: "owner", label: "GitHub owner", placeholder: "vercel-labs", required: true },
     { name: "repo", label: "Repository", placeholder: "agent-skills", required: true },
-    { name: "skill", label: "Skill slug", placeholder: "frontend-design", required: true },
+    { name: "skill", label: "Skill slug", placeholder: "vercel-react-best-practices", required: true },
   ]}
-  defaults={{ owner: "vercel-labs", repo: "agent-skills", skill: "frontend-design" }}
+  defaults={{ owner: "vercel-labs", repo: "agent-skills", skill: "vercel-react-best-practices" }}
 />
 
 ### URL format
@@ -116,32 +115,32 @@ Show the skill's position on the all-time skills.sh leaderboard. Covers the top 
 ### Examples
 
 <BadgePreviewGroup>
-  <BadgePreviewCard src="/skills/rank/vercel-labs/agent-skills/frontend-design.svg" alt="rank" description="Default variant" />
-  <BadgePreviewCard src="/skills/rank/vercel-labs/agent-skills/frontend-design.svg?variant=branded" alt="rank branded" description="Branded variant" />
-  <BadgePreviewCard src="/skills/rank/vercel-labs/agent-skills/frontend-design.svg?variant=secondary" alt="rank secondary" description="Secondary variant" />
-  <BadgePreviewCard src="/skills/rank/vercel-labs/agent-skills/frontend-design.svg?variant=outline" alt="rank outline" description="Outline variant" />
+  <BadgePreviewCard src="/skills/rank/vercel-labs/agent-skills/vercel-react-best-practices.svg" alt="rank" description="Default variant" />
+  <BadgePreviewCard src="/skills/rank/vercel-labs/agent-skills/vercel-react-best-practices.svg?variant=branded" alt="rank branded" description="Branded variant" />
+  <BadgePreviewCard src="/skills/rank/vercel-labs/agent-skills/vercel-react-best-practices.svg?variant=secondary" alt="rank secondary" description="Secondary variant" />
+  <BadgePreviewCard src="/skills/rank/vercel-labs/agent-skills/vercel-react-best-practices.svg?variant=outline" alt="rank outline" description="Outline variant" />
 </BadgePreviewGroup>
 
 ### Copy-paste examples
 
-<BadgePreview src="/skills/rank/vercel-labs/agent-skills/frontend-design.svg" alt="skill rank" description="Default — all-time leaderboard position" />
+<BadgePreview src="/skills/rank/vercel-labs/agent-skills/vercel-react-best-practices.svg" alt="skill rank" description="Default — all-time leaderboard position" />
 
-<BadgePreview src="/skills/rank/vercel-labs/agent-skills/frontend-design.svg?variant=branded" alt="skill rank" description="Branded — Vercel black background" />
+<BadgePreview src="/skills/rank/vercel-labs/agent-skills/vercel-react-best-practices.svg?variant=branded" alt="skill rank" description="Branded — Vercel black background" />
 
 ### Trending & Hot
 
 These sections cover the `skills/trending` and `skills/hot` badge endpoints.
 
-Show the skill's position on the trending or hot (last 24h) leaderboards. Both cover the top 500 — a skill that isn't currently listed returns a not-found badge, so these work best for skills that are actively climbing.
+Show the skill's position on the trending or hot (last 24h) leaderboards. A skill that isn't currently listed returns a not-found badge, so these work best for skills that are actively climbing.
 
 <BadgeSandbox
   endpoint="/skills/trending/:owner/:repo/:skill.svg"
   pathParams={[
     { name: "owner", label: "GitHub owner", placeholder: "vercel-labs", required: true },
     { name: "repo", label: "Repository", placeholder: "agent-skills", required: true },
-    { name: "skill", label: "Skill slug", placeholder: "frontend-design", required: true },
+    { name: "skill", label: "Skill slug", placeholder: "vercel-react-best-practices", required: true },
   ]}
-  defaults={{ owner: "vercel-labs", repo: "agent-skills", skill: "frontend-design" }}
+  defaults={{ owner: "vercel-labs", repo: "agent-skills", skill: "vercel-react-best-practices" }}
 />
 
 ### URL format
@@ -153,43 +152,14 @@ Show the skill's position on the trending or hot (last 24h) leaderboards. Both c
 ### Examples
 
 <BadgePreviewGroup>
-  <BadgePreviewCard src="/skills/trending/vercel-labs/agent-skills/frontend-design.svg?variant=branded" alt="trending branded" description="Trending (branded)" />
-  <BadgePreviewCard src="/skills/trending/vercel-labs/agent-skills/frontend-design.svg?variant=secondary" alt="trending secondary" description="Trending (secondary)" />
-  <BadgePreviewCard src="/skills/hot/vercel-labs/agent-skills/frontend-design.svg?variant=outline" alt="hot outline" description="Hot (outline)" />
-  <BadgePreviewCard src="/skills/hot/vercel-labs/agent-skills/frontend-design.svg" alt="hot" description="Hot (default)" />
-</BadgePreviewGroup>
-
-### Skill Audit
-
-This section covers the `skills/audit` badge endpoint.
-
-Show the skill's security audit status. skills.sh runs audits from providers like Socket, Snyk, and Gen Agent Trust Hub after a skill's first install. The badge aggregates all audit results: `passed` (green), `warning` (amber), or `failed` (red).
-
-<BadgeSandbox
-  endpoint="/skills/audit/:owner/:repo/:skill.svg"
-  pathParams={[
-    { name: "owner", label: "GitHub owner", placeholder: "vercel-labs", required: true },
-    { name: "repo", label: "Repository", placeholder: "agent-skills", required: true },
-    { name: "skill", label: "Skill slug", placeholder: "frontend-design", required: true },
-  ]}
-  defaults={{ owner: "vercel-labs", repo: "agent-skills", skill: "frontend-design" }}
-/>
-
-### URL format
-
-<CodeLine language="bash" code="/skills/audit/{owner}/{repo}/{skill}.svg" hideCopy />
-
-### Examples
-
-<BadgePreviewGroup>
-  <BadgePreviewCard src="/skills/audit/vercel-labs/agent-skills/frontend-design.svg" alt="audit" description="Default variant" />
-  <BadgePreviewCard src="/skills/audit/vercel-labs/agent-skills/frontend-design.svg?variant=secondary" alt="audit secondary" description="Secondary variant" />
-  <BadgePreviewCard src="/skills/audit/vercel-labs/agent-skills/frontend-design.svg?variant=outline" alt="audit outline" description="Outline variant" />
-  <BadgePreviewCard src="/skills/audit/vercel-labs/agent-skills/frontend-design.svg?statusDot=true" alt="audit dot" description="With status dot" />
+  <BadgePreviewCard src="/skills/trending/vercel-labs/agent-skills/vercel-react-best-practices.svg?variant=branded" alt="trending branded" description="Trending (branded)" />
+  <BadgePreviewCard src="/skills/trending/vercel-labs/agent-skills/vercel-react-best-practices.svg?variant=secondary" alt="trending secondary" description="Trending (secondary)" />
+  <BadgePreviewCard src="/skills/hot/vercel-labs/agent-skills/vercel-react-best-practices.svg?variant=outline" alt="hot outline" description="Hot (outline)" />
+  <BadgePreviewCard src="/skills/hot/vercel-labs/agent-skills/vercel-react-best-practices.svg" alt="hot" description="Hot (default)" />
 </BadgePreviewGroup>
 
 ### Copy-paste examples
 
-<BadgePreview src="/skills/audit/vercel-labs/agent-skills/frontend-design.svg" alt="skill audit" description="Default — aggregated audit verdict, color-coded" />
+<BadgePreview src="/skills/trending/vercel-labs/agent-skills/vercel-react-best-practices.svg" alt="skill trending" description="Default — current trending position" />
 
-<BadgePreview src="/skills/audit/vercel-labs/agent-skills/frontend-design.svg?variant=outline&statusDot=true" alt="skill audit" description="Outline with a status dot — reads like a CI badge" />
+<BadgePreview src="/skills/hot/vercel-labs/agent-skills/vercel-react-best-practices.svg?variant=branded" alt="skill hot" description="Branded — hot (last 24h) position" />

--- a/packages/web/lib/showcase-data.ts
+++ b/packages/web/lib/showcase-data.ts
@@ -53,6 +53,7 @@ export const featuredBadges: ShowcaseBadge[] = [
   dynamicBadge("Bundle Size", "featured bundlephobia", "/bundlephobia/minzip/react.svg?variant=secondary", "Show how lightweight your package is.", "/docs/badges/bundlephobia"),
   dynamicBadge("Built in the USA", "featured location", "/flag/us.svg", "Country flag badge with a natural-aspect flag chip.", "/docs/badges/flag"),
   dynamicBadge("Ship It", "featured emoji", "/badge/ship-it.svg?logo=twemoji:\uD83D\uDE80&variant=secondary", "Any emoji as a logo, rendered via Twemoji.", "/docs/customization/logos"),
+  dynamicBadge("Skill Installs", "featured skills.sh", "/skills/installs/vercel-labs/agent-skills/frontend-design.svg?variant=branded", "Install count for an agent skill on skills.sh.", "/docs/badges/skills"),
 ]
 
 export const categories: Category[] = [
@@ -205,6 +206,16 @@ export const categories: Category[] = [
       dynamicBadge("WakaTime", "coding stats", "/wakatime/wakatime.svg?variant=branded", "WakaTime coding time badge.", "/docs/badges/wakatime"),
       dynamicBadge("Tokscale Tokens", "ai usage", "/tokscale/tokens/junhoyeo.svg?variant=branded", "Tokscale AI token usage.", "/docs/badges/tokscale"),
       dynamicBadge("Tokscale Rank", "ai usage", "/tokscale/rank/junhoyeo.svg?variant=secondary", "Tokscale leaderboard rank.", "/docs/badges/tokscale"),
+    ],
+  },
+  {
+    name: "Agent Skills",
+    description: "Badges for skills.sh — Vercel's open agent skills directory. Show installs, leaderboard rank, and security audit status for your skill.",
+    icons: [
+      dynamicBadge("Skill Installs", "social proof", "/skills/installs/vercel-labs/agent-skills/frontend-design.svg?variant=branded", "All-time install count for a skill on skills.sh.", "/docs/badges/skills"),
+      dynamicBadge("Skill Rank", "leaderboard", "/skills/rank/vercel-labs/agent-skills/frontend-design.svg?variant=secondary", "Position on the all-time skills.sh leaderboard.", "/docs/badges/skills"),
+      dynamicBadge("Skill Audit", "security", "/skills/audit/vercel-labs/agent-skills/frontend-design.svg?variant=outline", "Aggregated security audit verdict, color-coded.", "/docs/badges/skills"),
+      dynamicBadge("shieldcn Skill", "social proof", "/skills/installs/jal-co/shieldcn/shieldcn-badges.svg?variant=branded", "Installs of shieldcn's own agent skill — npx skills add jal-co/shieldcn.", "/docs/badges/skills"),
     ],
   },
   {

--- a/packages/web/lib/showcase-data.ts
+++ b/packages/web/lib/showcase-data.ts
@@ -53,7 +53,7 @@ export const featuredBadges: ShowcaseBadge[] = [
   dynamicBadge("Bundle Size", "featured bundlephobia", "/bundlephobia/minzip/react.svg?variant=secondary", "Show how lightweight your package is.", "/docs/badges/bundlephobia"),
   dynamicBadge("Built in the USA", "featured location", "/flag/us.svg", "Country flag badge with a natural-aspect flag chip.", "/docs/badges/flag"),
   dynamicBadge("Ship It", "featured emoji", "/badge/ship-it.svg?logo=twemoji:\uD83D\uDE80&variant=secondary", "Any emoji as a logo, rendered via Twemoji.", "/docs/customization/logos"),
-  dynamicBadge("Skill Installs", "featured skills.sh", "/skills/installs/vercel-labs/agent-skills/frontend-design.svg?variant=branded", "Install count for an agent skill on skills.sh.", "/docs/badges/skills"),
+  dynamicBadge("Skill Installs", "featured skills.sh", "/skills/installs/vercel-labs/agent-skills/vercel-react-best-practices.svg?variant=branded", "Install count for an agent skill on skills.sh.", "/docs/badges/skills"),
 ]
 
 export const categories: Category[] = [
@@ -210,12 +210,12 @@ export const categories: Category[] = [
   },
   {
     name: "Agent Skills",
-    description: "Badges for skills.sh — Vercel's open agent skills directory. Show installs, leaderboard rank, and security audit status for your skill.",
+    description: "Badges for skills.sh — Vercel's open agent skills directory. Show all-time installs and leaderboard rank for your agent skill.",
     icons: [
-      dynamicBadge("Skill Installs", "social proof", "/skills/installs/vercel-labs/agent-skills/frontend-design.svg?variant=branded", "All-time install count for a skill on skills.sh.", "/docs/badges/skills"),
-      dynamicBadge("Skill Rank", "leaderboard", "/skills/rank/vercel-labs/agent-skills/frontend-design.svg?variant=secondary", "Position on the all-time skills.sh leaderboard.", "/docs/badges/skills"),
-      dynamicBadge("Skill Audit", "security", "/skills/audit/vercel-labs/agent-skills/frontend-design.svg?variant=outline", "Aggregated security audit verdict, color-coded.", "/docs/badges/skills"),
-      dynamicBadge("shieldcn Skill", "social proof", "/skills/installs/jal-co/shieldcn/shieldcn-badges.svg?variant=branded", "Installs of shieldcn's own agent skill — npx skills add jal-co/shieldcn.", "/docs/badges/skills"),
+      dynamicBadge("Skill Installs", "social proof", "/skills/installs/vercel-labs/agent-skills/vercel-react-best-practices.svg?variant=branded", "All-time install count for a skill on skills.sh.", "/docs/badges/skills"),
+      dynamicBadge("Skill Rank", "leaderboard", "/skills/rank/vercel-labs/agent-skills/vercel-react-best-practices.svg?variant=secondary", "Position on the all-time skills.sh leaderboard.", "/docs/badges/skills"),
+      dynamicBadge("Trending Skill", "leaderboard", "/skills/trending/vercel-labs/agent-skills/vercel-react-best-practices.svg?variant=branded", "Position on the trending skills leaderboard.", "/docs/badges/skills"),
+      dynamicBadge("Web Design Guidelines", "social proof", "/skills/installs/vercel-labs/agent-skills/web-design-guidelines.svg?variant=outline", "Installs for another popular Vercel agent skill.", "/docs/badges/skills"),
     ],
   },
   {

--- a/skills/shieldcn-badges/SKILL.md
+++ b/skills/shieldcn-badges/SKILL.md
@@ -100,6 +100,16 @@ CI supports `?workflow=name&branch=main` query params.
 | VS Code installs | `/vscode/installs/{publisher}/{ext}` | `/vscode/installs/esbenp/prettier-vscode` |
 | WakaTime | `/wakatime/{username}` | `/wakatime/@user` |
 
+### Agent skills (skills.sh)
+
+| Badge | Endpoint | Example |
+|-------|----------|---------|
+| Skill installs | `/skills/installs/{owner}/{repo}/{skill}` | `/skills/installs/vercel-labs/agent-skills/frontend-design` |
+| Skill rank | `/skills/rank/{owner}/{repo}/{skill}` | `/skills/rank/vercel-labs/agent-skills/frontend-design` |
+| Trending rank | `/skills/trending/{owner}/{repo}/{skill}` | `/skills/trending/vercel-labs/agent-skills/frontend-design` |
+| Hot rank | `/skills/hot/{owner}/{repo}/{skill}` | `/skills/hot/vercel-labs/agent-skills/frontend-design` |
+| Audit status | `/skills/audit/{owner}/{repo}/{skill}` | `/skills/audit/vercel-labs/agent-skills/frontend-design` |
+
 ### Custom badges
 
 | Type | Endpoint | Example |

--- a/skills/shieldcn-badges/SKILL.md
+++ b/skills/shieldcn-badges/SKILL.md
@@ -102,13 +102,14 @@ CI supports `?workflow=name&branch=main` query params.
 
 ### Agent skills (skills.sh)
 
+Addressed as `{owner}/{repo}/{skill}` — the GitHub repo (skills.sh `source`) plus the skill slug.
+
 | Badge | Endpoint | Example |
 |-------|----------|---------|
-| Skill installs | `/skills/installs/{owner}/{repo}/{skill}` | `/skills/installs/vercel-labs/agent-skills/frontend-design` |
-| Skill rank | `/skills/rank/{owner}/{repo}/{skill}` | `/skills/rank/vercel-labs/agent-skills/frontend-design` |
-| Trending rank | `/skills/trending/{owner}/{repo}/{skill}` | `/skills/trending/vercel-labs/agent-skills/frontend-design` |
-| Hot rank | `/skills/hot/{owner}/{repo}/{skill}` | `/skills/hot/vercel-labs/agent-skills/frontend-design` |
-| Audit status | `/skills/audit/{owner}/{repo}/{skill}` | `/skills/audit/vercel-labs/agent-skills/frontend-design` |
+| Skill installs | `/skills/installs/{owner}/{repo}/{skill}` | `/skills/installs/vercel-labs/agent-skills/vercel-react-best-practices` |
+| Skill rank | `/skills/rank/{owner}/{repo}/{skill}` | `/skills/rank/vercel-labs/agent-skills/vercel-react-best-practices` |
+| Trending rank | `/skills/trending/{owner}/{repo}/{skill}` | `/skills/trending/vercel-labs/agent-skills/vercel-react-best-practices` |
+| Hot rank | `/skills/hot/{owner}/{repo}/{skill}` | `/skills/hot/vercel-labs/agent-skills/vercel-react-best-practices` |
 
 ### Custom badges
 


### PR DESCRIPTION
New /skills provider backed by the official skills.sh API (api/v1):
installs, all-time rank, trending, hot, and security audit badges,
addressed as /skills/{topic}/{owner}/{repo}/{skill}. Base badges
default to the Vercel logo, branded variant uses Vercel black.

- Provider scans cached leaderboard pages for rank (top 1000) and
  trending/hot (top 500); optional SKILLS_SH_API_KEY raises the
  upstream rate limit
- Docs page with sandboxes and examples, sidebar + API reference
  entries, Agent Skills showcase category, README and agent skill
  endpoint tables
- Hero headline now reads 'The badges your readme and SKILL.md
  crave.' with the announcement pointing at the new docs page

https://claude.ai/code/session_01Hj2JcBwH1WDSx5HLfAhAWU