### PR TITLE
feat(badges): add NBA team badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ See the [docs](https://shieldcn.dev/docs) for full endpoint details, interactive
 | Provider | Badges | Endpoint |
 |----------|--------|----------|
 | **Discord** | online count, members | `/discord/{serverId}` |
+| **NBA** | team fan badges with logos and team colors (2026 Champs Knicks by default) | `/nba` or `/nba/{team}` |
 | **Reddit** | karma, subscribers | `/reddit/subscribers/r/{subreddit}` |
 | **Bluesky** | followers, following, posts | `/bluesky/{handle}` |
 | **X / Twitter** | follow CTA, mention CTA | `/x/follow/{username}` |
@@ -216,12 +217,12 @@ Three icon libraries (40,000+ icons) plus custom SVG upload:
 
 ## Response formats
 
-- **`.png`** — PNG image (recommended for GitHub READMEs and maximum compatibility)
-- **`.svg`** — SVG image (scalable, smaller file size)
+- **`.svg`** — SVG image (crisp, scalable, recommended default)
+- **`.png`** — PNG image (raster fallback for clients that reject SVG)
 - **`.json`** — raw badge data
 - **`/shields.json`** — shields.io-compatible endpoint
 
-Both `.png` and `.svg` work everywhere GitHub renders images. Just swap the extension.
+Use `.svg` for the sharpest result. Use `.png` only where SVG images are not accepted.
 
 ## Design principles
 

--- a/packages/core/src/badges/brand-colors.ts
+++ b/packages/core/src/badges/brand-colors.ts
@@ -14,6 +14,7 @@ export const providerBrandColors: Record<string, string> = {
   npm: "CB3837",
   github: "181717",
   discord: "5865F2",
+  nba: "17408B",
   reddit: "FF4500",
   pypi: "3775A9",
   crates: "dea584",

--- a/packages/core/src/badges/registry.ts
+++ b/packages/core/src/badges/registry.ts
@@ -191,6 +191,14 @@ export const REGISTRY: BadgeProvider[] = [
     ],
   },
   {
+    provider: "nba",
+    description: "NBA team fan badges with team logos.",
+    defaultTopic: "team",
+    topics: [
+      t("team", "Team fan badge", ["knicks"]),
+    ],
+  },
+  {
     provider: "reddit",
     description: "Reddit karma and subreddit subscribers.",
     topics: [

--- a/packages/core/src/badges/render.tsx
+++ b/packages/core/src/badges/render.tsx
@@ -14,6 +14,7 @@
  * that changes per variant is bg/fg/border color values.
  */
 
+import * as React from "react"
 import satori from "satori"
 import { optimize } from "svgo"
 import { readFileSync } from "node:fs"
@@ -208,6 +209,9 @@ interface ResolvedBadge {
 
   // Full-color emoji (Twemoji) SVG rendered as a square left inset
   emojiSvg: string | undefined
+
+  // Full-color logo data URI rendered as a square left inset
+  logoDataUri: string | undefined
 }
 
 // ---------------------------------------------------------------------------
@@ -369,6 +373,7 @@ function resolve(config: BadgeConfig): ResolvedBadge {
     iconRotation: config.iconRotation,
     flagSvg: config.flagSvg,
     emojiSvg: config.emojiSvg,
+    logoDataUri: config.logoDataUri,
   }
 }
 
@@ -576,6 +581,19 @@ function EmojiEl({ r }: { r: ResolvedBadge }) {
   )
 }
 
+function LogoEl({ r }: { r: ResolvedBadge }) {
+  if (!r.logoDataUri) return null
+  const size = Math.round(r.iconSize * 1.35)
+  return (
+    <img
+      src={r.logoDataUri}
+      width={size}
+      height={size}
+      style={{ width: size, height: size, objectFit: "contain", flexShrink: 0 }}
+    />
+  )
+}
+
 function IconEl({ r }: { r: ResolvedBadge }) {
   if (!r.icon) return null
   const vb = r.iconViewBox || "0 0 16 16"
@@ -697,6 +715,8 @@ function renderSingle(r: ResolvedBadge): React.ReactElement {
       {r.flagSvg && <div style={{ width: r.gap }} />}
       <EmojiEl r={r} />
       {r.emojiSvg && <div style={{ width: r.gap }} />}
+      <LogoEl r={r} />
+      {r.logoDataUri && <div style={{ width: r.gap }} />}
       <IconEl r={r} />
       {r.icon && <div style={{ width: r.gap }} />}
       {r.label && (
@@ -744,6 +764,8 @@ function renderSplit(r: ResolvedBadge): React.ReactElement {
         <DotEl r={r} />
         <EmojiEl r={r} />
         {r.emojiSvg && <div style={{ width: r.gap }} />}
+        <LogoEl r={r} />
+        {r.logoDataUri && <div style={{ width: r.gap }} />}
         <IconEl r={r} />
         {r.icon && <div style={{ width: r.gap }} />}
         {r.label && <span style={{ color: r.labelFg, ...textStyle }}>{r.label}</span>}

--- a/packages/core/src/badges/types.ts
+++ b/packages/core/src/badges/types.ts
@@ -121,6 +121,8 @@ export interface BadgeConfig {
    * original multi-color fills instead of recoloring it.
    */
   emojiSvg?: string
+  /** Full-color logo image data URI rendered as a square left inset. */
+  logoDataUri?: string
   /** Animation mode: "pulse" | "glow" | "shimmer" | "none". Default: none. */
   animate?: "pulse" | "glow" | "shimmer" | "none"
 }

--- a/packages/core/src/providers/nba.ts
+++ b/packages/core/src/providers/nba.ts
@@ -1,0 +1,91 @@
+/**
+ * shieldcn
+ * lib/providers/nba
+ *
+ * Static NBA team badge provider.
+ */
+
+import type { BadgeData } from "../badges/types"
+
+interface NbaTeam {
+  name: string
+  abbr: string
+  color: string
+  aliases: string[]
+}
+
+const ESPN_LOGO_BASE = "https://a.espncdn.com/i/teamlogos/nba/500"
+
+const TEAMS: NbaTeam[] = [
+  { name: "Atlanta Hawks", abbr: "atl", color: "E03A3E", aliases: ["atlanta", "hawks"] },
+  { name: "Boston Celtics", abbr: "bos", color: "007A33", aliases: ["boston", "celtics"] },
+  { name: "Brooklyn Nets", abbr: "bkn", color: "000000", aliases: ["brooklyn", "nets"] },
+  { name: "Charlotte Hornets", abbr: "cha", color: "1D1160", aliases: ["charlotte", "hornets"] },
+  { name: "Chicago Bulls", abbr: "chi", color: "CE1141", aliases: ["chicago", "bulls"] },
+  { name: "Cleveland Cavaliers", abbr: "cle", color: "860038", aliases: ["cleveland", "cavaliers", "cavs"] },
+  { name: "Dallas Mavericks", abbr: "dal", color: "00538C", aliases: ["dallas", "mavericks", "mavs"] },
+  { name: "Denver Nuggets", abbr: "den", color: "0E2240", aliases: ["denver", "nuggets"] },
+  { name: "Detroit Pistons", abbr: "det", color: "C8102E", aliases: ["detroit", "pistons"] },
+  { name: "Golden State Warriors", abbr: "gs", color: "1D428A", aliases: ["golden-state", "warriors", "gsw", "g-state"] },
+  { name: "Houston Rockets", abbr: "hou", color: "CE1141", aliases: ["houston", "rockets"] },
+  { name: "Indiana Pacers", abbr: "ind", color: "002D62", aliases: ["indiana", "pacers"] },
+  { name: "LA Clippers", abbr: "lac", color: "C8102E", aliases: ["la-clippers", "los-angeles-clippers", "clippers"] },
+  { name: "Los Angeles Lakers", abbr: "lal", color: "552583", aliases: ["los-angeles-lakers", "la-lakers", "lakers"] },
+  { name: "Memphis Grizzlies", abbr: "mem", color: "5D76A9", aliases: ["memphis", "grizzlies"] },
+  { name: "Miami Heat", abbr: "mia", color: "98002E", aliases: ["miami", "heat"] },
+  { name: "Milwaukee Bucks", abbr: "mil", color: "00471B", aliases: ["milwaukee", "bucks"] },
+  { name: "Minnesota Timberwolves", abbr: "min", color: "0C2340", aliases: ["minnesota", "timberwolves", "wolves"] },
+  { name: "New Orleans Pelicans", abbr: "no", color: "0C2340", aliases: ["new-orleans", "pelicans", "nop"] },
+  { name: "New York Knicks", abbr: "ny", color: "006BB6", aliases: ["new-york", "knicks", "nyk"] },
+  { name: "Oklahoma City Thunder", abbr: "okc", color: "007AC1", aliases: ["oklahoma-city", "thunder"] },
+  { name: "Orlando Magic", abbr: "orl", color: "0077C0", aliases: ["orlando", "magic"] },
+  { name: "Philadelphia 76ers", abbr: "phi", color: "006BB6", aliases: ["philadelphia", "76ers", "sixers", "seventy-sixers"] },
+  { name: "Phoenix Suns", abbr: "phx", color: "1D1160", aliases: ["phoenix", "suns"] },
+  { name: "Portland Trail Blazers", abbr: "por", color: "E03A3E", aliases: ["portland", "trail-blazers", "blazers"] },
+  { name: "Sacramento Kings", abbr: "sac", color: "5A2D81", aliases: ["sacramento", "kings"] },
+  { name: "San Antonio Spurs", abbr: "sa", color: "000000", aliases: ["san-antonio", "spurs", "sas"] },
+  { name: "Toronto Raptors", abbr: "tor", color: "CE1141", aliases: ["toronto", "raptors"] },
+  { name: "Utah Jazz", abbr: "utah", color: "002B5C", aliases: ["utah", "jazz"] },
+  { name: "Washington Wizards", abbr: "wsh", color: "002B5C", aliases: ["washington", "wizards"] },
+]
+
+const TEAM_BY_SLUG = new Map<string, NbaTeam>()
+
+for (const team of TEAMS) {
+  TEAM_BY_SLUG.set(team.abbr, team)
+  TEAM_BY_SLUG.set(slugify(team.name), team)
+  for (const alias of team.aliases) TEAM_BY_SLUG.set(slugify(alias), team)
+}
+
+function slugify(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/&/g, "and")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+}
+
+export function listNbaTeams(): NbaTeam[] {
+  return TEAMS
+}
+
+export function getNbaTeamBadge(teamSlug: string, options?: { label?: string; value?: string; color?: string }): BadgeData | null {
+  const team = TEAM_BY_SLUG.get(slugify(teamSlug))
+
+  if (!team) {
+    return {
+      label: "nba",
+      value: "team not found",
+      color: "red",
+      error: true,
+    }
+  }
+
+  return {
+    label: options?.label ?? "fan",
+    value: options?.value ?? team.name,
+    color: options?.color ?? team.color,
+    link: `${ESPN_LOGO_BASE}/${team.abbr}.png`,
+  }
+}

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -109,6 +109,7 @@ import {
   githubRepoExists,
 } from "./providers/github"
 import { getDiscordOnline, getDiscordByInvite } from "./providers/discord"
+import { getNbaTeamBadge } from "./providers/nba"
 import { parseStaticBadgeContent, getDynamicJsonBadge, getFlagBadge } from "./providers/badge"
 import { getRedditKarma, getRedditSubscribers } from "./providers/reddit"
 import { getMemoBadge, upsertMemoBadge } from "./providers/memo"
@@ -581,6 +582,12 @@ async function fetchBadgeData(
       }
 
       return getDiscordOnline(segments[1])
+    }
+
+    // /nba/{team} → fan badge with team logo
+    case "nba": {
+      if (segments.length < 2) return getNbaTeamBadge("knicks", { label: "2026 champs", value: "Knicks" })
+      return getNbaTeamBadge(segments.slice(1).join("/"))
     }
 
     // /reddit/karma/u/{user} or /reddit/subscribers/r/{subreddit}
@@ -1492,6 +1499,7 @@ function getDefaultLogoSlug(segments: string[]): { simpleIcon?: string; reactIco
 
   if (provider === "npm") return { simpleIcon: "npm" }
   if (provider === "discord") return { simpleIcon: "discord" }
+  if (provider === "nba") return null // NBA badges render the team logo as full-color art.
   if (provider === "pypi") return { simpleIcon: "pypi" }
   if (provider === "crates") return { simpleIcon: "rust" }
   if (provider === "docker") return { simpleIcon: "docker" }
@@ -1929,7 +1937,12 @@ async function handleBadgeGETInner(
   // Flag badges: fetch the full-color flag SVG to render as a left inset.
   // Default to the `secondary` variant so the flag chip sits on a soft surface.
   const isFlag = cleanSegments[0] === "flag"
+  const isNba = cleanSegments[0] === "nba"
+  if (isNba && cleanSegments.length === 1 && !searchParams.get("style") && !searchParams.get("variant")) {
+    style = "branded"
+  }
   let flagSvg: string | undefined
+  let logoDataUri: string | undefined
   if (isFlag) {
     if (!searchParams.get("style") && !searchParams.get("variant")) {
       style = "secondary"
@@ -1945,6 +1958,22 @@ async function handleBadgeGETInner(
       } catch {
         // No flag art — fall back to a normal text badge.
       }
+    }
+  }
+
+  if (isNba && data.link && !logoParam) {
+    try {
+      const logoRes = await raceTimeout(fetch(data.link, {
+        next: { revalidate: 86400 },
+        headers: { Accept: "image/png,image/svg+xml,image/*", "User-Agent": "shieldcn/1.0" },
+      }))
+      if (logoRes?.ok) {
+        const contentType = logoRes.headers.get("content-type")?.split(";")[0] || "image/png"
+        const bytes = Buffer.from(await logoRes.arrayBuffer())
+        logoDataUri = `data:${contentType};base64,${bytes.toString("base64")}`
+      }
+    } catch {
+      // No logo art — fall back to the default provider icon.
     }
   }
 
@@ -2090,6 +2119,10 @@ async function handleBadgeGETInner(
 
     }
 
+    if (isNba && data.color) {
+      brandColor = data.color
+    }
+
     // Fallback to provider brand color if no icon brand color found,
     // or if the icon brand color is black/near-black and the provider has a real color
     if (!brandColor && providerBrand) {
@@ -2187,6 +2220,7 @@ async function handleBadgeGETInner(
     gradient,
     flagSvg,
     emojiSvg,
+    logoDataUri,
     animate,
     valueColor: resolveColor(searchParams.get("valueColor")),
     labelTextColor: resolveColor(searchParams.get("labelTextColor")),

--- a/packages/web/app/dev/social/page.tsx
+++ b/packages/web/app/dev/social/page.tsx
@@ -134,43 +134,20 @@ async function downloadGif(item: BadgeItem, mode: Bg): Promise<void> {
   }
 }
 
-// A curated set of emoji (Twemoji) badges, seeded onto the canvas so
-// /dev/social opens ready to screenshot an emoji-logo showcase for social
-// posts. Each entry: [static badge path, emoji logo, variant].
-const EMOJI_SAMPLE: Array<[string, string, Variant]> = [
-  ["/badge/ship-it", "\uD83D\uDE80", "secondary"],
-  ["/badge/made%20with-love", "\u2764\uFE0F", "outline"],
-  ["/badge/status-on%20fire", "\uD83D\uDD25", "destructive"],
-  ["/badge/coffee-driven", "\u2615", "secondary"],
-  ["/badge/release-shipped", "\uD83C\uDF89", "outline"],
-  ["/badge/built%20by-a%20human", "\uD83D\uDC68\u200D\uD83D\uDCBB", "default"],
-  ["/badge/quality-magic", "\u2728", "secondary"],
-  ["/badge/score-100", "\uD83D\uDCAF", "outline"],
-  ["/badge/speed-blazing", "\u26A1", "default"],
-  ["/badge/mood-chill", "\uD83D\uDE0E", "secondary"],
-  ["/badge/star-this%20repo", "\u2B50", "outline"],
-  ["/badge/packaged%20with-care", "\uD83D\uDCE6", "secondary"],
-  ["/badge/idea-bright", "\uD83D\uDCA1", "outline"],
-  ["/badge/powered%20by-vibes", "\uD83C\uDF08", "secondary"],
-  ["/badge/tests-passing", "\u2705", "outline"],
-  ["/badge/build-rocketing", "\uD83D\uDEF0\uFE0F", "default"],
-  ["/badge/security-locked", "\uD83D\uDD12", "secondary"],
-  ["/badge/docs-sparkling", "\uD83D\uDCDA", "outline"],
-  ["/badge/made%20in-the%20usa", "\uD83C\uDDFA\uD83C\uDDF8", "secondary"],
-  ["/badge/party-time", "\uD83E\uDD73", "outline"],
+// Default social canvas: the Knicks champs badge. This page opens ready to
+// export the `/nba` social card without needing to add a badge manually.
+const DEFAULT_ITEMS: BadgeItem[] = [
+  {
+    id: nextId(),
+    path: "/nba",
+    variant: "branded",
+    size: "lg",
+    font: "inter",
+    animate: "none",
+    label: "none",
+    labelText: "",
+  },
 ]
-
-const DEFAULT_ITEMS: BadgeItem[] = EMOJI_SAMPLE.map(([path, logo, variant]) => ({
-  id: nextId(),
-  path,
-  logo,
-  variant,
-  size: "sm",
-  font: "inter",
-  animate: "none",
-  label: "none",
-  labelText: "",
-}))
 
 // ---------------------------------------------------------------------------
 // Inline SVG badge — pure renderer. The page fetches each badge's base SVG
@@ -327,10 +304,10 @@ export default function DevSocialPage() {
   const [preset, setPreset] = useState<PresetKey>("og")
   const [bg, setBg] = useState<Bg>("black")
   const [gap, setGap] = useState(16)
-  const [showText, setShowText] = useState(false)
+  const [showText, setShowText] = useState(true)
   const [showLogo, setShowLogo] = useState(true)
-  const [title, setTitle] = useState("shieldcn")
-  const [subtitle, setSubtitle] = useState("Beautiful README badges")
+  const [title, setTitle] = useState("2026 Champs")
+  const [subtitle, setSubtitle] = useState("Knicks")
   const [saving, setSaving] = useState(false)
   // Resolved SVG (base + animated preview + dot color) per badge id.
   const [svgMap, setSvgMap] = useState<Record<string, BadgeSvg>>({})

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -13,7 +13,7 @@ import { websiteJsonLd, softwareAppJsonLd } from "@/lib/json-ld"
 export const metadata: Metadata = pageMetadata({
   title: "shieldcn — Beautiful README Badges",
   description:
-    "Beautiful GitHub README badges styled as shadcn/ui buttons. Generate SVG and PNG badges for npm, GitHub, GitLab, Discord, and 45+ providers. 6 variants, 16 themes, 40,000+ icons. Free and open source.",
+    "Beautiful GitHub README badges styled as shadcn/ui buttons. Generate SVG and PNG badges for npm, GitHub, GitLab, Discord, NBA, and 45+ providers. 6 variants, 16 themes, 40,000+ icons. Free and open source.",
   path: "/",
   ogTitle: "shieldcn — Beautiful README Badges",
 })

--- a/packages/web/app/showcase/page.tsx
+++ b/packages/web/app/showcase/page.tsx
@@ -6,7 +6,7 @@ import { pageMetadata } from "@/lib/metadata"
 export const metadata: Metadata = pageMetadata({
   title: "Showcase",
   description:
-    "Live badge examples for GitHub, npm, and Discord. Click any badge to customize variant, size, theme, and mode — then copy the markdown for your README.",
+    "Live badge examples for GitHub, npm, Discord, and NBA teams. Click any badge to customize variant, size, theme, and mode — then copy the markdown for your README.",
   path: "/showcase",
 })
 

--- a/packages/web/app/showcase/showcase-client.tsx
+++ b/packages/web/app/showcase/showcase-client.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import Link from "next/link"
 import { useMemo, useState } from "react"
 import { Search, X } from "lucide-react"
 import { BadgeCard } from "@/components/badge-card"
@@ -19,6 +20,7 @@ export default function ShowcasePage() {
   const [activeCategory, setActiveCategory] = useState("All")
 
   const activeCategoryData = categories.find((c) => c.name === activeCategory)
+  const nbaCategory = categories.find((c) => c.name === "NBA")
 
   const filteredIcons = useMemo(() => {
     const icons = activeCategory === "All"
@@ -66,6 +68,23 @@ export default function ShowcasePage() {
           </div>
         </div>
 
+        {nbaCategory ? (
+          <div className="space-y-3 rounded-xl border border-border bg-card/40 p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <h2 className="text-sm font-semibold tracking-wide text-muted-foreground uppercase">NBA team badges</h2>
+                <p className="mt-1 text-xs text-muted-foreground">Fan badges with full-color team logos and team-color branded variants.</p>
+              </div>
+              <Button variant="outline" size="sm" onClick={() => setActiveCategory("NBA")}>View all</Button>
+            </div>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+              {nbaCategory.icons.slice(0, 6).map((badge) => (
+                <BadgeCard key={`nba-featured-${badge.badgePath}-${badge.title}`} badge={badge} />
+              ))}
+            </div>
+          </div>
+        ) : null}
+
         {/* Animated badges — live <img> row */}
         <AnimatedShowcase />
 
@@ -73,7 +92,7 @@ export default function ShowcasePage() {
         <div className="space-y-3">
           <div className="flex items-center justify-between">
             <h2 className="text-sm font-semibold tracking-wide text-muted-foreground uppercase">Badge Groups</h2>
-            <a href="/docs/badges/group" className="text-xs text-muted-foreground hover:text-foreground transition-colors">docs →</a>
+            <Link href="/docs/badges/group" className="text-xs text-muted-foreground hover:text-foreground transition-colors">docs →</Link>
           </div>
           <GroupShowcase items={groupShowcaseItems} />
         </div>

--- a/packages/web/components/badge-sandbox.tsx
+++ b/packages/web/components/badge-sandbox.tsx
@@ -80,7 +80,7 @@ export function BadgeSandbox({
   })
 
   // Standard styling params (same for every badge)
-  const [imageFormat, setImageFormat] = useState<"png" | "svg">("png")
+  const [imageFormat, setImageFormat] = useState<"png" | "svg">("svg")
   const [variant, setVariant] = useState("default")
   const [size, setSize] = useState("sm")
   const [mode, setMode] = useState("dark")

--- a/packages/web/components/sidebar.tsx
+++ b/packages/web/components/sidebar.tsx
@@ -114,6 +114,7 @@ const docsNav: NavGroup[] = [
     title: "Social & Community",
     items: [
       { title: "Discord", href: "/docs/badges/discord" },
+      { title: "NBA", href: "/docs/badges/nba" },
       { title: "Bluesky", href: "/docs/badges/bluesky" },
       { title: "X / Twitter", href: "/docs/badges/x" },
       { title: "YouTube", href: "/docs/badges/youtube" },

--- a/packages/web/content/docs/api-reference.mdx
+++ b/packages/web/content/docs/api-reference.mdx
@@ -5,10 +5,10 @@ description: Complete URL specification, query parameters, and response formats.
 
 ## URL format
 
-<InlineHint variant="tip">All endpoints support both `.png` and `.svg` — swap `.json` to get raw badge data, or append `/shields.json` for shields.io compatibility.</InlineHint>
+<InlineHint variant="tip">All endpoints support both `.svg` and `.png` — swap `.json` to get raw badge data, or append `/shields.json` for shields.io compatibility. Use SVG by default for the crispest rendering.</InlineHint>
 
-<CodeLine language="bash" code="https://shieldcn.dev/{provider}/{...params}.png" />
 <CodeLine language="bash" code="https://shieldcn.dev/{provider}/{...params}.svg" />
+<CodeLine language="bash" code="https://shieldcn.dev/{provider}/{...params}.png" />
 <CodeLine language="bash" code="https://shieldcn.dev/{provider}/{...params}.json" />
 <CodeLine language="bash" code="https://shieldcn.dev/{provider}/{...params}/shields.json" />
 
@@ -44,6 +44,15 @@ description: Complete URL specification, query parameters, and response formats.
 | `/discord/{serverId}.svg` | Online member count |
 | `/discord/members/{inviteCode}.svg` | Approximate member count from invite |
 | `/discord/online-members/{inviteCode}.svg` | Approximate online member count from invite |
+
+### NBA
+
+| Endpoint | Description |
+|----------|-------------|
+| `/nba.svg` | Default “2026 champs / Knicks” badge using the branded Knicks color |
+| `/nba/{team}.svg` | NBA team fan badge with team logo and team color |
+
+`{team}` accepts common team slugs, names, abbreviations, and nicknames such as `knicks`, `ny`, `celtics`, `bos`, `warriors`, and `gs`. Omit `{team}` for the default “2026 champs / Knicks” badge. See [NBA docs](/docs/badges/nba).
 
 ### X / Twitter
 
@@ -291,7 +300,7 @@ Join any badge paths with `+`. Query params apply to all segments. See [Badge Gr
 
 <CodeBlock language="http" code={"Content-Type: image/png\nCache-Control: public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400"} />
 
-PNG badges are rasterized at the exact badge dimensions. Recommended for GitHub READMEs and maximum cross-platform compatibility.
+PNG badges are rasterized at exact badge dimensions. Use SVG when you want the crispest badge rendering; use PNG only where SVG is not accepted.
 
 ### SVG
 

--- a/packages/web/content/docs/badges/meta.json
+++ b/packages/web/content/docs/badges/meta.json
@@ -5,6 +5,7 @@
     "github",
     "gitlab",
     "discord",
+    "nba",
     "pypi",
     "crates",
     "docker",

--- a/packages/web/content/docs/badges/nba/index.mdx
+++ b/packages/web/content/docs/badges/nba/index.mdx
@@ -1,0 +1,75 @@
+---
+title: NBA
+description: NBA team fan badges with team logos and team colors.
+badge: "/nba.svg"
+---
+
+Show which NBA team you support with a fan badge that renders the team logo next to the badge text.
+
+<BadgePreviewGroup>
+  <BadgePreviewCard src="/nba/knicks.svg?variant=branded" alt="fan New York Knicks" description="Knicks (branded)" />
+  <BadgePreviewCard src="/nba/celtics.svg?variant=branded" alt="fan Boston Celtics" description="Celtics (branded)" />
+  <BadgePreviewCard src="/nba/warriors.svg?variant=secondary" alt="fan Golden State Warriors" description="Warriors" />
+  <BadgePreviewCard src="/nba/bulls.svg?variant=outline" alt="fan Chicago Bulls" description="Bulls outline" />
+  <BadgePreviewCard src="/nba/lakers.svg?variant=ghost" alt="fan Los Angeles Lakers" description="Lakers ghost" />
+  <BadgePreviewCard src="/nba/heat.svg?variant=branded" alt="fan Miami Heat" description="Heat (branded)" />
+</BadgePreviewGroup>
+
+## Available badges
+
+| Badge | Endpoint | Description |
+|-------|----------|-------------|
+| NBA champs | `/nba` | Default “2026 champs / Knicks” badge using the branded Knicks color |
+| NBA team | `/nba/{team}` | Fan badge with NBA team name, logo, and team color |
+
+`{team}` accepts common team slugs, names, abbreviations, and nicknames. For example, `knicks`, `ny`, `new-york-knicks`, and `celtics` all resolve to a team badge. Omit `{team}` for the default “2026 champs / Knicks” badge.
+
+<BadgeSandbox
+  endpoint="/nba/:team.svg"
+  pathParams={[
+    { name: "team", label: "NBA team", placeholder: "knicks", required: true, description: "Team slug, abbreviation, city, or nickname." },
+  ]}
+  defaults={{ team: "knicks" }}
+/>
+
+## Quick examples
+
+<CodeLine language="markdown" code='![2026 Champs Knicks](https://shieldcn.dev/nba.svg)' />
+
+<CodeLine language="markdown" code='![Celtics fan](https://shieldcn.dev/nba/celtics.svg?variant=branded)' />
+
+<CodeLine language="markdown" code='![Warriors fan](https://shieldcn.dev/nba/warriors.svg?variant=outline)' />
+
+<CodeLine language="markdown" code='![Bulls fan](https://shieldcn.dev/nba/chi.svg?variant=secondary)' />
+
+## Team slugs
+
+Use lowercase team names with spaces replaced by dashes, a team abbreviation, or a common nickname:
+
+- `/nba/knicks`, `/nba/ny`, `/nba/new-york-knicks`
+- `/nba/celtics`, `/nba/bos`, `/nba/boston`
+- `/nba/warriors`, `/nba/gs`, `/nba/golden-state-warriors`
+- `/nba/lakers`, `/nba/lal`, `/nba/los-angeles-lakers`
+- `/nba/sixers`, `/nba/phi`, `/nba/76ers`
+
+Unknown teams return a readable error badge instead of a broken image.
+
+## Customizing
+
+All standard badge query params apply (`variant`, `size`, `mode`, `font`, `label`, colors, etc.). The `branded` variant uses the resolved team's primary color.
+
+<BadgePreview
+  src="/nba/knicks.svg?variant=branded&label=team"
+  alt="team New York Knicks"
+  description="Override the label while keeping the Knicks logo and team color."
+/>
+
+<BadgePreview
+  src="/nba/celtics.svg?variant=outline&mode=light"
+  alt="fan Boston Celtics outline"
+  description="Outline badges stay readable in light mode while preserving the full-color team logo."
+/>
+
+## Data source
+
+Team names, aliases, and primary colors are resolved from a static NBA team map. Team logo images are fetched from ESPN's public team logo CDN and cached for 24 hours. No API key required.

--- a/packages/web/content/docs/badges/nba/meta.json
+++ b/packages/web/content/docs/badges/nba/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "NBA",
+  "pages": ["index"]
+}

--- a/packages/web/content/docs/index.mdx
+++ b/packages/web/content/docs/index.mdx
@@ -11,11 +11,11 @@ shieldcn serves SVG badge images that look like **shadcn/ui Button components** 
 
 Add a badge to your README:
 
-<CodeLine language="markdown" code="![npm version](https://shieldcn.dev/npm/react.png)" />
+<CodeLine language="markdown" code="![npm version](https://shieldcn.dev/npm/react.svg)" />
 
-That's it. No configuration, no API keys, no build step. Both `.png` and `.svg` extensions are supported — just swap the extension.
+That's it. No configuration, no API keys, no build step. Both `.svg` and `.png` extensions are supported — just swap the extension.
 
-<InlineHint variant="tip">Use `.png` for GitHub READMEs — it renders more consistently across clients than `.svg`.</InlineHint>
+<InlineHint variant="tip">Use `.svg` by default for the crispest badge rendering. Use `.png` only where SVG images are not accepted.</InlineHint>
 
 ## Badge types
 
@@ -35,13 +35,14 @@ That's it. No configuration, no API keys, no build step. Both `.png` and `.svg` 
 | GitHub commits | `/github/commits/{owner}/{repo}` |
 | Discord online | `/discord/{serverId}` |
 | Discord members | `/discord/members/{inviteCode}` |
+| NBA team fan | `/nba` or `/nba/{team}` |
 | Reddit karma | `/reddit/{type}/u/{user}` |
 | Static | `/badge/{label}-{message}-{color}` |
 | Dynamic JSON | `/badge/dynamic/json?url=...&query=...` |
 | HTTPS endpoint | `/https/{hostname}/{path}` |
 | Memo | `/memo/{key}` |
 
-Append `.png` or `.svg` to any endpoint (e.g. `/npm/react.png` or `/npm/react.svg`).
+Append `.svg` or `.png` to any endpoint (e.g. `/npm/react.svg` or `/npm/react.png`).
 
 ## Variants
 
@@ -72,12 +73,12 @@ Badges auto-detect icons per provider. Override with any [Simple Icons](https://
 
 ## Response formats
 
-- **`.png`** — PNG image (recommended for GitHub READMEs and most use cases)
-- **`.svg`** — SVG image (scalable, smaller file size)
+- **`.svg`** — SVG image (crisp, scalable, recommended default)
+- **`.png`** — PNG image (raster fallback for clients that reject SVG)
 - **`.json`** — raw badge data
 - **`/shields.json`** — shields.io-compatible endpoint
 
-Both `.png` and `.svg` work everywhere GitHub renders images. Use `.png` for maximum compatibility across platforms.
+Use `.svg` for the sharpest result. Use `.png` only for platforms that reject SVG images.
 
 ## Built with
 

--- a/packages/web/lib/badge-builder-shared.ts
+++ b/packages/web/lib/badge-builder-shared.ts
@@ -65,6 +65,7 @@ export const BADGE_PRESETS: BadgePreset[] = [
 
   // Social
   { label: "Discord — online", template: "/discord/{serverId}.svg", params: [{ key: "serverId", label: "Server ID", placeholder: "1316199667142496307", default: "1316199667142496307" }], group: "Social" },
+  { label: "NBA — team fan", template: "/nba/{team}.svg", params: [{ key: "team", label: "Team", placeholder: "knicks", default: "knicks" }], group: "Social", defaultLinkUrl: "https://www.nba.com/{team}" },
   { label: "Reddit — subscribers", template: "/reddit/{subreddit}.svg", params: [{ key: "subreddit", label: "Subreddit", placeholder: "typescript", default: "typescript" }], group: "Social", defaultLinkUrl: "https://www.reddit.com/r/{subreddit}" },
   { label: "X — follow", template: "/x/follow/{username}.svg", params: [{ key: "username", label: "Username", placeholder: "jal_co", default: "jal_co" }], group: "Social", defaultLinkUrl: "https://x.com/{username}" },
   { label: "X — mention", template: "/x/mention/{username}.svg", params: [{ key: "username", label: "Username", placeholder: "jal_co", default: "jal_co" }], group: "Social", defaultLinkUrl: "https://x.com/{username}" },

--- a/packages/web/lib/json-ld.ts
+++ b/packages/web/lib/json-ld.ts
@@ -15,7 +15,7 @@ export function websiteJsonLd() {
     name: "shieldcn",
     url: SITE_URL,
     description:
-      "Beautiful GitHub README badges styled as shadcn/ui buttons. Generate SVG and PNG badges for npm, GitHub, Discord, and 25+ providers. 6 variants, 16 themes, 40,000+ icons. Free and open source.",
+      "Beautiful GitHub README badges styled as shadcn/ui buttons. Generate SVG and PNG badges for npm, GitHub, Discord, NBA, and 25+ providers. 6 variants, 16 themes, 40,000+ icons. Free and open source.",
     inLanguage: "en-US",
   }
 }
@@ -30,7 +30,7 @@ export function softwareAppJsonLd() {
     applicationCategory: "DeveloperApplication",
     operatingSystem: "Any",
     description:
-      "Beautiful GitHub README badges styled as shadcn/ui buttons. Generate SVG and PNG badges for npm, GitHub, Discord, and 25+ providers. 6 variants, 16 themes, 40,000+ icons. Free and open source.",
+      "Beautiful GitHub README badges styled as shadcn/ui buttons. Generate SVG and PNG badges for npm, GitHub, Discord, NBA, and 25+ providers. 6 variants, 16 themes, 40,000+ icons. Free and open source.",
     offers: {
       "@type": "Offer",
       price: "0",

--- a/packages/web/lib/showcase-data.ts
+++ b/packages/web/lib/showcase-data.ts
@@ -52,6 +52,7 @@ export const featuredBadges: ShowcaseBadge[] = [
   dynamicBadge("Bluesky Followers", "featured social", "/bluesky/jay.bsky.team.svg?variant=outline", "Social proof badge for Bluesky profiles.", "/docs/badges/bluesky"),
   dynamicBadge("Bundle Size", "featured bundlephobia", "/bundlephobia/minzip/react.svg?variant=secondary", "Show how lightweight your package is.", "/docs/badges/bundlephobia"),
   dynamicBadge("Built in the USA", "featured location", "/flag/us.svg", "Country flag badge with a natural-aspect flag chip.", "/docs/badges/flag"),
+  dynamicBadge("2026 Champs Knicks", "featured nba", "/nba.svg", "Default Knicks champs badge with full-color logo art and branded team color.", "/docs/badges/nba"),
   dynamicBadge("Ship It", "featured emoji", "/badge/ship-it.svg?logo=twemoji:\uD83D\uDE80&variant=secondary", "Any emoji as a logo, rendered via Twemoji.", "/docs/customization/logos"),
   dynamicBadge("Skill Installs", "featured skills.sh", "/skills/installs/vercel-labs/agent-skills/vercel-react-best-practices.svg?variant=branded", "Install count for an agent skill on skills.sh.", "/docs/badges/skills"),
 ]
@@ -107,12 +108,18 @@ export const categories: Category[] = [
     ],
   },
   {
-    name: "Discord",
-    description: "Community badges using either the widget API or invite-count API.",
+    name: "Social",
+    description: "Community and fan badges for social proof, groups, and team identity.",
     icons: [
       dynamicBadge("Discord Online", "widget api", "/discord/1316199667142496307.svg?variant=secondary", "Live online count using the server widget API.", "/docs/badges/discord"),
       dynamicBadge("Discord Members", "invite api", "/discord/members/reactiflux.svg?variant=outline", "Approximate member count using the invite API with counts.", "/docs/badges/discord"),
       dynamicBadge("Discord Online Members", "invite api", "/discord/online-members/reactiflux.svg?variant=branded", "Approximate online members using invite counts.", "/docs/badges/discord"),
+      dynamicBadge("2026 Champs Knicks", "nba team", "/nba.svg", "Default Knicks champs badge with full-color logo art and branded team color.", "/docs/badges/nba"),
+      dynamicBadge("Celtics Fan", "nba team", "/nba/celtics.svg?variant=branded", "Boston Celtics badge with full-color logo art.", "/docs/badges/nba"),
+      dynamicBadge("Warriors Fan", "nba team", "/nba/warriors.svg?variant=secondary", "Golden State Warriors fan badge.", "/docs/badges/nba"),
+      dynamicBadge("Bulls Fan", "nba team", "/nba/bulls.svg?variant=outline", "Chicago Bulls outline badge.", "/docs/badges/nba"),
+      dynamicBadge("Lakers Fan", "nba team", "/nba/lakers.svg?variant=ghost", "Los Angeles Lakers ghost badge.", "/docs/badges/nba"),
+      dynamicBadge("Heat Fan", "nba team", "/nba/heat.svg?variant=branded", "Miami Heat team-color badge.", "/docs/badges/nba"),
     ],
   },
   {


### PR DESCRIPTION
## What

- Add `/nba` and `/nba/{team}` badge support for NBA team fan badges.
- Render full-color NBA team logos while keeping the existing shared badge render pipeline.
- Default `/nba` to a branded `2026 champs / Knicks` badge.
- Add NBA docs, API reference entries, README/provider discovery, builder preset, showcase examples, and `/dev/social` default canvas.
- Prefer SVG defaults in docs/sandbox because PNG output is rasterized.

## Why

Adds fan-facing NBA team logo badges and makes the Knicks default easy to use in docs, showcase, and social-card generation.

Closes #

## Type

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `docs` — Documentation
- [ ] `refactor` — Code restructuring
- [ ] `perf` — Performance improvement
- [ ] `style` — Visual / CSS changes
- [ ] `chore` — Maintenance / deps
- [ ] `ci` — CI/CD changes
- [ ] `test` — Tests

## Testing

- [x] `pnpm --filter @shieldcn/core test`
- [x] targeted eslint on changed web files
- [x] `pnpm build:web`
- [x] manual route checks for `/nba.svg`, `/nba.json`, `/nba.png`, `/nba/knicks.svg`, and representative team badges

## Checklist

- [x] Branch follows conventional naming (`feat/`, `fix/`, `docs`, etc.)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tested locally with `pnpm dev`
- [x] Badge renders correctly in SVG and PNG (if applicable)
- [x] Docs updated (if adding/changing a provider or query param)

## Screenshots

Not captured locally. Visual badge routes verified via direct render checks; `/dev/social` now opens with the default Knicks champs badge.
