### PR TITLE
fix(badges): self-heal stale GitHub badges and survive DB autosuspend

### DIFF
--- a/packages/core/src/badges/types.ts
+++ b/packages/core/src/badges/types.ts
@@ -142,4 +142,13 @@ export interface BadgeData {
    * instead of being pinned at the CDN like a success.
    */
   error?: boolean
+  /**
+   * Marks a value served from the last-known-good ("stale") store because the
+   * live upstream fetch failed. The data is real and renderable, but it may be
+   * out of date — so the route serves it with short cache headers (like an
+   * error) instead of pinning it at the CDN for an hour. That way the badge
+   * picks up fresh data within ~a minute of the upstream recovering rather than
+   * staying frozen for up to the full success-cache window.
+   */
+  stale?: boolean
 }

--- a/packages/core/src/cache.test.ts
+++ b/packages/core/src/cache.test.ts
@@ -80,6 +80,36 @@ describe("cachedFetchStale", () => {
     expect(await cacheGet(staleKey)).toEqual({ label: "stars", value: "325" })
   })
 
+  it("invokes onStale only when it serves a last-known-good value, not on a fresh fetch", async () => {
+    // Fresh success → onStale must NOT fire.
+    const okKey = freshKey()
+    let okStaleHits = 0
+    const ok = await cachedFetchStale(
+      "test", okKey,
+      vi.fn().mockResolvedValue({ label: "stars", value: "1" }),
+      300, 3600,
+      { onStale: () => { okStaleHits++ } },
+    )
+    expect(ok).toEqual({ label: "stars", value: "1" })
+    expect(okStaleHits).toBe(0)
+
+    // Seed last-known-good directly (fresh store stays empty), then fail the
+    // fetch → last-known-good is served → onStale fires exactly once.
+    const key = freshKey()
+    const staleKey = `shieldcn:test:stale:${key}`
+    await cacheSet(staleKey, { label: "stars", value: "325" }, 3600)
+
+    let staleHits = 0
+    const stale = await cachedFetchStale(
+      "test", key,
+      vi.fn().mockResolvedValue(null),
+      300, 3600,
+      { onStale: () => { staleHits++ } },
+    )
+    expect(stale).toEqual({ label: "stars", value: "325" })
+    expect(staleHits).toBe(1)
+  })
+
   it("returns null when a fetch fails and there is no prior good value", async () => {
     const key = freshKey()
     const result = await cachedFetchStale(
@@ -128,6 +158,36 @@ describe("provider alerts", () => {
 
     expect(result).toEqual({ label: "x", value: "1" })
     expect(alerts).toHaveLength(0)
+  })
+
+  it("escalates a 'stale' alert when the last-known-good value served is very old", async () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"))
+      const key = freshKey()
+      const staleKey = `shieldcn:test:stale:${key}`
+      // Seed last-known-good "now"; fresh store stays empty so the fetch runs.
+      // Long TTL keeps the entry alive (lru TTL uses performance.now, which the
+      // fake Date clock doesn't advance) while its Date-based timestamp ages.
+      await cacheSet(staleKey, { label: "x", value: "1" }, 7 * 24 * 3600)
+
+      // 90 minutes pass with the upstream still broken.
+      vi.setSystemTime(new Date("2026-01-01T01:30:00Z"))
+
+      const alerts: ProviderAlert[] = []
+      setProviderAlertCallback((a) => alerts.push(a))
+
+      const stale = await cachedFetchStale(
+        "test", key,
+        vi.fn().mockResolvedValue(null),
+        300, 7 * 24 * 3600,
+      )
+      expect(stale).toEqual({ label: "x", value: "1" })
+      expect(alerts.filter((a) => a.reason === "stale")).toHaveLength(1)
+      expect(alerts.find((a) => a.reason === "stale")).toMatchObject({ provider: "test" })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("alerts any provider once per backoff cycle on a rate limit", async () => {

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -218,9 +218,20 @@ function cacheKey(provider: string, ...parts: string[]): string {
  * Returns undefined on miss.
  */
 export async function cacheGet<T>(key: string): Promise<T | undefined> {
+  const entry = await cacheGetEntry<T>(key)
+  return entry?.data
+}
+
+/**
+ * Like {@link cacheGet} but returns the full cache entry, including `ts` (the
+ * time the value was written). Callers that need to reason about how old a
+ * cached value is — e.g. to escalate when a last-known-good value has been
+ * served for too long — use this instead of {@link cacheGet}.
+ */
+export async function cacheGetEntry<T>(key: string): Promise<CachedValue<T> | undefined> {
   // Tier 1: memory
   const mem = memoryCache.get(key) as CachedValue<T> | undefined
-  if (mem) return mem.data
+  if (mem) return mem
 
   // Tier 2: Redis
   const r = getRedis()
@@ -230,7 +241,7 @@ export async function cacheGet<T>(key: string): Promise<T | undefined> {
       if (val) {
         // Backfill memory cache
         memoryCache.set(key, val as CachedValue<unknown>)
-        return val.data
+        return val
       }
     } catch {
       // Redis unavailable, continue without it
@@ -313,7 +324,7 @@ export interface ProviderAlert {
   /** Provider name, e.g. "github". */
   provider: string
   /** What went wrong — used for triage and Sentry grouping. */
-  reason: "rate_limit" | "unavailable" | "badge_unavailable"
+  reason: "rate_limit" | "unavailable" | "badge_unavailable" | "stale"
   /** HTTP status, when applicable (e.g. 429, 503). */
   status?: number
   /** Stable human-readable summary (avoid per-request detail here). */
@@ -340,6 +351,48 @@ export function reportProviderAlert(alert: ProviderAlert): void {
   } catch {
     // Alerting must never break a badge response.
   }
+}
+
+// ---------------------------------------------------------------------------
+// Stale-served escalation
+// ---------------------------------------------------------------------------
+//
+// Serving last-known-good is normal and healthy for a brief upstream blip. But
+// when a badge has been served from the stale store for a long time, the
+// upstream (or the GitHub token pool / DB behind it) is genuinely broken and
+// the badge is silently frozen — exactly the failure that otherwise goes
+// unnoticed for days. Escalate to a Sentry alert when that happens, throttled
+// so one frozen badge doesn't spam an alert per request.
+
+/** Escalate when a last-known-good value has been frozen longer than this. */
+const STALE_ALERT_AFTER_MS = 60 * 60 * 1000 // 1 hour
+/** At most one stale alert per provider+key within this window. */
+const STALE_ALERT_THROTTLE_MS = 60 * 60 * 1000 // 1 hour
+
+const staleAlerted = new Map<string, number>()
+
+/**
+ * Emit a throttled "stale" alert when a last-known-good value served from the
+ * stale store is older than {@link STALE_ALERT_AFTER_MS}. `ts` is the time the
+ * value was last written (i.e. the last successful upstream fetch), so
+ * `now - ts` is exactly how long the badge has been frozen.
+ */
+function maybeAlertStale(provider: string, key: string, ts: number): void {
+  const age = Date.now() - ts
+  if (age < STALE_ALERT_AFTER_MS) return
+
+  const alertKey = `${provider}:${key}`
+  const last = staleAlerted.get(alertKey)
+  const now = Date.now()
+  if (last && now - last < STALE_ALERT_THROTTLE_MS) return
+  staleAlerted.set(alertKey, now)
+
+  reportProviderAlert({
+    provider,
+    reason: "stale",
+    message: `${provider} serving stale last-known-good (>${Math.round(STALE_ALERT_AFTER_MS / 60000)}m old) — upstream likely broken`,
+    context: { key, ageMs: String(age) },
+  })
 }
 
 export async function cachedFetch<T>(
@@ -441,7 +494,16 @@ export async function cachedFetchStale<T>(
   fetcher: () => Promise<T | null>,
   freshTtl: number = 300,
   staleTtl: number = 60 * 60 * 24 * 7,
-  opts?: { isError?: (data: T) => boolean; errorTtl?: number },
+  opts?: {
+    isError?: (data: T) => boolean
+    errorTtl?: number
+    /**
+     * Called when the returned value came from the last-known-good ("stale")
+     * store rather than a fresh fetch. The caller uses this to serve the
+     * response with short cache headers so it self-heals quickly.
+     */
+    onStale?: () => void
+  },
 ): Promise<T | null> {
   const freshKey = cacheKey(provider, key)
   const staleKey = cacheKey(provider, "stale", key)
@@ -465,13 +527,17 @@ export async function cachedFetchStale<T>(
   // value to fall back to) so it shows up in Sentry rather than silently
   // rendering "not found".
   const serveStale = async (): Promise<T | null> => {
-    const stale = await cacheGet<T>(staleKey)
-    if (stale !== undefined) {
+    const staleEntry = await cacheGetEntry<T>(staleKey)
+    if (staleEntry !== undefined) {
       cacheMetricsCallback?.({
         type: "counter", name: "badge.cache", value: 1,
         tags: { provider, result: "stale" },
       })
-      return stale
+      // Tell the caller this is last-known-good (so it can shorten cache
+      // headers) and escalate if the badge has been frozen for too long.
+      opts?.onStale?.()
+      maybeAlertStale(provider, key, staleEntry.ts)
+      return staleEntry.data
     }
     reportProviderAlert({
       provider,

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -5,7 +5,7 @@
  * Postgres connection + schema initialization.
  */
 
-import { Pool } from "pg"
+import { Pool, type PoolClient, type QueryResult, type QueryResultRow } from "pg"
 
 let pool: Pool | null = null
 
@@ -15,6 +15,18 @@ export function getPool(): Pool {
     pool = new Pool({
       connectionString: connString,
       max: 5,
+      // The pool is designed to let a serverless Postgres (e.g. Neon) autosuspend
+      // when badge traffic is served from the in-memory token cache. Two settings
+      // make the next request after a suspend reliable rather than handing out a
+      // dead socket:
+      //   - idleTimeoutMillis: close our own idle connections quickly, before the
+      //     provider tears them down on suspend, so we rarely hold a dead client.
+      //   - connectionTimeoutMillis: bound how long a brand-new connection waits
+      //     while the database wakes, so a hung connect fails fast and `query()`
+      //     can retry instead of stalling the request.
+      idleTimeoutMillis: 10_000,
+      connectionTimeoutMillis: 10_000,
+      keepAlive: true,
       // Enable SSL for known cloud providers or explicit sslmode=require.
       // Docker/local Postgres connections default to no SSL.
       ssl: connString && (
@@ -26,17 +38,76 @@ export function getPool(): Pool {
         ? { rejectUnauthorized: false }
         : undefined,
     })
+    // node-postgres emits 'error' on idle clients that the server drops (exactly
+    // what happens when a serverless DB suspends). Without a listener this throws
+    // and can crash the process; swallow it — the dead client is removed from the
+    // pool and the next checkout opens a fresh one.
+    pool.on("error", () => {})
   }
   return pool
 }
+
+/**
+ * True when an error looks like a transient connection failure (server dropped
+ * an idle socket, a wake-from-suspend race, a connect timeout) rather than a
+ * real query/logic error. These are safe to retry once with a fresh connection.
+ */
+function isTransientConnectionError(err: unknown): boolean {
+  const e = err as { code?: string; message?: string } | undefined
+  if (!e) return false
+  const code = e.code
+  if (code && [
+    "ECONNRESET", "ECONNREFUSED", "ETIMEDOUT", "EPIPE", "ENOTFOUND",
+    "57P01", // admin_shutdown — server terminated the connection
+    "57P03", // cannot_connect_now — server still starting up (waking)
+    "08006", // connection_failure
+    "08001", // sqlclient_unable_to_establish_sqlconnection
+    "08003", // connection_does_not_exist
+  ].includes(code)) return true
+  const msg = e.message ?? ""
+  return (
+    msg.includes("Connection terminated") ||
+    msg.includes("connection timeout") ||
+    msg.includes("timeout exceeded when trying to connect") ||
+    msg.includes("terminating connection") ||
+    msg.includes("Client has encountered a connection error")
+  )
+}
+
+/**
+ * Run a query with one retry on a transient connection failure.
+ *
+ * A serverless Postgres that has autosuspended often rejects the very first
+ * query (the pool hands out a socket the server already closed, or the connect
+ * races the wake) but succeeds on the retry once it's awake. Routing all DB
+ * access through here means a wake-from-suspend shows up as a ~1s slower request
+ * instead of a hard failure — which is what surfaced as "db store failed" when
+ * users tried to add a token to the pool.
+ */
+export async function query<R extends QueryResultRow = QueryResultRow>(
+  text: string,
+  params?: unknown[],
+): Promise<QueryResult<R>> {
+  const db = getPool()
+  try {
+    return await db.query<R>(text, params as never)
+  } catch (err) {
+    if (!isTransientConnectionError(err)) throw err
+    // Brief pause to let the database finish waking, then retry once on a fresh
+    // connection from the pool.
+    await new Promise((r) => setTimeout(r, 250))
+    return await db.query<R>(text, params as never)
+  }
+}
+
+export type { PoolClient }
 
 /**
  * Initialize the database schema.
  * Called on first request or at startup.
  */
 export async function initDB() {
-  const db = getPool()
-  await db.query(`
+  await query(`
     CREATE TABLE IF NOT EXISTS github_tokens (
       id SERIAL PRIMARY KEY,
       github_user TEXT NOT NULL UNIQUE,

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -536,6 +536,7 @@ async function fetchBadgeData(
       const wf = searchParams.get("workflow")
       const br = searchParams.get("branch")
       const ghKey = rest.join("/") + (wf ? `|wf=${wf}` : "") + (br ? `|br=${br}` : "")
+      let servedStale = false
       const ghData = await cachedFetchStale(
         "github",
         ghKey,
@@ -545,9 +546,21 @@ async function fetchBadgeData(
         // An "invalid repository" verdict is a terminal error, not a value:
         // cache it briefly and never persist it as last-known-good, so a repo
         // that later becomes available self-heals quickly.
-        { isError: (d) => d.error === true, errorTtl: GITHUB_ERROR_TTL },
+        {
+          isError: (d) => d.error === true,
+          errorTtl: GITHUB_ERROR_TTL,
+          onStale: () => { servedStale = true },
+        },
       )
-      if (ghData !== null) return ghData
+      if (ghData !== null) {
+        // A last-known-good value is real and renderable, but possibly out of
+        // date — flag it so the route serves it with short cache headers and it
+        // refreshes within ~a minute of GitHub recovering instead of being
+        // pinned at the CDN for the full success-cache window. Don't re-mark a
+        // terminal-error verdict (already short-cached via `error`).
+        if (servedStale && !ghData.error) return { ...ghData, stale: true }
+        return ghData
+      }
 
       // No data and no last-known-good. When GitHub is in a backoff window
       // the fetcher was never called, so the transient-failure verdict from
@@ -1617,11 +1630,11 @@ async function handleBadgeGroup(
     })
   )
 
-  // If any segment fell back to "not found" or carries a terminal-error
-  // verdict (e.g. "unavailable"), treat the whole group as an error response
-  // so the failure self-heals quickly instead of being pinned at the CDN
-  // for an hour.
-  const groupCacheHeaders = allData.some(({ data }) => !data || data.error)
+  // If any segment fell back to "not found", carries a terminal-error verdict
+  // (e.g. "unavailable"), or is a last-known-good value served because the live
+  // fetch failed (`stale`), treat the whole group as an error response so it
+  // self-heals quickly instead of being pinned at the CDN for an hour.
+  const groupCacheHeaders = allData.some(({ data }) => !data || data.error || data.stale)
     ? ERROR_CACHE_HEADERS
     : CACHE_HEADERS
 
@@ -1870,10 +1883,13 @@ async function handleBadgeGETInner(
     )
   }
 
-  // A terminal-error verdict (e.g. a genuine 404 → "invalid repository")
-  // renders a real badge but must not be cached like a success — short
-  // headers let it self-heal quickly instead of being pinned at the CDN.
-  const dataCacheHeaders = data.error ? ERROR_CACHE_HEADERS : CACHE_HEADERS
+  // A terminal-error verdict (e.g. a genuine 404 → "invalid repository") or a
+  // last-known-good value served because the live fetch failed (`stale`)
+  // renders a real badge but must not be cached like a success — short headers
+  // let it self-heal quickly instead of being pinned at the CDN. `stale` in
+  // particular ensures a frozen badge picks up fresh data within ~a minute of
+  // the upstream recovering, not up to an hour later.
+  const dataCacheHeaders = data.error || data.stale ? ERROR_CACHE_HEADERS : CACHE_HEADERS
 
   // JSON response
   if (format === "json") {

--- a/packages/core/src/token-pool.ts
+++ b/packages/core/src/token-pool.ts
@@ -13,7 +13,7 @@
  */
 
 import { createHash, createCipheriv, createDecipheriv, randomBytes } from "node:crypto"
-import { getPool, initDB } from "./db"
+import { query, initDB } from "./db"
 
 let initialized = false
 
@@ -118,9 +118,8 @@ function hashToken(token: string): string {
  */
 export async function addToken(githubUser: string, accessToken: string) {
   await ensureInit()
-  const db = getPool()
   const encrypted = encryptToken(accessToken)
-  await db.query(
+  await query(
     `INSERT INTO github_tokens (github_user, access_token, is_valid)
      VALUES ($1, $2, TRUE)
      ON CONFLICT (github_user)
@@ -147,19 +146,18 @@ export async function pickToken(): Promise<string | undefined> {
 
   try {
     await ensureInit()
-    const db = getPool()
 
     // Occasionally sweep invalid tokens that haven't healed in 7 days.
     // Kept off the per-request path — this is housekeeping, not serving.
     if (Math.random() < CLEANUP_PROBABILITY) {
-      await db.query(
+      await query(
         `DELETE FROM github_tokens
          WHERE is_valid = FALSE
            AND COALESCE(last_used_at, created_at) < NOW() - INTERVAL '7 days'`
       )
     }
 
-    const result = await db.query(
+    const result = await query<{ access_token: string }>(
       `SELECT access_token FROM github_tokens
        WHERE is_valid = TRUE
        ORDER BY random()
@@ -208,20 +206,19 @@ export async function invalidateToken(accessToken: string) {
 
   try {
     await ensureInit()
-    const db = getPool()
     // We can't match on encrypted token directly, so find by decrypting
     // For efficiency, mark all tokens invalid that fail auth — GitHub will
     // reject them anyway. In practice, the caller retries without auth.
     // Better approach: store a hash of the plaintext for lookup.
     // last_used_at records when the token was invalidated, so the cleanup
     // sweep in pickToken can remove it 7 days later.
-    const result = await db.query(
+    const result = await query<{ id: number; access_token: string }>(
       `SELECT id, access_token FROM github_tokens WHERE is_valid = TRUE`
     )
     for (const row of result.rows) {
       try {
         if (decryptToken(row.access_token) === accessToken) {
-          await db.query(
+          await query(
             `UPDATE github_tokens SET is_valid = FALSE, last_used_at = NOW() WHERE id = $1`,
             [row.id]
           )
@@ -229,7 +226,7 @@ export async function invalidateToken(accessToken: string) {
         }
       } catch {
         // Decryption failed — token was stored with different key, mark invalid
-        await db.query(
+        await query(
           `UPDATE github_tokens SET is_valid = FALSE, last_used_at = NOW() WHERE id = $1`,
           [row.id]
         )
@@ -245,8 +242,7 @@ export async function invalidateToken(accessToken: string) {
  */
 export async function removeToken(githubUser: string) {
   await ensureInit()
-  const db = getPool()
-  await db.query(
+  await query(
     `DELETE FROM github_tokens WHERE github_user = $1`,
     [githubUser]
   )
@@ -263,8 +259,7 @@ export async function getPoolStats(): Promise<{
 }> {
   try {
     await ensureInit()
-    const db = getPool()
-    const result = await db.query(
+    const result = await query<{ total: string; valid: string; invalid: string }>(
       `SELECT
          COUNT(*) as total,
          COUNT(*) FILTER (WHERE is_valid = TRUE) as valid,


### PR DESCRIPTION
A profile-README badge that froze for days traces to two issues that
compound: GitHub badges serve a 7-day last-known-good value when the live
fetch fails, and since the token pool let Neon autosuspend (#127), the
DB layer wasn't resilient to wake-from-suspend — so token reads/writes
failed, the pool went empty, GitHub calls fell to unauthenticated, hit
the rate limit, and every GitHub badge served frozen last-known-good.

Three changes:

- Faster self-heal: when cachedFetchStale serves a last-known-good value
  (live fetch failed), flag it (BadgeData.stale) so the route returns it
  with short error-cache headers instead of the 1h success headers. A
  recovered upstream now refreshes the badge within ~a minute instead of
  up to the full success-cache window. Applies to single and group badges.

- Stale-age escalation: emit a throttled Sentry "stale" provider alert
  when a last-known-good value served has been frozen longer than an hour,
  so a broken pool/upstream pages us instead of silently freezing badges
  for days.

- DB resilience: configure the pg pool for autosuspend (idle/connection
  timeouts, keepAlive, pool error handler) and route token-pool queries
  through a query() helper that retries once on transient connection
  errors. This fixes the "db store failed" error when adding a token and
  keeps pickToken from emptying the cache on a cold DB.

https://claude.ai/code/session_01CX1AfMuv4T5kq32T15xWJe