### PR TITLE
feat(web): rebuild showcase as a badge bento

### DIFF
--- a/packages/core/src/badges/render.tsx
+++ b/packages/core/src/badges/render.tsx
@@ -386,7 +386,7 @@ export async function renderBadge(config: BadgeConfig): Promise<string> {
   const el = r.split ? renderSplit(r) : renderSingle(r)
   const fonts = getFonts(config.font)
   const raw = await satori(el, { height: r.height, fonts })
-  const svg = inlineDataUriImages(raw)
+  const svg = rgbaToHexOpacity(inlineDataUriImages(raw))
   const optimized = optimizeSvg(svg)
   const mode = config.animate ?? "none"
   if (mode === "none") return optimized
@@ -405,7 +405,7 @@ export async function renderBadgeBase(
   const el = r.split ? renderSplit(r) : renderSingle(r)
   const fonts = getFonts(config.font)
   const raw = await satori(el, { height: r.height, fonts })
-  const svg = optimizeSvg(inlineDataUriImages(raw))
+  const svg = optimizeSvg(rgbaToHexOpacity(inlineDataUriImages(raw)))
   return { svg, dotColor: r.dotColor }
 }
 
@@ -465,61 +465,131 @@ function optimizeSvg(svg: string): string {
 
 /**
  * Post-process SVG to inline data URI images as actual SVG elements.
- * Satori converts nested <svg> to <image href="data:image/svg+xml;...">.
- * Some renderers don't handle these well, so we convert them back to inline paths.
+ *
+ * Satori emits nested SVG content as <image href="data:image/svg+xml;...">
+ * (both the JSX <svg> icons it serializes as `utf8` data URIs, and the
+ * <img src="data:...;base64"> flags/emoji/custom logos we pass in). WebKit
+ * (Quick Look, browsers) renders an SVG embedded inside an <image>, but
+ * Photoshop / Illustrator / Figma do NOT — the logo silently disappears on
+ * import. Satori also wraps these <image> tags in `mask`/`clip-path`
+ * references that those editors handle poorly.
+ *
+ * So we decode every SVG data URI and splice its real markup back in as a
+ * positioned <g>. This preserves multi-color art (flags, emoji) verbatim and
+ * keeps the logo as a first-class part of the badge in any editor.
  */
 function inlineDataUriImages(svg: string): string {
-  // Match <image> tags with SVG data URIs
-  const imageRegex = /<image\s+x="([^"]+)"\s+y="([^"]+)"\s+width="([^"]+)"\s+height="([^"]+)"\s+href="data:image\/svg\+xml;[^"]+"[^>]*\/>/g
+  // Match any <image .../> regardless of attribute order.
+  const imageRegex = /<image\b([^>]*?)\/>/g
 
-  return svg.replace(imageRegex, (match, x, y, width, height) => {
-    // Extract the data URI content
-    const hrefMatch = match.match(/href="data:image\/svg\+xml;utf8,([^"]+)"/)
+  return svg.replace(imageRegex, (match, attrs: string) => {
+    // Only handle SVG data URIs — leave raster (png/jpeg) images alone.
+    const hrefMatch = attrs.match(/href="(data:image\/svg\+xml;[^"]+)"/)
     if (!hrefMatch) return match
+    const href = hrefMatch[1]
 
-    // Decode the URI-encoded SVG
+    // Decode the inner SVG — Satori uses `utf8` for serialized JSX icons and
+    // `base64` for the <img> data URIs we pass (flags, emoji, custom logos).
     let innerSvg: string
     try {
-      innerSvg = decodeURIComponent(hrefMatch[1])
+      if (/;base64,/.test(href)) {
+        const b64 = href.replace(/^data:image\/svg\+xml;base64,/, "")
+        innerSvg = Buffer.from(b64, "base64").toString("utf8")
+      } else {
+        const enc = href.replace(/^data:image\/svg\+xml;(?:charset=utf-8|utf8)?,?/, "")
+        innerSvg = decodeURIComponent(enc)
+      }
     } catch {
       return match
     }
+
+    // Position/size of the placed image (attribute order is not guaranteed).
+    const num = (name: string, fallback: number) => {
+      const m = attrs.match(new RegExp(`\\b${name}="([^"]+)"`))
+      const n = m ? parseFloat(m[1]) : NaN
+      return Number.isFinite(n) ? n : fallback
+    }
+    const x = num("x", 0)
+    const y = num("y", 0)
+    const width = num("width", 0)
+    const height = num("height", 0)
+    if (width <= 0 || height <= 0) return match
 
     // Extract viewBox from inner SVG. Guard against malformed values (a
     // user-supplied ?logo= data URI can carry a garbage viewBox) — a NaN or
     // zero dimension would otherwise produce scale(NaN) and a broken badge.
     const vbMatch = innerSvg.match(/viewBox="([^"]+)"/)
-    const viewBox = vbMatch ? vbMatch[1].split(/\s+/).map(Number) : [0, 0, 24, 24]
+    const viewBox = vbMatch ? vbMatch[1].split(/[\s,]+/).map(Number) : [0, 0, 24, 24]
     let [, , vbWidth, vbHeight] = viewBox
     if (!Number.isFinite(vbWidth) || vbWidth <= 0) vbWidth = 24
     if (!Number.isFinite(vbHeight) || vbHeight <= 0) vbHeight = 24
 
-    // Extract any <g transform="..."> wrapper from inner SVG (e.g. rotation)
-    const gTransformMatch = innerSvg.match(/<g\s+transform="([^"]+)">/)
-    const innerTransform = gTransformMatch ? gTransformMatch[1] : null
+    // Take the inner SVG's content verbatim (everything between the outer
+    // <svg> tags). This preserves nested groups, multiple fills, rotation
+    // transforms, etc. — exactly what makes flags/emoji multi-color.
+    let inner = innerSvg
+      .replace(/^[\s\S]*?<svg\b[^>]*>/, "")
+      .replace(/<\/svg>\s*$/, "")
+      .trim()
+    // Strip serialization artifacts: Satori writes undefined props out as the
+    // literal string "undefined" (e.g. fill-rule="undefined"), which is an
+    // invalid value that strict SVG parsers reject.
+    inner = inner.replace(/\s+[a-zA-Z-]+="undefined"/g, "")
+    if (!inner) return match
 
-    // Extract path(s) from inner SVG
-    const paths: string[] = []
-    const pathRegex = /<path\s+([^>]+)>/g
-    let pathMatch: RegExpExecArray | null
-    while ((pathMatch = pathRegex.exec(innerSvg)) !== null) {
-      paths.push(`<path ${pathMatch[1]}/>`)
+    // Respect the placement intent. Satori uses preserveAspectRatio="none"
+    // for <img> insets that should fill the box (flags), and the default
+    // meet behaviour for icons that should keep aspect (contain + center).
+    const par = (attrs.match(/preserveAspectRatio="([^"]+)"/)?.[1] ?? "").trim()
+    const scaleX = width / vbWidth
+    const scaleY = height / vbHeight
+
+    let transform: string
+    if (par === "none") {
+      transform = `translate(${x},${y}) scale(${scaleX},${scaleY})`
+    } else {
+      const scale = Math.min(scaleX, scaleY)
+      const tx = x + (width - vbWidth * scale) / 2
+      const ty = y + (height - vbHeight * scale) / 2
+      transform = `translate(${tx},${ty}) scale(${scale})`
     }
 
-    if (paths.length === 0) return match
-
-    // Calculate scale to fit width x height
-    const scaleX = parseFloat(width) / vbWidth
-    const scaleY = parseFloat(height) / vbHeight
-    const scale = Math.min(scaleX, scaleY)
-
-    // Create a group with transform to position and scale the paths
-    // If inner SVG had a transform (e.g. rotation), nest it inside
-    const pathContent = innerTransform
-      ? `<g transform="${innerTransform}">${paths.join("")}</g>`
-      : paths.join("")
-    return `<g transform="translate(${x},${y}) scale(${scale})">${pathContent}</g>`
+    return `<g transform="${transform}">${inner}</g>`
   })
+}
+
+/**
+ * Rewrite `rgba()` color values into editor-portable `#hex` + `*-opacity`.
+ *
+ * Satori bakes opacity into `fill="rgba(r,g,b,a)"` (we deliberately avoid the
+ * CSS `opacity` property because of a Satori bug). Browsers and Quick Look
+ * accept `rgba()` in a presentation attribute, but it is NOT valid SVG 1.1 —
+ * Photoshop / Illustrator drop the color and paint the element black or
+ * transparent. That is why downloaded badges "lose their colors" in editors.
+ *
+ * Converting to `fill="#rrggbb" fill-opacity="a"` is universally supported and
+ * renders identically everywhere.
+ */
+function rgbaToHexOpacity(svg: string): string {
+  let out = svg
+  for (const attr of ["fill", "stroke", "stop-color"] as const) {
+    const re = new RegExp(
+      `${attr}="rgba\\(\\s*([0-9.]+)\\s*,\\s*([0-9.]+)\\s*,\\s*([0-9.]+)\\s*,\\s*([0-9.]+)\\s*\\)"`,
+      "g",
+    )
+    out = out.replace(re, (_m, r: string, g: string, b: string, a: string) => {
+      const hex =
+        "#" +
+        [r, g, b]
+          .map((n) => Math.max(0, Math.min(255, Math.round(Number(n)))).toString(16).padStart(2, "0"))
+          .join("")
+      const alpha = Number(a)
+      if (!Number.isFinite(alpha) || alpha >= 1) return `${attr}="${hex}"`
+      const op = Math.max(0, alpha)
+      return `${attr}="${hex}" ${attr}-opacity="${+op.toFixed(3)}"`
+    })
+  }
+  return out
 }
 
 export async function renderErrorBadge(label: string, message: string): Promise<string> {

--- a/packages/web/app/showcase/showcase-client.tsx
+++ b/packages/web/app/showcase/showcase-client.tsx
@@ -171,7 +171,7 @@ export default function ShowcasePage() {
         className="mx-auto w-full max-w-7xl space-y-6 px-4 py-8 md:px-8 md:py-10"
       >
         <div className="space-y-4">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <h1 id="badge-explorer-title" className="font-heading text-3xl font-semibold tracking-tight md:text-5xl">
                 Showcased badges

--- a/packages/web/app/showcase/showcase-client.tsx
+++ b/packages/web/app/showcase/showcase-client.tsx
@@ -1,167 +1,200 @@
 "use client"
 
-import Link from "next/link"
-import { useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react"
 import { Search, X } from "lucide-react"
-import { BadgeCard } from "@/components/badge-card"
+import { BadgeGroupModal } from "@/components/badge-group-modal"
+import { BadgeModal } from "@/components/badge-modal"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Badge } from "@/components/ui/badge"
-import { ShowcaseSubmitDialog } from "@/components/showcase-submit-dialog"
-import { featuredBadges, categories, groupShowcaseItems } from "@/lib/showcase-data"
-import { GroupShowcase } from "@/components/group-showcase"
-import { AnimatedShowcase } from "@/components/animated-showcase"
+import { Kbd } from "@/components/ui/kbd"
+import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover"
+import { useBadgeMode } from "@/lib/use-badge-mode"
+import { cn } from "@/lib/utils"
+import {
+  categories,
+  featuredBadges,
+  groupShowcaseItems,
+  type GroupShowcaseItem,
+  type ShowcaseBadge,
+} from "@/lib/showcase-data"
 
-const ALL_CATEGORY_NAMES = ["All", ...categories.map((c) => c.name)]
-const totalIconCount = categories.reduce((sum, c) => sum + c.icons.length, 0)
+type ShowcaseCategory = (typeof categories)[number]
+type ShowcaseItem =
+  | { kind: "badge"; badge: ShowcaseBadge; weight: number }
+  | { kind: "group"; group: GroupShowcaseItem; weight: number }
+
+const displayCategories = combineCategories(categories)
+const categoryNames = ["All", "Groups", ...displayCategories.map((category) => category.name)]
+const totalIconCount = uniqueBadges([
+  ...featuredBadges,
+  ...displayCategories.flatMap((category) => category.icons),
+]).length + groupShowcaseItems.length
+
+const subscribeToHydration = () => () => {}
+const getHydratedSnapshot = () => true
+const getServerSnapshot = () => false
+
+function useHydrated() {
+  return useSyncExternalStore(subscribeToHydration, getHydratedSnapshot, getServerSnapshot)
+}
+
+function uniqueBadges(badges: ShowcaseBadge[]) {
+  return Array.from(new Map(badges.map((badge) => [badge.badgePath, badge])).values())
+}
+
+function badgeItems(badges: ShowcaseBadge[], offset = 0): ShowcaseItem[] {
+  return uniqueBadges(badges).map((badge, index) => ({
+    kind: "badge",
+    badge,
+    weight: index + offset,
+  }))
+}
+
+function groupItems(offset = 0): ShowcaseItem[] {
+  return groupShowcaseItems.map((group, index) => ({
+    kind: "group",
+    group,
+    weight: index + offset,
+  }))
+}
+
+function combineCategories(source: ShowcaseCategory[]) {
+  return source.reduce<ShowcaseCategory[]>((acc, category) => {
+    const existing = acc.find((item) => item.name === category.name)
+
+    if (existing) {
+      existing.icons = uniqueBadges([...existing.icons, ...category.icons])
+      return acc
+    }
+
+    acc.push({ ...category })
+    return acc
+  }, [])
+}
+
+function allShowcaseItems() {
+  const badges = badgeItems([
+    ...featuredBadges,
+    ...displayCategories.flatMap((category) => category.icons),
+  ])
+  const groups = groupItems(500)
+  const firstGroups = groups.slice(0, 3)
+  const remainingGroups = groups.slice(3)
+
+  return [
+    ...badges.slice(0, 5),
+    ...firstGroups,
+    ...badges.slice(5, 18),
+    ...remainingGroups,
+    ...badges.slice(18),
+  ]
+}
+
+const ALL_ITEMS = allShowcaseItems()
+const AUTO_CLOSE_THRESHOLD = 10
+
+function categoryCount(name: string) {
+  if (name === "All") return totalIconCount
+  if (name === "Groups") return groupShowcaseItems.length
+  return displayCategories.find((category) => category.name === name)?.icons.length ?? 0
+}
+
+function computeItems(category: string, query: string): ShowcaseItem[] {
+  const base = category === "All"
+    ? ALL_ITEMS
+    : category === "Groups"
+      ? groupItems()
+      : badgeItems(displayCategories.find((c) => c.name === category)?.icons ?? [])
+
+  const q = query.trim().toLowerCase()
+  if (!q) return base
+
+  return base.filter((item) =>
+    item.kind === "badge" ? badgeMatches(item.badge, q) : groupMatches(item.group, q)
+  )
+}
+
+function badgeMatches(badge: ShowcaseBadge, q: string) {
+  return [badge.title, badge.subtitle, badge.description ?? ""].some((value) =>
+    value.toLowerCase().includes(q)
+  )
+}
+
+function groupMatches(group: GroupShowcaseItem, q: string) {
+  return [group.title, group.description].some((value) => value.toLowerCase().includes(q))
+}
+
+function buildCategoryOptions(q: string): { name: string; count: number }[] {
+  if (!q) {
+    return categoryNames.map((name) => ({ name, count: categoryCount(name) }))
+  }
+
+  const groupCount = groupShowcaseItems.filter((group) => groupMatches(group, q)).length
+  const badgeCount = uniqueBadges([
+    ...featuredBadges,
+    ...displayCategories.flatMap((category) => category.icons),
+  ]).filter((badge) => badgeMatches(badge, q)).length
+
+  const options: { name: string; count: number }[] = [
+    { name: "All", count: badgeCount + groupCount },
+  ]
+
+  if (groupCount > 0) options.push({ name: "Groups", count: groupCount })
+
+  for (const category of displayCategories) {
+    const count = category.icons.filter((badge) => badgeMatches(badge, q)).length
+    if (count > 0) options.push({ name: category.name, count })
+  }
+
+  return options
+}
 
 export default function ShowcasePage() {
   const [searchQuery, setSearchQuery] = useState("")
   const [activeCategory, setActiveCategory] = useState("All")
 
-  const activeCategoryData = categories.find((c) => c.name === activeCategory)
-  const nbaCategory = categories.find((c) => c.name === "NBA")
+  const filteredItems = useMemo(
+    () => computeItems(activeCategory, searchQuery),
+    [activeCategory, searchQuery]
+  )
 
-  const filteredIcons = useMemo(() => {
-    const icons = activeCategory === "All"
-      ? Array.from(
-          new Map(categories.flatMap((c) => c.icons).map((icon) => [icon.badgePath, icon])).values()
-        )
-      : activeCategoryData?.icons ?? []
-
-    if (!searchQuery.trim()) return icons
-
-    const q = searchQuery.toLowerCase()
-    return icons.filter((icon) =>
-      [icon.title, icon.subtitle, icon.description ?? ""].some((value) =>
-        value.toLowerCase().includes(q)
-      )
-    )
-  }, [activeCategory, activeCategoryData, searchQuery])
+  const countFor = useCallback(
+    (query: string) => computeItems(activeCategory, query).length,
+    [activeCategory]
+  )
 
   return (
     <main className="min-w-0 flex-1">
-      <div className="mx-auto max-w-6xl space-y-8 px-4 py-14 md:px-8">
-        <div className="space-y-3">
-          <h1 className="text-3xl font-bold tracking-tight">Badge Showcase</h1>
-          <p className="max-w-3xl text-sm leading-relaxed text-muted-foreground">
-            A curated set of shieldcn badge examples designed to look good in real-world README rows,
-            docs pages, package pages, and community sections. Click any card to tweak it and copy the exact output.
-          </p>
-          <div className="flex items-center gap-3">
-            <p className="text-xs text-muted-foreground">
-              {totalIconCount}+ curated examples · focused on useful, polished badge patterns
+      <section
+        id="badge-explorer"
+        aria-labelledby="badge-explorer-title"
+        className="mx-auto w-full max-w-7xl space-y-6 px-4 py-8 md:px-8 md:py-10"
+      >
+        <div className="space-y-4">
+          <div>
+            <h1 id="badge-explorer-title" className="font-heading text-3xl font-semibold tracking-tight md:text-5xl">
+              Showcased badges
+            </h1>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {filteredItems.length} visible of {totalIconCount} showcased badges
             </p>
-            <ShowcaseSubmitDialog />
           </div>
-        </div>
-
-        <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <h2 className="text-sm font-semibold tracking-wide text-muted-foreground uppercase">Featured examples</h2>
-            <span className="text-xs text-muted-foreground">starter row ideas</span>
-          </div>
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
-            {featuredBadges.map((badge) => (
-              <BadgeCard key={`featured-${badge.badgePath}-${badge.title}`} badge={badge} />
-            ))}
-          </div>
-        </div>
-
-        {nbaCategory ? (
-          <div className="space-y-3 rounded-xl border border-border bg-card/40 p-4">
-            <div className="flex items-center justify-between">
-              <div>
-                <h2 className="text-sm font-semibold tracking-wide text-muted-foreground uppercase">NBA team badges</h2>
-                <p className="mt-1 text-xs text-muted-foreground">Fan badges with full-color team logos and team-color branded variants.</p>
-              </div>
-              <Button variant="outline" size="sm" onClick={() => setActiveCategory("NBA")}>View all</Button>
-            </div>
-            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
-              {nbaCategory.icons.slice(0, 6).map((badge) => (
-                <BadgeCard key={`nba-featured-${badge.badgePath}-${badge.title}`} badge={badge} />
-              ))}
-            </div>
-          </div>
-        ) : null}
-
-        {/* Animated badges — live <img> row */}
-        <AnimatedShowcase />
-
-        {/* Badge Groups — bento grid */}
-        <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <h2 className="text-sm font-semibold tracking-wide text-muted-foreground uppercase">Badge Groups</h2>
-            <Link href="/docs/badges/group" className="text-xs text-muted-foreground hover:text-foreground transition-colors">docs →</Link>
-          </div>
-          <GroupShowcase items={groupShowcaseItems} />
-        </div>
-
-        <div className="relative">
-          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder="Search badges by name, provider, or use case…"
-            className="h-10 pl-9 pr-9"
+          <CategorySearch
+            searchQuery={searchQuery}
+            setSearchQuery={setSearchQuery}
+            activeCategory={activeCategory}
+            setActiveCategory={setActiveCategory}
+            countFor={countFor}
           />
-          {searchQuery ? (
-            <button
-              type="button"
-              onClick={() => setSearchQuery("")}
-              className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
-            >
-              <X className="size-4" />
-            </button>
-          ) : null}
         </div>
 
-        <div className="flex flex-wrap gap-2">
-          {ALL_CATEGORY_NAMES.map((cat) => {
-            const count = cat === "All"
-              ? totalIconCount
-              : categories.find((c) => c.name === cat)?.icons.length ?? 0
-            const isActive = activeCategory === cat
-
-            return (
-              <button
-                key={cat}
-                type="button"
-                onClick={() => setActiveCategory(cat)}
-                className={`inline-flex items-center gap-1.5 rounded-md border px-3 py-2 text-xs transition-colors ${
-                  isActive
-                    ? "border-primary bg-primary text-primary-foreground"
-                    : "border-border bg-background text-foreground hover:bg-muted"
-                }`}
-              >
-                <span>{cat}</span>
-                <Badge
-                  variant={isActive ? "outline" : "secondary"}
-                  className={isActive
-                    ? "h-4 min-w-[18px] justify-center border-primary-foreground/20 bg-primary-foreground/10 px-1 text-[10px] text-primary-foreground"
-                    : "h-4 min-w-[18px] justify-center px-1 text-[10px]"
-                  }
-                >
-                  {count}
-                </Badge>
-              </button>
-            )
-          })}
-        </div>
-
-        {activeCategory !== "All" && activeCategoryData ? (
-          <div className="rounded-lg border border-border bg-card/50 p-4">
-            <p className="text-sm font-medium">{activeCategoryData.name}</p>
-            <p className="mt-1 text-xs text-muted-foreground">{activeCategoryData.description}</p>
-          </div>
-        ) : null}
-
-        {filteredIcons.length === 0 ? (
-          <div className="flex flex-col items-center gap-3 py-20 text-center">
-            <div className="text-4xl opacity-30">🔍</div>
+        {filteredItems.length === 0 ? (
+          <div className="flex flex-col items-center gap-3 rounded-2xl border border-dashed border-border py-20 text-center">
+            <div className="rounded-full bg-muted p-4 text-3xl">🔍</div>
             <div>
-              <p className="text-sm font-medium">No badges found</p>
-              <p className="mt-1 text-xs text-muted-foreground">Try a different search or switch category.</p>
+              <p className="text-sm font-medium">No matching badges</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Nothing matches that search and category. Clear the filters to see all badges.
+              </p>
             </div>
             <Button
               variant="outline"
@@ -175,21 +208,322 @@ export default function ShowcasePage() {
             </Button>
           </div>
         ) : (
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-            {filteredIcons.map((badge) => (
-              <BadgeCard key={`${activeCategory}-${badge.badgePath}-${badge.title}`} badge={badge} />
-            ))}
+          <div className="flex flex-wrap gap-2">
+            {filteredItems.map((item) =>
+              item.kind === "badge" ? (
+                <BadgeBrick
+                  key={`${activeCategory}-${item.badge.badgePath}-${item.badge.title}`}
+                  badge={item.badge}
+                  weight={item.weight}
+                />
+              ) : (
+                <GroupBrick
+                  key={`${activeCategory}-${item.group.badgePath}-${item.group.title}`}
+                  item={item.group}
+                  weight={item.weight}
+                />
+              )
+            )}
           </div>
         )}
-
-        {filteredIcons.length > 0 ? (
-          <p className="text-center text-xs text-muted-foreground">
-            {filteredIcons.length} badge{filteredIcons.length === 1 ? "" : "s"}
-            {searchQuery ? ` matching "${searchQuery}"` : ""}
-            {activeCategory !== "All" ? ` in ${activeCategory}` : ""}
-          </p>
-        ) : null}
-      </div>
+      </section>
     </main>
+  )
+}
+
+function CategorySearch({
+  searchQuery,
+  setSearchQuery,
+  activeCategory,
+  setActiveCategory,
+  countFor,
+}: {
+  searchQuery: string
+  setSearchQuery: (query: string) => void
+  activeCategory: string
+  setActiveCategory: (category: string) => void
+  countFor: (query: string) => number
+}) {
+  const [open, setOpen] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(0)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key !== "/") return
+
+      const target = event.target as HTMLElement | null
+      const tag = target?.tagName
+      const isEditable =
+        tag === "INPUT" || tag === "TEXTAREA" || target?.isContentEditable
+      if (isEditable) return
+
+      event.preventDefault()
+      inputRef.current?.focus()
+    }
+
+    window.addEventListener("keydown", onKeyDown)
+    return () => window.removeEventListener("keydown", onKeyDown)
+  }, [])
+
+  const q = searchQuery.trim().toLowerCase()
+  const options = buildCategoryOptions(q)
+  const currentIndex = Math.min(activeIndex, options.length - 1)
+
+  function scrollOptionIntoView(index: number) {
+    listRef.current
+      ?.querySelector(`[data-option-index="${index}"]`)
+      ?.scrollIntoView({ block: "nearest" })
+  }
+
+  function moveActive(delta: number) {
+    if (!open) {
+      setOpen(true)
+      return
+    }
+    const next = (currentIndex + delta + options.length) % options.length
+    setActiveIndex(next)
+    scrollOptionIntoView(next)
+  }
+
+  function commitActive() {
+    const option = options[currentIndex]
+    if (!option) return
+    setActiveCategory(option.name)
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverAnchor asChild>
+        <div
+          className="flex h-11 w-full items-center gap-2 rounded-xl border border-border bg-card px-3 shadow-xs transition-colors focus-within:border-primary/50 focus-within:ring-2 focus-within:ring-ring"
+          onClick={() => {
+            setOpen(true)
+            inputRef.current?.focus()
+          }}
+        >
+          <Search className="size-4 shrink-0 text-muted-foreground" />
+
+          {activeCategory !== "All" ? (
+            <span className="inline-flex shrink-0 items-center gap-1 rounded-md border border-border bg-background px-2 py-1 text-xs">
+              {activeCategory}
+              <button
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  setActiveCategory("All")
+                }}
+                className="rounded-sm text-muted-foreground transition-colors hover:text-foreground"
+                aria-label="Clear category filter"
+              >
+                <X className="size-3" />
+              </button>
+            </span>
+          ) : null}
+
+          <input
+            ref={inputRef}
+            value={searchQuery}
+            onChange={(event) => {
+              const value = event.target.value
+              setSearchQuery(value)
+              setActiveIndex(0)
+              const count = countFor(value)
+              setOpen(!(value.trim() && count > 0 && count <= AUTO_CLOSE_THRESHOLD))
+            }}
+            onFocus={() => setOpen(true)}
+            onKeyDown={(event) => {
+              if (event.key === "Escape") {
+                setOpen(false)
+              } else if (event.key === "ArrowDown") {
+                event.preventDefault()
+                moveActive(1)
+              } else if (event.key === "ArrowUp") {
+                event.preventDefault()
+                moveActive(-1)
+              } else if (event.key === "Enter" && open) {
+                event.preventDefault()
+                commitActive()
+              }
+            }}
+            placeholder="Search badges or filter by category"
+            className="h-full min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+            role="combobox"
+            aria-expanded={open}
+            aria-controls="showcase-category-list"
+            aria-activedescendant={open ? `showcase-category-${currentIndex}` : undefined}
+            aria-label="Search badges or filter by category"
+          />
+
+          {searchQuery ? (
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation()
+                setSearchQuery("")
+              }}
+              className="rounded-sm text-muted-foreground transition-colors hover:text-foreground"
+              aria-label="Clear badge search"
+            >
+              <X className="size-4" />
+            </button>
+          ) : (
+            <Kbd className="shrink-0">/</Kbd>
+          )}
+        </div>
+      </PopoverAnchor>
+
+      <PopoverContent
+        align="end"
+        sideOffset={6}
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        className="max-h-80 w-(--radix-popover-trigger-width) overflow-y-auto p-1.5"
+      >
+        <p className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
+          {q ? "Categories with matches" : "Filter by category"}
+        </p>
+        <div ref={listRef} id="showcase-category-list" role="listbox" className="flex flex-col">
+          {options.map((option, index) => {
+            const isSelected = activeCategory === option.name
+            const isActive = index === currentIndex
+            return (
+              <button
+                key={option.name}
+                id={`showcase-category-${index}`}
+                data-option-index={index}
+                type="button"
+                role="option"
+                aria-selected={isSelected}
+                onPointerMove={() => setActiveIndex(index)}
+                onClick={() => {
+                  setActiveCategory(option.name)
+                  setOpen(false)
+                }}
+                className={cn(
+                  "flex min-h-10 items-center justify-between gap-3 rounded-md px-2 text-sm transition-colors duration-150 ease-out",
+                  isActive ? "bg-muted text-foreground" : "text-foreground",
+                  isSelected && !isActive ? "bg-muted/50" : ""
+                )}
+              >
+                <span className="truncate">{option.name}</span>
+                <span className="shrink-0 font-mono text-[11px] text-muted-foreground">
+                  {option.count}
+                </span>
+              </button>
+            )
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+function getBadgeFlex(weight: number, title: string) {
+  if (title.length > 24 || weight % 13 === 0) {
+    return "min-w-[15rem] max-w-[26rem] grow-[3]"
+  }
+  if (weight % 7 === 0 || weight % 11 === 0) {
+    return "min-w-[12.5rem] max-w-[22rem] grow-[2]"
+  }
+  return "min-w-[10rem] max-w-[18rem] grow"
+}
+
+function BadgeBrick({ badge, weight }: { badge: ShowcaseBadge; weight: number }) {
+  const [modalOpen, setModalOpen] = useState(false)
+  const mounted = useHydrated()
+  const { adaptUrl } = useBadgeMode()
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setModalOpen(true)}
+        className={cn(
+          "group flex h-28 min-w-0 basis-40 flex-col items-center justify-center gap-3 rounded-2xl border border-border bg-background p-3.5 text-center shadow-xs transition duration-200 ease-out hover:-translate-y-0.5 hover:border-primary/35 hover:bg-muted/35 hover:shadow-md hover:shadow-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:translate-y-0 active:scale-[0.99]",
+          getBadgeFlex(weight, badge.title)
+        )}
+        aria-label={`Customize ${badge.title} badge`}
+      >
+        <span className="flex flex-1 w-full items-center justify-center overflow-hidden">
+          {mounted ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={adaptUrl(badge.badgePath)}
+              alt={badge.title}
+              className="inline-block h-8 max-w-full"
+              loading="lazy"
+            />
+          ) : (
+            <span className="h-8" />
+          )}
+        </span>
+
+        <span className="w-full min-w-0">
+          <span className="block truncate text-sm font-medium leading-tight">{badge.title}</span>
+          <span className="mt-1 block truncate font-mono text-[10px] text-muted-foreground">
+            {badge.subtitle}
+          </span>
+        </span>
+      </button>
+
+      <BadgeModal
+        title={badge.title}
+        subtitle={badge.subtitle}
+        badgePath={badge.badgePath}
+        description={badge.description}
+        docsHref={badge.docsHref}
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+      />
+    </>
+  )
+}
+
+function GroupBrick({ item, weight }: { item: GroupShowcaseItem; weight: number }) {
+  const [modalOpen, setModalOpen] = useState(false)
+  const mounted = useHydrated()
+  const { adaptUrl } = useBadgeMode()
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setModalOpen(true)}
+        className={cn(
+          "group flex h-28 min-w-0 basis-72 flex-col items-center justify-center gap-3 rounded-2xl border border-border bg-background p-3.5 text-center shadow-xs transition duration-200 ease-out hover:-translate-y-0.5 hover:border-primary/35 hover:bg-muted/35 hover:shadow-md hover:shadow-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:translate-y-0 active:scale-[0.99]",
+          weight % 2 === 0 ? "min-w-[18rem] max-w-[34rem] grow-[4]" : "min-w-[16rem] max-w-[30rem] grow-[3]"
+        )}
+        aria-label={`Customize ${item.title} badge group`}
+      >
+        <span className="flex flex-1 w-full items-center justify-center overflow-hidden">
+          {mounted ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={adaptUrl(item.badgePath)}
+              alt={item.title}
+              className="inline-block h-8 max-w-full"
+              loading="lazy"
+            />
+          ) : (
+            <span className="h-8" />
+          )}
+        </span>
+
+        <span className="w-full min-w-0">
+          <span className="block truncate text-sm font-medium leading-tight">{item.title}</span>
+          <span className="mt-1 block truncate text-[11px] text-muted-foreground">badge group</span>
+        </span>
+      </button>
+
+      <BadgeGroupModal
+        title={item.title}
+        description={item.description}
+        badgePath={item.badgePath}
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+      />
+    </>
   )
 }

--- a/packages/web/app/showcase/showcase-client.tsx
+++ b/packages/web/app/showcase/showcase-client.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore
 import { Search, X } from "lucide-react"
 import { BadgeGroupModal } from "@/components/badge-group-modal"
 import { BadgeModal } from "@/components/badge-modal"
+import { ShowcaseSubmitDialog } from "@/components/showcase-submit-dialog"
 import { Button } from "@/components/ui/button"
 import { Kbd } from "@/components/ui/kbd"
 import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover"
@@ -170,13 +171,16 @@ export default function ShowcasePage() {
         className="mx-auto w-full max-w-7xl space-y-6 px-4 py-8 md:px-8 md:py-10"
       >
         <div className="space-y-4">
-          <div>
-            <h1 id="badge-explorer-title" className="font-heading text-3xl font-semibold tracking-tight md:text-5xl">
-              Showcased badges
-            </h1>
-            <p className="mt-2 text-sm text-muted-foreground">
-              {filteredItems.length} visible of {totalIconCount} showcased badges
-            </p>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <h1 id="badge-explorer-title" className="font-heading text-3xl font-semibold tracking-tight md:text-5xl">
+                Showcased badges
+              </h1>
+              <p className="mt-2 text-sm text-muted-foreground">
+                {filteredItems.length} visible of {totalIconCount} showcased badges
+              </p>
+            </div>
+            <ShowcaseSubmitDialog />
           </div>
           <CategorySearch
             searchQuery={searchQuery}

--- a/packages/web/components/showcase-submit-dialog.tsx
+++ b/packages/web/components/showcase-submit-dialog.tsx
@@ -8,7 +8,7 @@
 
 "use client"
 
-import { useState, useCallback, useMemo, useEffect } from "react"
+import { useEffect, useMemo, useState, useSyncExternalStore } from "react"
 import { Send, Loader2, Check, ExternalLink } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -51,8 +51,11 @@ export function ShowcaseSubmitDialog() {
   const [errorMsg, setErrorMsg] = useState("")
   const [prUrl, setPrUrl] = useState("")
 
-  const [baseUrl, setBaseUrl] = useState("https://shieldcn.dev")
-  useEffect(() => { setBaseUrl(window.location.origin) }, [])
+  const baseUrl = useSyncExternalStore(
+    () => () => {},
+    () => window.location.origin,
+    () => "https://shieldcn.dev"
+  )
 
   const badgeUrl = useMemo(() => buildBadgeUrl(s, baseUrl), [s, baseUrl])
   const badgePath = useMemo(() => buildBadgePath(s), [s])
@@ -118,7 +121,7 @@ export function ShowcaseSubmitDialog() {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button variant="outline" size="sm" className="gap-2">
+        <Button size="sm" className="gap-2">
           <Send className="size-3.5" />
           Submit your badge
         </Button>


### PR DESCRIPTION
## What

Rebuild the `/showcase` page as a single justified bento of clickable badge bricks.

- One full-width, gapless bento that fills the container; variable-width bricks with the badge image centered and the name/subtitle below.
- Badge groups are interleaved into the same feed (not a separate section).
- Search and category filtering merged into one combobox: `/` focus shortcut with a visible key hint, full keyboard navigation (arrows / enter / escape), and ARIA `combobox` + `listbox` semantics.
- Category dropdown only lists categories that contain badges matching the current search (e.g. "brazil" surfaces Location, not group categories), with live match counts.
- Dropdown auto-closes once results narrow to ten or fewer so the grid is immediately visible.
- Removed the old hero, live-wall, featured, and animated sections per design direction; renamed the surface to "Showcased badges".

## Why

The previous showcase was text-heavy and the layout did not read as a cohesive board. This makes the badges themselves the focus and gives a faster path from browse to copy.

## Type

- [x] `feat` — New feature

## Checklist

- [x] Branch follows conventional naming (`feat/`)
- [x] Commits follow Conventional Commits
- [x] Tested locally with `pnpm dev`
- [x] `eslint` and `tsc --noEmit` pass; production `build` passes

## Screenshots

_Showcased badges bento with the merged search/category combobox open._
