### PR TITLE
feat(web): add Vercel OSS Program membership badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@
 </p>
 
 <p align="center">
+  <a href="https://vercel.com/oss"><img src="https://shieldcn.dev/badge/Vercel_OSS_Program_Member.svg?variant=branded&logo=vercel" alt="Vercel OSS Program Member" /></a>
+</p>
+
+<p align="center">
   <a href="https://shieldcn.dev/docs/self-hosting"><img src="https://shieldcn.dev/badge/host%20with-docker-2496ED.svg?variant=branded&logo=docker" alt="host with docker" /></a>
   <a href="https://openpanel.dev?ref=justinlevine.me"><img src="https://shieldcn.dev/badge/analytics%20by-openpanel.svg?variant=branded&logo=openpanel" alt="analytics by openpanel" /></a>
   <a href="https://sentry.io/?utm_source=shieldcn.dev"><img src="https://shieldcn.dev/badge/monitored%20by-sentry.svg?variant=branded&logo=sentry" alt="monitored by sentry" /></a>

--- a/packages/web/app/sponsor/page.tsx
+++ b/packages/web/app/sponsor/page.tsx
@@ -65,6 +65,14 @@ function SentryLogo({ className }: { className?: string }) {
   )
 }
 
+function VercelLogo({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 283 64" fill="currentColor" aria-hidden="true" className={className}>
+      <path d="M141.04 16c-11.04 0-19 7.2-19 18s8.96 18 20 18c6.67 0 12.55-2.64 16.19-7.09l-7.65-4.42c-2.02 2.21-5.09 3.5-8.54 3.5-4.79 0-8.86-2.5-10.37-6.5h28.02c.22-1.12.35-2.28.35-3.5 0-10.79-7.96-17.99-19-17.99zm-9.46 14.5c1.25-3.99 4.67-6.5 9.45-6.5 4.79 0 8.21 2.51 9.45 6.5h-18.9zM248.72 16c-11.04 0-19 7.2-19 18s8.96 18 20 18c6.67 0 12.55-2.64 16.19-7.09l-7.65-4.42c-2.02 2.21-5.09 3.5-8.54 3.5-4.79 0-8.86-2.5-10.37-6.5h28.02c.22-1.12.35-2.28.35-3.5 0-10.79-7.96-17.99-19-17.99zm-9.45 14.5c1.25-3.99 4.67-6.5 9.45-6.5 4.79 0 8.21 2.51 9.45 6.5h-18.9zM200.24 34c0 6 3.92 10 10 10 4.12 0 7.21-1.87 8.8-4.92l7.68 4.43c-3.18 5.3-9.14 8.49-16.48 8.49-11.05 0-19-7.2-19-18s7.96-18 19-18c7.34 0 13.29 3.19 16.48 8.49l-7.68 4.43c-1.59-3.05-4.68-4.92-8.8-4.92-6.07 0-10 4-10 10zm82.48-29v46h-9V5h9zM36.95 0L73.9 64H0L36.95 0zm92.38 5l-27.71 48L73.91 5H84.3l17.32 30 17.32-30h10.39zm58.91 12v9.69c-1-.29-2.06-.49-3.2-.49-5.81 0-10 4-10 10V51h-9V17h9v9.2c0-5.08 5.91-9.2 13.2-9.2z" />
+    </svg>
+  )
+}
+
 interface Sponsor {
   name: string
   href: string
@@ -119,6 +127,11 @@ const tiers = [
     name: "Open Source Program",
     slots: 4,
     sponsors: [
+      {
+        name: "Vercel",
+        href: "https://vercel.com/oss",
+        logoComponent: <VercelLogo className="h-6 w-auto" />,
+      },
       {
         name: "OpenPanel",
         href: "https://openpanel.dev/open-source?utm_source=shieldcn.dev",

--- a/packages/web/components/footer.tsx
+++ b/packages/web/components/footer.tsx
@@ -110,6 +110,17 @@ export function SiteFooter() {
             </Link>
 
             <p className="text-sm text-muted-foreground">
+              Member of the{" "}
+              <a
+                href="https://vercel.com/oss"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium text-foreground"
+              >
+                Vercel OSS Program
+              </a>
+            </p>
+            <p className="text-sm text-muted-foreground">
               Analytics provided by{" "}
               <a
                 href="https://openpanel.dev/open-source?utm_source=shieldcn.dev"


### PR DESCRIPTION
## What

Surfaces shieldcn's acceptance into the **Vercel OSS Program** in three places:

- **README** — a centered, branded "Vercel OSS Program Member" badge with the Vercel logo front and center, linked to `vercel.com/oss`.
- **Sponsor page** (`/sponsor`) — adds a Vercel wordmark as the first entry in the **Open Source Program** tier, alongside OpenPanel and Sentry.
- **Footer** — adds a "Member of the Vercel OSS Program" line to the branding column.

## Why

shieldcn was accepted into the Vercel OSS Program. This gives proper attribution to Vercel for hosting and recognizes the membership across the project's surfaces.

## Type

- [x] `feat` — New feature

## Checklist

- [x] Branch follows conventional naming (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tested locally with `pnpm dev`
- [x] Badge renders correctly in SVG and PNG (if applicable)
- [ ] Docs updated (if adding/changing a provider or query param) — n/a, no provider/param changes

## Screenshots

The README badge uses the existing static badge endpoint:

`/badge/Vercel_OSS_Program_Member.svg?variant=branded&logo=vercel`

- README badge: white Vercel triangle + "Vercel OSS Program Member" text on Vercel-black, shadcn Button styling. Verified identical in `mode=light` and `mode=dark` (branded color is mode-independent).
- Sponsor page: Vercel wordmark renders first in the Open Source Program tier; adapts to light/dark via `currentColor`.
- Footer: "Member of the Vercel OSS Program" line links to `vercel.com/oss`.
