### PR TITLE
feat(skills): use skills.sh v1 direct lookup with Vercel OIDC auth

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@resvg/resvg-wasm": "^2.6.2",
     "@upstash/redis": "^1.37.0",
+    "@vercel/oidc": "^3.6.1",
     "jsonpath-plus": "^10.4.0",
     "lru-cache": "^11.3.5",
     "modern-gif": "^2.1.0",

--- a/packages/core/src/providers/skills.test.ts
+++ b/packages/core/src/providers/skills.test.ts
@@ -2,68 +2,105 @@
  * shieldcn
  * lib/providers/skills.test
  *
- * Verifies the skills.sh provider against the public leaderboard envelope
- * (`/api/skills/{view}/{page}` → { skills: [{ source, skillId, name, installs }], hasMore }).
- * Real field names confirmed from the upstream API and many cached dumps.
- *
- * NOTE: leaderboard pages are cached module-globally by `{view}:{page}` (shared
- * across every skills badge — the intended optimization), so this file uses one
- * consistent board per view; cache hits across tests then stay correct.
+ * Verifies the skills.sh provider against the v1 API:
+ * - Direct lookup: `/api/v1/skills/{source}/{skill}` for installs
+ * - Leaderboard: `/api/v1/skills?view=...&page=...` for rank/trending/hot
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { getSkillsInstalls, getSkillsRank, getSkillsTrending, getSkillsHot } from "./skills"
 
 interface PageSkill {
+  id: string
   source: string
   skillId: string
+  slug: string
   name: string
   installs: number
 }
 
-const s = (source: string, skillId: string, installs: number): PageSkill =>
-  ({ source, skillId, name: skillId, installs })
+const s = (source: string, skillId: string, installs: number): PageSkill => ({
+  id: `${source}/${skillId}`,
+  source,
+  skillId,
+  slug: skillId,
+  name: skillId,
+  installs,
+})
 
-// A single stable board, mirroring the real top of the all-time leaderboard.
 const ALL_TIME: PageSkill[][] = [
   [
-    s("vercel-labs/agent-skills", "vercel-react-best-practices", 389226), // pos 1
-    s("vercel-labs/agent-skills", "web-design-guidelines", 96576),        // pos 2
+    s("vercel-labs/agent-skills", "vercel-react-best-practices", 389226),
+    s("vercel-labs/agent-skills", "web-design-guidelines", 96576),
   ],
   [
-    s("remotion-dev/skills", "remotion-best-practices", 17700),           // pos 3
-    s("anthropics/skills", "frontend-design", 6900),                      // pos 4
+    s("remotion-dev/skills", "remotion-best-practices", 17700),
+    s("anthropics/skills", "frontend-design", 6900),
   ],
 ]
 
 const TRENDING: PageSkill[][] = [[s("vercel-labs/agent-skills", "vercel-react-best-practices", 5)]]
 const HOT: PageSkill[][] = [
   [s("x/y", "a", 9)],
-  [s("vercel-labs/agent-skills", "vercel-react-best-practices", 5)], // pos 2
+  [s("vercel-labs/agent-skills", "vercel-react-best-practices", 5)],
 ]
 
+// Flat map of direct lookups: id → skill detail.
+// Only the all-time board carries canonical install counts.
+const DIRECT: Record<string, { id: string; installs: number }> = {}
+for (const page of ALL_TIME) {
+  for (const skill of page) {
+    DIRECT[skill.id] = { id: skill.id, installs: skill.installs }
+  }
+}
+
 beforeEach(() => {
+  // Mock @vercel/oidc to return no token (unauthenticated in tests)
+  vi.mock("@vercel/oidc", () => ({
+    getVercelOidcToken: async () => null,
+  }))
+
   const board: Record<string, PageSkill[][]> = { "all-time": ALL_TIME, trending: TRENDING, hot: HOT }
+
   vi.stubGlobal("fetch", vi.fn(async (url: string) => {
-    const m = url.match(/\/api\/skills\/([^/]+)\/(\d+)$/)
-    if (!m) return new Response("not found", { status: 404 })
-    const [, view, pageStr] = m
-    const pages = board[view] ?? []
-    const page = pages[Number(pageStr)] ?? []
-    const hasMore = Number(pageStr) < pages.length - 1
-    return new Response(JSON.stringify({ skills: page, hasMore }), {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    })
+    // Direct skill lookup: /api/v1/skills/{owner}/{repo}/{skill}
+    const directMatch = url.match(/\/api\/v1\/skills\/([^?][^/]+\/[^/]+\/[^/]+)$/)
+    if (directMatch) {
+      const id = directMatch[1]
+      const detail = DIRECT[id]
+      if (!detail) return new Response(JSON.stringify({ error: "not_found" }), { status: 404 })
+      return new Response(JSON.stringify(detail), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    }
+
+    // Leaderboard: /api/v1/skills?view=...&page=...
+    const leaderboardMatch = url.match(/\/api\/v1\/skills\?/)
+    if (leaderboardMatch) {
+      const u = new URL(url)
+      const view = u.searchParams.get("view") ?? "all-time"
+      const pageNum = Number(u.searchParams.get("page") ?? "0")
+      const pages = board[view] ?? []
+      const data = pages[pageNum] ?? []
+      const hasMore = pageNum < pages.length - 1
+      return new Response(JSON.stringify({ data, pagination: { hasMore } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    }
+
+    return new Response("not found", { status: 404 })
   }))
 })
 
 afterEach(() => {
   vi.unstubAllGlobals()
+  vi.restoreAllMocks()
 })
 
 describe("skills.sh provider", () => {
-  it("reads installs from the all-time board (formatted)", async () => {
+  it("reads installs via direct v1 lookup (formatted)", async () => {
     const data = await getSkillsInstalls("vercel-labs", "agent-skills", "vercel-react-best-practices")
     expect(data?.label).toBe("installs")
     expect(data?.value).toBe("389.2k")
@@ -77,12 +114,11 @@ describe("skills.sh provider", () => {
   })
 
   it("computes 1-based rank across pages and matches by source + skillId", async () => {
-    // frontend-design lives under anthropics/skills at the 4th position overall.
     const data = await getSkillsRank("anthropics", "skills", "frontend-design")
     expect(data?.value).toBe("#4")
   })
 
-  it("returns null when a skill isn't on the board", async () => {
+  it("returns null when a skill isn't found", async () => {
     const data = await getSkillsInstalls("nope", "nope", "missing-skill-xyz")
     expect(data).toBeNull()
   })

--- a/packages/core/src/providers/skills.ts
+++ b/packages/core/src/providers/skills.ts
@@ -6,9 +6,9 @@
  * Supports: installs, rank, trending, hot.
  * API: https://www.skills.sh/docs/api
  *
- * Uses the public leaderboard endpoint `/api/skills/{view}/{page}` which needs
- * no authentication. A skill is addressed as {owner}/{repo}/{skill}, matching
- * the upstream `source` ("owner/repo") plus `skillId`.
+ * Uses the v1 API for direct skill lookups (installs) and the paginated
+ * leaderboard for positional data (rank, trending, hot).
+ * Authentication via Vercel OIDC token (auto-minted on Vercel deployments).
  */
 
 import type { BadgeData } from "../badges/types"
@@ -19,6 +19,15 @@ import { providerFetch } from "../provider-fetch"
 // Types
 // ---------------------------------------------------------------------------
 
+/** Shape returned by /api/v1/skills/{source}/{skill} */
+interface V1SkillDetail {
+  id?: string
+  source?: string
+  slug?: string
+  installs?: number
+}
+
+/** Shape returned in leaderboard/search listing arrays */
 interface SkillsShSkill {
   id?: string
   source?: string
@@ -28,39 +37,86 @@ interface SkillsShSkill {
   installs?: number
 }
 
-/** Leaderboard page. Field names vary slightly across skills.sh tiers. */
+/** Leaderboard page (v1 and legacy shapes) */
 interface SkillsShPage {
   skills?: SkillsShSkill[]
   data?: SkillsShSkill[]
   results?: SkillsShSkill[]
   hasMore?: boolean
-  pagination?: { hasMore?: boolean }
+  pagination?: { hasMore?: boolean; total?: number }
 }
 
 type View = "all-time" | "trending" | "hot"
 
 // ---------------------------------------------------------------------------
-// Fetch helpers
+// Auth
 // ---------------------------------------------------------------------------
 
-// Canonical host — skills.sh redirects to www, so target www directly.
-const API_BASE = "https://www.skills.sh/api"
+const API_BASE = "https://www.skills.sh/api/v1"
 
-/** How many leaderboard pages to scan before giving up on a skill. */
-const MAX_PAGES = 5
+/**
+ * Get auth headers for skills.sh API.
+ * Prefers Vercel OIDC token (available on Vercel deployments), falls back to
+ * explicit SKILLS_SH_API_KEY env var.
+ */
+async function getAuthHeaders(): Promise<HeadersInit> {
+  // Try Vercel OIDC first (available on Vercel deployments)
+  try {
+    const { getVercelOidcToken } = await import("@vercel/oidc")
+    const token = await getVercelOidcToken()
+    if (token) return { Authorization: `Bearer ${token}` }
+  } catch {
+    // Not on Vercel or @vercel/oidc not available — fall through
+  }
 
-/** Optional API key raises the skills.sh rate limit (60 → 600 req/min). */
-function authHeaders(): HeadersInit {
+  // Fall back to raw env var (works with `vercel env pull` locally)
+  const oidc = process.env.VERCEL_OIDC_TOKEN
+  if (oidc) return { Authorization: `Bearer ${oidc}` }
+
+  // Legacy: explicit API key
   const key = process.env.SKILLS_SH_API_KEY
-  return key ? { Authorization: `Bearer ${key}` } : {}
+  if (key) return { Authorization: `Bearer ${key}` }
+
+  return {}
 }
 
+// ---------------------------------------------------------------------------
+// Direct skill lookup (v1 API)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch a single skill's details via the v1 direct endpoint.
+ * Returns install count without needing to scan the leaderboard.
+ */
+async function fetchSkillDirect(
+  owner: string,
+  repo: string,
+  skill: string
+): Promise<V1SkillDetail | null> {
+  const headers = await getAuthHeaders()
+  return providerFetch<V1SkillDetail>({
+    provider: "skills",
+    cacheKey: `v1:${owner}/${repo}/${skill}`,
+    url: `${API_BASE}/skills/${owner}/${repo}/${skill}`,
+    headers,
+    ttl: 300, // 5 min, matching upstream Cache-Control
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Leaderboard scan (for rank / trending / hot)
+// ---------------------------------------------------------------------------
+
+/** How many leaderboard pages to scan before giving up on a skill. */
+const MAX_PAGES = 10
+
 async function fetchLeaderboardPage(view: View, page: number): Promise<SkillsShPage | null> {
+  const headers = await getAuthHeaders()
   return providerFetch<SkillsShPage>({
     provider: "skills",
     cacheKey: `board:${view}:${page}`,
-    url: `${API_BASE}/skills/${view}/${page}`,
-    headers: authHeaders(),
+    url: `${API_BASE}/skills?view=${view}&page=${page}&per_page=100`,
+    headers,
     ttl: 1800,
   })
 }
@@ -77,16 +133,10 @@ function matchesSkill(item: SkillsShSkill, owner: string, repo: string, skill: s
 }
 
 interface ScanHit {
-  /** 1-based position on the leaderboard. */
   rank: number
   installs: number | null
 }
 
-/**
- * Scan a leaderboard view for a skill, returning its position and install
- * count. Pages are cached (30 min) and shared across every skills badge, so a
- * warm scan costs nothing. Stops as soon as the skill is found.
- */
 async function scanLeaderboard(
   view: View,
   owner: string,
@@ -111,6 +161,10 @@ async function scanLeaderboard(
   return null
 }
 
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
 function skillLink(owner: string, repo: string, skill: string): string {
   return `https://www.skills.sh/${owner}/${repo}/${skill}`
 }
@@ -120,6 +174,17 @@ function skillLink(owner: string, repo: string, skill: string): string {
 // ---------------------------------------------------------------------------
 
 export async function getSkillsInstalls(owner: string, repo: string, skill: string): Promise<BadgeData | null> {
+  // Use direct v1 lookup — works for any skill, not just top-ranked
+  const detail = await fetchSkillDirect(owner, repo, skill)
+  if (detail && typeof detail.installs === "number") {
+    return {
+      label: "installs",
+      value: formatCount(detail.installs),
+      link: skillLink(owner, repo, skill),
+    }
+  }
+
+  // Fallback: scan leaderboard (covers edge cases where v1 is down)
   const hit = await scanLeaderboard("all-time", owner, repo, skill)
   if (!hit || hit.installs === null) return null
   return {

--- a/packages/web/.gitignore
+++ b/packages/web/.gitignore
@@ -1,1 +1,2 @@
 .vercel
+.env*.local

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@upstash/redis':
         specifier: ^1.37.0
         version: 1.37.0
+      '@vercel/oidc':
+        specifier: ^3.6.1
+        version: 3.6.1
       jsonpath-plus:
         specifier: ^10.4.0
         version: 10.4.0
@@ -2725,6 +2728,17 @@ packages:
   '@upstash/redis@1.37.0':
     resolution: {integrity: sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==}
 
+  '@vercel/cli-config@0.2.0':
+    resolution: {integrity: sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==}
+
+  '@vercel/cli-exec@0.1.1':
+    resolution: {integrity: sha512-LMRMEai3Z+BODyxGcU9+KiWrS/UElNiOLKiNRfGNt2Vu3NTEmXgFeXG9wBfocAnTe5yJCX/DY6k3k7S/LkPp/g==}
+    engines: {node: '>= 18'}
+
+  '@vercel/oidc@3.6.1':
+    resolution: {integrity: sha512-8ipTFoiX3WBRrvXLjSrmgAiwtMDQk3EgSxe8N7v2rXBz39NBIIyoGXeVbJRoBcP8WEuVnvjvIQsggbGU7ZKrMw==}
+    engines: {node: '>= 20'}
+
   '@vitest/expect@3.2.6':
     resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
 
@@ -4443,6 +4457,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
+
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
@@ -5135,6 +5152,10 @@ packages:
   ora@8.2.0:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
+
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
 
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
@@ -6391,6 +6412,14 @@ packages:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
 
+  xdg-app-paths@5.5.1:
+    resolution: {integrity: sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==}
+    engines: {node: '>= 6.0'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -6443,6 +6472,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -8792,6 +8824,21 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
+  '@vercel/cli-config@0.2.0':
+    dependencies:
+      xdg-app-paths: 5.5.1
+      zod: 4.1.11
+
+  '@vercel/cli-exec@0.1.1':
+    dependencies:
+      execa: 5.1.1
+
+  '@vercel/oidc@3.6.1':
+    dependencies:
+      '@vercel/cli-config': 0.2.0
+      '@vercel/cli-exec': 0.1.1
+      jose: 5.10.0
+
   '@vitest/expect@3.2.6':
     dependencies:
       '@types/chai': 5.2.3
@@ -10790,6 +10837,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@5.10.0: {}
+
   jose@6.2.3: {}
 
   joycon@3.1.1: {}
@@ -11722,6 +11771,8 @@ snapshots:
       stdin-discarder: 0.2.2
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  os-paths@4.4.0: {}
 
   outvariant@1.4.3: {}
 
@@ -13346,6 +13397,15 @@ snapshots:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
+  xdg-app-paths@5.5.1:
+    dependencies:
+      os-paths: 4.4.0
+      xdg-portable: 7.3.0
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
+
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
@@ -13385,6 +13445,8 @@ snapshots:
       zod: 4.3.6
 
   zod@3.25.76: {}
+
+  zod@4.1.11: {}
 
   zod@4.3.6: {}
 


### PR DESCRIPTION
## What

Switch the skills.sh provider from leaderboard-scanning to the v1 direct lookup endpoint (`/api/v1/skills/{source}/{skill}`) for installs badges, authenticated via Vercel OIDC.

## Why

Installs badges returned **not found** for any skill outside the top ~500 of the all-time leaderboard. The old provider had no direct lookup — it scanned paginated leaderboard results (max 5 pages) and gave up if the skill wasn't ranked high enough.

Example: `/skills/installs/usenotra/skills/brand-logos.svg` (20 installs) was never found because it isn't a top-ranked skill.

The v1 `/api/v1/skills/{source}/{skill}` endpoint returns exact install counts for **any** skill, but requires Vercel OIDC authentication.

## How

- Add `@vercel/oidc` and a `getAuthHeaders()` helper that mints a request-scoped OIDC token, with fallbacks to `VERCEL_OIDC_TOKEN` then `SKILLS_SH_API_KEY`
- `getSkillsInstalls()` now uses the direct v1 lookup, falling back to a leaderboard scan only if v1 is unavailable
- Migrate all endpoints to the `/api/v1` base; bump `MAX_PAGES` 5 → 10 for positional badges (rank/trending/hot)
- Update tests for the v1 direct + leaderboard response shapes

## Testing

Verified locally with `vercel env pull` (OIDC token) + dev server:

```
$ curl .../skills/installs/usenotra/skills/brand-logos.json
{"label":"installs","value":"20","link":"https://www.skills.sh/usenotra/skills/brand-logos"}
```

- Installs badge (JSON + branded SVG) resolves correctly
- `rank` still returns not found for low-ranked skills — expected, positional badges are inherently leaderboard-bound
- All 67 `@shieldcn/core` tests pass; `tsc --noEmit` clean

## Deploy notes

- **OIDC Federation** is already enabled on the Vercel project (Team issuer mode, scoped to `project:shieldcn`)
- The self-hosted `engine` (Docker, not on Vercel) won't have OIDC — set `SKILLS_SH_API_KEY` there for skills badges
