### PR TITLE
feat(charts): add shadcn-styled charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,27 @@ For `.svg` badges the animation is pure CSS — no JavaScript — and automatica
 
 See the [API reference](https://shieldcn.dev/docs/api-reference) for the full list of animation options.
 
+### Charts
+
+Shadcn-styled line/area graphs — GitHub star history (like
+[starcharts](https://github.com/caarlos0/starcharts)), issues over time, npm
+downloads, and your own JSON data — all as portable SVGs:
+
+<p>
+  <img src="https://shieldcn.dev/chart/github/stars/vercel/next.js.svg" alt="vercel/next.js star history" />
+</p>
+
+```md
+![Star History](https://shieldcn.dev/chart/github/stars/vercel/next.js.svg)
+![Issues](https://shieldcn.dev/chart/github/issues/honojs/hono.svg)
+![npm downloads](https://shieldcn.dev/chart/npm/zod.svg)
+![Custom](https://shieldcn.dev/chart/json.svg?values=10,25,40,30,60&title=Metric)
+```
+
+Available as `.svg`, `.png`, and `.json`. Customize with `mode`, `theme`,
+`color`, `fill`, `area`, `bg`, `border`, `font`, `width`, `height`, and
+`title`. See the [Charts docs](https://shieldcn.dev/docs/charts).
+
 ## Supported providers
 
 See the [docs](https://shieldcn.dev/docs) for full endpoint details, interactive sandboxes, and copy-paste examples.

--- a/packages/core/src/badges/chart-route.test.ts
+++ b/packages/core/src/badges/chart-route.test.ts
@@ -1,0 +1,79 @@
+/**
+ * shieldcn
+ * src/badges/chart-route.test
+ *
+ * End-to-end: handleBadgeGET routes /chart/... through the star-history
+ * provider and the chart renderer. GitHub is stubbed via global fetch.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { handleBadgeGET } from "../route-handler"
+
+function ghStub() {
+  const stargazers = Array.from({ length: 40 }, (_, i) => ({
+    starred_at: new Date(Date.UTC(2022, 0, 1) + i * 86400000).toISOString(),
+  }))
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.includes("/stargazers")) {
+      // Page 1 has data, later pages are empty.
+      const page = Number(new URL(url).searchParams.get("page") || "1")
+      const body = page === 1 ? stargazers : []
+      return new Response(JSON.stringify(body), { status: 200 })
+    }
+    if (url.match(/\/repos\/[^/]+\/[^/]+$/)) {
+      return new Response(JSON.stringify({ stargazers_count: 40 }), { status: 200 })
+    }
+    return new Response("[]", { status: 200 })
+  })
+}
+
+describe("handleBadgeGET /chart", () => {
+  const realFetch = globalThis.fetch
+  beforeEach(() => { globalThis.fetch = ghStub() as unknown as typeof fetch })
+  afterEach(() => { globalThis.fetch = realFetch })
+
+  it("renders a star-history SVG", async () => {
+    const req = new Request("https://x.dev/chart/github/stars/vercel/next.js.svg?theme=blue")
+    const res = await handleBadgeGET(req, ["chart", "github", "stars", "vercel", "next.js.svg"])
+    expect(res.status).toBe(200)
+    expect(res.headers.get("Content-Type")).toBe("image/svg+xml")
+    const svg = await res.text()
+    expect(svg.startsWith("<svg")).toBe(true)
+    expect(svg).toContain("vercel/next.js")
+    expect(svg).not.toContain("NaN")
+  })
+
+  it("returns JSON time series for .json", async () => {
+    const req = new Request("https://x.dev/chart/github/stars/vercel/next.js.json")
+    const res = await handleBadgeGET(req, ["chart", "github", "stars", "vercel", "next.js.json"])
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.total).toBe(40)
+    expect(Array.isArray(data.points)).toBe(true)
+    expect(data.points.length).toBeGreaterThan(1)
+  })
+
+  it("shows a usage error for a malformed path", async () => {
+    const req = new Request("https://x.dev/chart/github/stars.svg")
+    const res = await handleBadgeGET(req, ["chart", "github", "stars.svg"])
+    const svg = await res.text()
+    expect(svg).toContain("usage:")
+  })
+
+  it("renders an inline JSON chart from ?values=", async () => {
+    const req = new Request("https://x.dev/chart/json.svg?values=10,25,40,30,60&title=Latency&label=ms")
+    const res = await handleBadgeGET(req, ["chart", "json.svg"])
+    expect(res.status).toBe(200)
+    const svg = await res.text()
+    expect(svg).toContain("Latency")
+    expect(svg).not.toContain("NaN")
+  })
+
+  it("returns inline JSON points for .json", async () => {
+    const req = new Request("https://x.dev/chart/json.json?values=5,10,15")
+    const res = await handleBadgeGET(req, ["chart", "json.json"])
+    const data = await res.json()
+    expect(data.points.map((p: { value: number }) => p.value)).toEqual([5, 10, 15])
+  })
+})

--- a/packages/core/src/badges/render-chart.test.ts
+++ b/packages/core/src/badges/render-chart.test.ts
@@ -1,0 +1,112 @@
+/**
+ * shieldcn
+ * src/badges/render-chart.test
+ */
+
+import { describe, it, expect } from "vitest"
+import { renderChart, resolveAccent, type ChartPoint } from "./render-chart"
+
+function synth(n: number): ChartPoint[] {
+  const pts: ChartPoint[] = []
+  let value = 0
+  const start = new Date("2022-01-01").getTime()
+  for (let i = 0; i < n; i++) {
+    value += 100 + i * 7
+    pts.push({ date: new Date(start + i * 86400000 * 30).toISOString(), value })
+  }
+  return pts
+}
+
+describe("renderChart", () => {
+  it("produces a valid SVG in both modes", () => {
+    const pts = synth(30)
+    for (const mode of ["dark", "light"] as const) {
+      const svg = renderChart({
+        title: "vercel/next.js",
+        subtitle: "12k stars",
+        series: [{ label: "next.js", points: pts, color: resolveAccent("blue", null) }],
+        width: 800,
+        height: 400,
+        mode,
+        area: true,
+      })
+      expect(svg.startsWith("<svg")).toBe(true)
+      expect(svg.includes("</svg>")).toBe(true)
+      expect(svg).toContain("linearGradient")
+      expect(svg).toContain("vercel/next.js")
+      // no NaN leaked into coordinates
+      expect(svg).not.toContain("NaN")
+    }
+  })
+
+  it("handles a single point gracefully (degenerate domain)", () => {
+    const svg = renderChart({
+      title: "a/b",
+      series: [{ label: "b", points: [{ date: new Date().toISOString(), value: 1 }], color: "#3b82f6" }],
+      width: 600,
+      height: 300,
+      mode: "dark",
+      area: true,
+    })
+    expect(svg).not.toContain("NaN")
+    expect(svg.includes("</svg>")).toBe(true)
+  })
+
+  it("escapes title text", () => {
+    const svg = renderChart({
+      title: "<script>&\"",
+      series: [],
+      width: 400,
+      height: 200,
+      mode: "dark",
+      area: false,
+    })
+    expect(svg).not.toContain("<script>")
+    expect(svg).toContain("&lt;script&gt;")
+  })
+
+  it("renders an index axis when points have no dates", () => {
+    const svg = renderChart({
+      title: "inline",
+      series: [{ label: "v", points: [10, 25, 40, 30, 60].map((value) => ({ value })), color: "#3b82f6" }],
+      width: 600,
+      height: 300,
+      mode: "dark",
+      area: true,
+    })
+    expect(svg).not.toContain("NaN")
+    expect(svg.includes("</svg>")).toBe(true)
+    // index axis labels start at 1
+    expect(svg).toContain(">1<")
+  })
+
+  it("supports log scale and custom y-domain / tick counts", () => {
+    const pts = [1, 10, 100, 1000, 10000].map((value, i) => ({
+      date: new Date(2022, 0, 1 + i).toISOString(),
+      value,
+    }))
+    const svg = renderChart({
+      title: "log",
+      series: [{ label: "v", points: pts, color: "#3b82f6" }],
+      width: 700,
+      height: 350,
+      mode: "dark",
+      area: true,
+      yScale: "log",
+      yMin: 1,
+      yMax: 10000,
+      yTicks: 5,
+      xTicks: 6,
+    })
+    expect(svg).not.toContain("NaN")
+    expect(svg.includes("</svg>")).toBe(true)
+    // 6 x-ticks + 6 y-tick labels (yTicks=5 → 6 labels) => many <text> nodes
+    expect((svg.match(/<text /g) || []).length).toBeGreaterThanOrEqual(12)
+  })
+
+  it("resolveAccent honors color > theme > default", () => {
+    expect(resolveAccent("blue", "ff0000")).toBe("#ff0000")
+    expect(resolveAccent("blue", null)).toMatch(/^#/)
+    expect(resolveAccent(null, null)).toBe("#3b82f6")
+  })
+})

--- a/packages/core/src/badges/render-chart.ts
+++ b/packages/core/src/badges/render-chart.ts
@@ -1,0 +1,453 @@
+/**
+ * shieldcn
+ * src/badges/render-chart
+ *
+ * Hand-built SVG line/area chart with shadcn styling. Used for star-history
+ * charts (like starcharts) but generic over any cumulative time series.
+ *
+ * SVGs served as `<img>` are sandboxed — no external CSS, no CSS variables.
+ * Everything here resolves to inline attributes/values. Text uses a system
+ * sans stack (the same approach starcharts uses) so charts render crisply in
+ * GitHub READMEs without an embedded font.
+ */
+
+import { formatCount } from "../format"
+import { resolveColor, themes, type ThemeName } from "./themes"
+
+/**
+ * A single point on a chart series. `date` (ISO-8601) places the point on a
+ * time axis; when a series has no dates the points are spaced evenly by index
+ * and `label` (if present) is used for the x-axis ticks.
+ */
+export interface ChartPoint {
+  value: number
+  date?: string
+  label?: string
+}
+
+/** shadcn card surface tokens per mode. */
+interface ChartSurface {
+  bg: string
+  border: string
+  grid: string
+  muted: string
+  fg: string
+}
+
+const SURFACE: Record<"dark" | "light", ChartSurface> = {
+  dark: {
+    bg: "#09090b", // zinc-950 (card)
+    border: "#27272a", // zinc-800
+    grid: "#27272a",
+    muted: "#a1a1aa", // zinc-400
+    fg: "#fafafa", // zinc-50
+  },
+  light: {
+    bg: "#ffffff",
+    border: "#e4e4e7", // zinc-200
+    grid: "#e4e4e7",
+    muted: "#71717a", // zinc-500
+    fg: "#18181b", // zinc-900
+  },
+}
+
+/** A line series with its accent color. */
+export interface ChartSeries {
+  label: string
+  points: ChartPoint[]
+  /** Line + end-dot color. */
+  color: string
+  /** Area fill color. Defaults to `color`. */
+  fill?: string
+}
+
+export interface ChartConfig {
+  title: string
+  subtitle?: string
+  series: ChartSeries[]
+  width: number
+  height: number
+  mode: "dark" | "light"
+  /** Show the area fill under the line. */
+  area: boolean
+  /** Optional link wrapping the whole chart. */
+  link?: string
+  /**
+   * Card background. `undefined` → mode default surface; `"transparent"` →
+   * no card fill (just the plot, useful for embedding on any page); any
+   * `#rrggbb` → explicit fill.
+   */
+  background?: string
+  /** Draw the rounded card border. Defaults to true. */
+  border?: boolean
+  /** font-family stack for all text. Defaults to the Inter stack. */
+  fontFamily?: string
+  /** Force the y-axis minimum (default 0 linear, smallest positive for log). */
+  yMin?: number
+  /** Force the y-axis maximum (default a nice ceiling above the data max). */
+  yMax?: number
+  /** y-axis scale type. Defaults to linear. */
+  yScale?: "linear" | "log"
+  /** Number of y-axis gridline intervals (labels = intervals + 1). */
+  yTicks?: number
+  /** Number of x-axis labels. */
+  xTicks?: number
+  /** Show the shieldcn watermark in the top-right corner. Defaults to true. */
+  logo?: boolean
+  /** Watermark color (defaults to the muted surface color). */
+  logoColor?: string
+  /** Optional icon drawn to the left of the title (resolved SimpleIcons data). */
+  titleIcon?: {
+    path?: string
+    paths?: string[]
+    viewBox?: string
+    fillRule?: string
+    isStroke?: boolean
+    strokeWidth?: number
+    strokeLinecap?: string
+    strokeLinejoin?: string
+  }
+  /** Title icon color (defaults to the title foreground color). */
+  titleIconColor?: string
+}
+
+/**
+ * shieldcn logo paths (viewBox 0 0 512 512), embedded so the chart can render
+ * a small corner watermark without an external asset.
+ */
+const SHIELDCN_LOGO =
+  '<path d="M148.02,363.76c-4.48,0-8.64-2.42-10.86-6.32l-54.29-95.68c-2.15-3.8-2.15-8.52,0-12.32l54.29-95.68c2.21-3.9,6.37-6.32,10.86-6.32h18.51c4.44,0,8.45,2.28,10.73,6.09,2.27,3.82,2.37,8.43.25,12.33l-42.23,77.99c-3.98,7.36-3.98,16.14,0,23.49l22.22,41.02c4.25,7.85,12.43,12.8,21.36,12.92,0,0,45.08.61,45.11.61,8.68,0,16.83-4.64,21.26-12.12l24.87-41.99c2.23-3.77,6.34-6.11,10.72-6.12l19.47-.04c4.48,0,8.49,2.29,10.76,6.12,2.27,3.83,2.35,8.45.21,12.35l-42.2,77.17c-2.19,4-6.39,6.49-10.95,6.49h-110.08Z"/><path d="M346.7,363.69c-4.44,0-8.45-2.28-10.73-6.09-2.27-3.82-2.37-8.43-.25-12.33l42.23-77.99c3.98-7.35,3.98-16.14,0-23.49l-22.22-41.02c-4.25-7.85-12.44-12.8-21.36-12.92,0,0-46.51-.63-46.53-.63-8.88,0-17.12,4.81-21.48,12.54l-23.35,41.36c-2.2,3.9-6.36,6.34-10.84,6.35l-19.21.04c-4.48,0-8.49-2.29-10.76-6.12-2.27-3.83-2.35-8.45-.22-12.36l42.2-77.17c2.19-4.01,6.39-6.5,10.95-6.5h110.08c4.48,0,8.64,2.42,10.86,6.32l54.29,95.68c2.16,3.8,2.16,8.52,0,12.32l-54.29,95.68c-2.21,3.9-6.37,6.32-10.86,6.32h-18.51Z"/>'
+
+/**
+ * Named font keywords → a renderable family stack. Custom embedded fonts
+ * aren't possible in a sandboxed `<img>` SVG, so these resolve to widely
+ * available system families; the keyword still nudges the viewer's renderer
+ * toward the intended look.
+ */
+const SANS_FALLBACK = "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+const MONO_FALLBACK = "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace"
+
+/**
+ * Mirrors the badge `font` vocabulary so charts and badges accept the same
+ * keywords. Each resolves to a family stack ending in a system fallback.
+ */
+const FONT_STACKS: Record<string, string> = {
+  inter: `'Inter', ${SANS_FALLBACK}`,
+  geist: `'Geist', ${SANS_FALLBACK}`,
+  "geist-mono": `'Geist Mono', ${MONO_FALLBACK}`,
+  "jetbrains-mono": `'JetBrains Mono', ${MONO_FALLBACK}`,
+  "fira-code": `'Fira Code', ${MONO_FALLBACK}`,
+  roboto: `'Roboto', ${SANS_FALLBACK}`,
+  "space-grotesk": `'Space Grotesk', ${SANS_FALLBACK}`,
+  // Friendly generic aliases.
+  sans: SANS_FALLBACK,
+  mono: MONO_FALLBACK,
+  serif: "ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif",
+}
+
+/** The default font matches the badge default (`inter`). */
+const DEFAULT_FONT = FONT_STACKS.inter
+
+/** Resolve a `?font=` keyword to a family stack (defaults to inter). */
+export function resolveFontFamily(font?: string | null): string {
+  if (font && FONT_STACKS[font]) return FONT_STACKS[font]
+  return DEFAULT_FONT
+}
+
+/** Default accent when no theme/color override is supplied. */
+const DEFAULT_ACCENT = "#3b82f6" // blue-500
+
+/**
+ * Resolve the accent color from theme/color params.
+ * Priority: explicit `color` > `theme` border tint > default.
+ */
+export function resolveAccent(
+  theme?: string | null,
+  color?: string | null,
+): string {
+  const c = resolveColor(color)
+  if (c) return `#${c}`
+  if (theme && theme in themes) return themes[theme as ThemeName].border
+  return DEFAULT_ACCENT
+}
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+}
+
+/** Convert hex (#rrggbb) to an rgba() string at the given alpha. */
+function rgba(hex: string, alpha: number): string {
+  const h = hex.replace("#", "")
+  const r = parseInt(h.substring(0, 2), 16)
+  const g = parseInt(h.substring(2, 4), 16)
+  const b = parseInt(h.substring(4, 6), 16)
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`
+}
+
+/** Round to 2dp for compact path data. */
+function r2(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+/** Format a date as a short month/year label. */
+function dateLabel(iso: string): string {
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return ""
+  return d.toLocaleDateString("en-US", { month: "short", year: "2-digit" })
+}
+
+/** Nice rounded ceiling for the y-axis max. */
+function niceMax(value: number): number {
+  if (value <= 5) return 5
+  const pow = Math.pow(10, Math.floor(Math.log10(value)))
+  const steps = [1, 2, 2.5, 5, 10]
+  for (const s of steps) {
+    const candidate = s * pow
+    if (candidate >= value) return candidate
+  }
+  return 10 * pow
+}
+
+/**
+ * Render the chart to an SVG string.
+ */
+export function renderChart(cfg: ChartConfig): string {
+  const { width, height, mode, area, series } = cfg
+  const surf = SURFACE[mode]
+  const fontStack = cfg.fontFamily ?? DEFAULT_FONT
+  const showBorder = cfg.border !== false
+  // Resolve card background: explicit > transparent > mode default.
+  const cardBg =
+    cfg.background === "transparent"
+      ? "none"
+      : cfg.background ?? surf.bg
+  // The end-dot halo matches the card so a transparent bg gets a transparent
+  // halo (no stray ring on top of whatever the chart is embedded on).
+  const dotHalo = cfg.background === "transparent" ? "none" : cardBg
+
+  // Plot insets: room for title above and axis labels left/bottom.
+  const padTop = 64
+  const padBottom = 36
+  const padLeft = 56
+  const padRight = 24
+  const plotW = Math.max(10, width - padLeft - padRight)
+  const plotH = Math.max(10, height - padTop - padBottom)
+
+  // Time axis when every point carries a valid date; otherwise an evenly
+  // spaced index axis (for arbitrary JSON series).
+  const hasDates =
+    series.length > 0 &&
+    series.every((s) =>
+      s.points.length > 0 && s.points.every((p) => p.date && !isNaN(new Date(p.date).getTime())),
+    )
+
+  // Domain across all series.
+  let tMin = Infinity
+  let tMax = -Infinity
+  let yMaxData = 0
+  let yMinPositive = Infinity
+  for (const s of series) {
+    for (const p of s.points) {
+      if (hasDates && p.date) {
+        const t = new Date(p.date).getTime()
+        if (t < tMin) tMin = t
+        if (t > tMax) tMax = t
+      }
+      if (p.value > yMaxData) yMaxData = p.value
+      if (p.value > 0 && p.value < yMinPositive) yMinPositive = p.value
+    }
+  }
+  if (!isFinite(tMin) || !isFinite(tMax) || tMax === tMin) {
+    // Degenerate domain (single point / same instant) — widen by a day.
+    const base = isFinite(tMin) ? tMin : Date.now()
+    tMin = base - 86400000
+    tMax = base + 86400000
+  }
+
+  // y-axis domain + scale. Log requires a positive floor.
+  const yScale = cfg.yScale === "log" ? "log" : "linear"
+  const yTickCount = Math.min(10, Math.max(1, Math.round(cfg.yTicks ?? 4)))
+  const xTickCount = Math.min(12, Math.max(2, Math.round(cfg.xTicks ?? 3)))
+  let yBottom = cfg.yMin ?? (yScale === "log" ? (isFinite(yMinPositive) ? yMinPositive : 1) : 0)
+  if (yScale === "log" && yBottom <= 0) yBottom = 1
+  let yTop = cfg.yMax ?? (yScale === "log" ? Math.max(yMaxData, yBottom * 10) : niceMax(yMaxData))
+  if (yTop <= yBottom) yTop = yBottom + (yScale === "log" ? yBottom * 9 : 1)
+
+  const xOfDate = (iso: string): number => {
+    const t = new Date(iso).getTime()
+    const frac = (t - tMin) / (tMax - tMin)
+    return padLeft + Math.min(1, Math.max(0, frac)) * plotW
+  }
+  const xOfIndex = (i: number, len: number): number =>
+    padLeft + (len <= 1 ? 0 : i / (len - 1)) * plotW
+  const yOf = (value: number): number => {
+    let frac: number
+    if (yScale === "log") {
+      const lb = Math.log10(yBottom)
+      const lt = Math.log10(yTop)
+      const lv = Math.log10(Math.max(value, yBottom))
+      frac = lt === lb ? 0 : (lv - lb) / (lt - lb)
+    } else {
+      frac = yTop === yBottom ? 0 : (value - yBottom) / (yTop - yBottom)
+    }
+    frac = Math.min(1, Math.max(0, frac))
+    return padTop + plotH - frac * plotH
+  }
+
+  // y tick values, evenly spaced in linear or log space.
+  const yTickValues: number[] = []
+  for (let i = 0; i <= yTickCount; i++) {
+    const f = i / yTickCount
+    yTickValues.push(
+      yScale === "log"
+        ? yBottom * Math.pow(yTop / yBottom, f)
+        : yBottom + (yTop - yBottom) * f,
+    )
+  }
+
+  // --- Grid + y-axis labels ---
+  let grid = ""
+  yTickValues.forEach((v, i) => {
+    const y = r2(yOf(v))
+    grid += `<line x1="${padLeft}" y1="${y}" x2="${padLeft + plotW}" y2="${y}" stroke="${surf.grid}" stroke-width="1" ${i === 0 ? "" : 'stroke-dasharray="3 3"'} />`
+    grid += `<text x="${padLeft - 10}" y="${y + 3.5}" text-anchor="end" font-size="11" fill="${surf.muted}" font-family="${fontStack}">${esc(formatCount(Math.round(v)))}</text>`
+  })
+
+  // --- X-axis labels (start, mid, end) ---
+  let xLabels = ""
+  const xTickText: string[] = []
+  const xTickX: number[] = []
+  if (hasDates) {
+    for (let i = 0; i < xTickCount; i++) {
+      const t = tMin + ((tMax - tMin) * i) / (xTickCount - 1)
+      const iso = new Date(t).toISOString()
+      xTickText.push(dateLabel(iso))
+      xTickX.push(r2(xOfDate(iso)))
+    }
+  } else {
+    // Index axis — evenly spaced ticks from the longest series.
+    const rep = series.reduce((a, b) => (b.points.length > a.points.length ? b : a), series[0] ?? { points: [] as ChartPoint[] })
+    const n = rep.points.length
+    const ticks = Math.min(xTickCount, Math.max(1, n))
+    const idxs = ticks <= 1 ? [0] : [...new Set(Array.from({ length: ticks }, (_, k) => Math.round((k * (n - 1)) / (ticks - 1))))]
+    idxs.forEach((i) => {
+      const p = rep.points[i]
+      xTickText.push(p?.label ?? String(i + 1))
+      xTickX.push(r2(xOfIndex(i, n)))
+    })
+  }
+  xTickText.forEach((txt, i) => {
+    const anchor =
+      xTickText.length === 1 ? "middle" : i === 0 ? "start" : i === xTickText.length - 1 ? "end" : "middle"
+    xLabels += `<text x="${xTickX[i]}" y="${padTop + plotH + 22}" text-anchor="${anchor}" font-size="11" fill="${surf.muted}" font-family="${fontStack}">${esc(txt)}</text>`
+  })
+
+  // --- Series paths ---
+  let defs = ""
+  let seriesSvg = ""
+  series.forEach((s, si) => {
+    const pts = hasDates
+      ? [...s.points].sort((a, b) => new Date(a.date!).getTime() - new Date(b.date!).getTime())
+      : s.points
+    if (pts.length === 0) return
+    const coords = pts.map((p, i) => ({
+      x: r2(hasDates ? xOfDate(p.date!) : xOfIndex(i, pts.length)),
+      y: r2(yOf(p.value)),
+    }))
+    const lineD = coords
+      .map((c, i) => `${i === 0 ? "M" : "L"}${c.x} ${c.y}`)
+      .join(" ")
+
+    if (area) {
+      const gid = `chartFill${si}`
+      const fillColor = s.fill ?? s.color
+      defs += `<linearGradient id="${gid}" x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0%" stop-color="${rgba(fillColor, 0.35)}" />
+        <stop offset="100%" stop-color="${rgba(fillColor, 0)}" />
+      </linearGradient>`
+      const baseY = r2(padTop + plotH)
+      const areaD = `${lineD} L${coords[coords.length - 1].x} ${baseY} L${coords[0].x} ${baseY} Z`
+      seriesSvg += `<path d="${areaD}" fill="url(#${gid})" />`
+    }
+
+    seriesSvg += `<path d="${lineD}" fill="none" stroke="${s.color}" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />`
+    // End dot.
+    const last = coords[coords.length - 1]
+    seriesSvg += `<circle cx="${last.x}" cy="${last.y}" r="3.5" fill="${s.color}" stroke="${dotHalo}" stroke-width="2" />`
+  })
+
+  // --- Legend (only when >1 series) ---
+  let legend = ""
+  if (series.length > 1) {
+    let lx = padLeft
+    const ly = padTop - 16
+    series.forEach((s) => {
+      legend += `<rect x="${lx}" y="${ly - 8}" width="10" height="10" rx="2" fill="${s.color}" />`
+      legend += `<text x="${lx + 16}" y="${ly + 1}" font-size="12" fill="${surf.muted}" font-family="${fontStack}">${esc(s.label)}</text>`
+      lx += 24 + s.label.length * 7
+    })
+  }
+
+  // --- shieldcn watermark (top-right): wordmark + logo glyph ---
+  let watermark = ""
+  if (cfg.logo !== false) {
+    const logoSize = 20
+    const wmColor = cfg.logoColor ?? surf.muted
+    const logoX = width - padRight - logoSize
+    const logoY = 14
+    const logoCenterY = logoY + logoSize / 2
+    const textRight = logoX - 6
+    const logoGlyph = `<g transform="translate(${logoX}, ${logoY}) scale(${r2(logoSize / 512)})" fill="${wmColor}">${SHIELDCN_LOGO}</g>`
+    const wordmark = `<text x="${textRight}" y="${r2(logoCenterY + 4)}" text-anchor="end" font-size="12" font-weight="500" fill="${wmColor}" font-family="${fontStack}">shieldcn.dev</text>`
+    watermark = `<g fill-opacity="0.65">${wordmark}${logoGlyph}</g>`
+  }
+
+  // --- Title block (optional leading icon + title + subtitle) ---
+  let titleX = padLeft
+  let titleIconSvg = ""
+  const ti = cfg.titleIcon
+  if (ti && (ti.path || (ti.paths && ti.paths.length))) {
+    const iconSize = 26
+    const vb = (ti.viewBox || "0 0 24 24").split(/\s+/).map(Number)
+    const vbW = vb[2] && vb[2] > 0 ? vb[2] : 24
+    const scale = r2(iconSize / vbW)
+    const iconY = cfg.subtitle ? 17 : 13
+    const pathSvg = ti.paths && ti.paths.length
+      ? ti.paths.map((d) => `<path d="${d}" />`).join("")
+      : `<path d="${ti.path}" />`
+    const iconColor = cfg.titleIconColor ?? surf.fg
+    // Stroke icons (Lucide etc.) must not be filled; fill icons (SimpleIcons)
+    // must not be stroked — mirrors the badge icon pipeline.
+    const paint = ti.isStroke
+      ? `fill="none" stroke="${iconColor}" stroke-width="${ti.strokeWidth ?? 2}" stroke-linecap="${ti.strokeLinecap ?? "round"}" stroke-linejoin="${ti.strokeLinejoin ?? "round"}"`
+      : `fill="${iconColor}"${ti.fillRule ? ` fill-rule="${ti.fillRule}"` : ""}`
+    titleIconSvg = `<g transform="translate(${padLeft}, ${iconY}) scale(${scale})" ${paint}>${pathSvg}</g>`
+    titleX = padLeft + iconSize + 10
+  }
+  const title = `<text x="${titleX}" y="30" font-size="16" font-weight="600" fill="${surf.fg}" font-family="${fontStack}">${esc(cfg.title)}</text>`
+  const subtitle = cfg.subtitle
+    ? `<text x="${titleX}" y="48" font-size="12" fill="${surf.muted}" font-family="${fontStack}">${esc(cfg.subtitle)}</text>`
+    : ""
+
+  const body = `
+  <rect x="0.5" y="0.5" width="${width - 1}" height="${height - 1}" rx="12" fill="${cardBg}" stroke="${showBorder ? surf.border : "none"}" stroke-width="1" />
+  ${grid}
+  ${xLabels}
+  ${seriesSvg}
+  ${legend}
+  ${titleIconSvg}
+  ${title}
+  ${subtitle}
+  ${watermark}`
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-label="${esc(cfg.title)}">
+  <defs>${defs}</defs>
+  ${body}
+</svg>`
+
+  return svg
+}

--- a/packages/core/src/badges/render.tsx
+++ b/packages/core/src/badges/render.tsx
@@ -573,6 +573,10 @@ function inlineDataUriImages(svg: string): string {
 function rgbaToHexOpacity(svg: string): string {
   let out = svg
   for (const attr of ["fill", "stroke", "stop-color"] as const) {
+    // The opacity attribute name is NOT always `${attr}-opacity`: a gradient
+    // stop's color is `stop-color` but its opacity is `stop-opacity` (per
+    // SVG 1.1), not `stop-color-opacity`. fill/stroke follow the regular form.
+    const opacityAttr = attr === "stop-color" ? "stop-opacity" : `${attr}-opacity`
     const re = new RegExp(
       `${attr}="rgba\\(\\s*([0-9.]+)\\s*,\\s*([0-9.]+)\\s*,\\s*([0-9.]+)\\s*,\\s*([0-9.]+)\\s*\\)"`,
       "g",
@@ -586,7 +590,7 @@ function rgbaToHexOpacity(svg: string): string {
       const alpha = Number(a)
       if (!Number.isFinite(alpha) || alpha >= 1) return `${attr}="${hex}"`
       const op = Math.max(0, alpha)
-      return `${attr}="${hex}" ${attr}-opacity="${+op.toFixed(3)}"`
+      return `${attr}="${hex}" ${opacityAttr}="${+op.toFixed(3)}"`
     })
   }
   return out

--- a/packages/core/src/providers/npm.ts
+++ b/packages/core/src/providers/npm.ts
@@ -72,6 +72,76 @@ export async function getNpmTotalDownloads(pkg: string): Promise<BadgeData | nul
 }
 
 // ---------------------------------------------------------------------------
+// Downloads time series (for charts)
+// ---------------------------------------------------------------------------
+
+/** A weekly downloads bucket. */
+export interface DownloadPoint {
+  date: string
+  value: number
+}
+
+/** Resolved npm downloads time series. */
+export interface NpmDownloadSeries {
+  pkg: string
+  total: number
+  points: DownloadPoint[]
+}
+
+/** Format a Date as YYYY-MM-DD (UTC). */
+function ymd(d: Date): string {
+  return d.toISOString().slice(0, 10)
+}
+
+/**
+ * Daily downloads over the last `days`, aggregated into weekly buckets so the
+ * chart stays readable. Uses the npm downloads/range API.
+ */
+export async function getNpmDownloadSeries(
+  pkg: string,
+  days: number = 365,
+): Promise<NpmDownloadSeries | null> {
+  const end = new Date()
+  const start = new Date(end.getTime() - days * 86400000)
+  const range = `${ymd(start)}:${ymd(end)}`
+  const encoded = encodeURIComponent(pkg)
+  const data = await npmFetch(
+    `https://api.npmjs.org/downloads/range/${range}/${encoded}`,
+    `dlseries:${pkg}:${range}`,
+  )
+  const daily = data?.downloads as Array<{ day?: string; downloads?: number }> | undefined
+  if (!Array.isArray(daily) || daily.length === 0) return null
+
+  // Aggregate consecutive days into weekly buckets.
+  const points: DownloadPoint[] = []
+  let total = 0
+  let bucketStart: string | null = null
+  let bucketSum = 0
+  let count = 0
+  for (const d of daily) {
+    if (typeof d.downloads !== "number" || typeof d.day !== "string") continue
+    if (bucketStart === null) bucketStart = d.day
+    bucketSum += d.downloads
+    total += d.downloads
+    count++
+    if (count === 7) {
+      points.push({ date: bucketStart, value: bucketSum })
+      bucketStart = null
+      bucketSum = 0
+      count = 0
+    }
+  }
+  // Drop the trailing partial week (the current, incomplete week sums only a
+  // day or two and would plunge the curve to ~0 at the right edge). Keep it
+  // only if it's the sole bucket, so short ranges still render something.
+  if (bucketStart !== null && count > 0 && points.length === 0) {
+    points.push({ date: bucketStart, value: bucketSum })
+  }
+  if (points.length === 0) return null
+  return { pkg, total, points }
+}
+
+// ---------------------------------------------------------------------------
 // License
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/providers/starhistory.ts
+++ b/packages/core/src/providers/starhistory.ts
@@ -1,0 +1,302 @@
+/**
+ * shieldcn
+ * src/providers/starhistory
+ *
+ * GitHub star-history data provider. Builds a time series of cumulative
+ * stargazer counts for a repository, suitable for rendering a star-history
+ * line chart (like https://github.com/caarlos0/starcharts).
+ *
+ * GitHub has no "stars over time" API. We reconstruct the curve from the
+ * stargazers endpoint, which (with the `star+json` media type) returns a
+ * `starred_at` timestamp per stargazer. For small/medium repos we fetch every
+ * page and sample the full list for an exact curve; for large repos we sample
+ * pages evenly and read the first stargazer of each, exactly like starcharts.
+ *
+ * Distributed rate limiting goes through the shared token pool; results are
+ * cached with a last-known-good fallback so a transient blip never collapses
+ * the chart.
+ */
+
+import { pickToken, invalidateToken } from "../token-pool"
+import { isBackedOff, recordBackoff, clearBackoff, cachedFetchStale } from "../cache"
+import { raceTimeout } from "../provider-fetch"
+
+/** A single point on a cumulative curve. */
+export interface StarPoint {
+  /** ISO-8601 timestamp. */
+  date: string
+  /** Cumulative count at that moment. */
+  value: number
+}
+
+/** Resolved cumulative time series for a repository. */
+export interface StarHistory {
+  owner: string
+  repo: string
+  /** Total right now. */
+  total: number
+  /** Time-ordered cumulative points (first → last). */
+  points: StarPoint[]
+}
+
+/** Max sampled points / pages — keeps the upstream cost bounded. */
+const MAX_POINTS = 30
+/** GitHub caps stargazer pagination at 400 pages (40k stars). */
+const MAX_PAGE = 400
+
+/** Same rate-limit detection as the main GitHub client. */
+function isRateLimitResponse(response: Response): boolean {
+  if (response.status === 429) return true
+  return (
+    response.status === 403 &&
+    (response.headers.get("x-ratelimit-remaining") === "0" ||
+      response.headers.get("retry-after") !== null)
+  )
+}
+
+/**
+ * Fetch a GitHub URL through the token pool. `accept` lets the caller request
+ * the `star+json` media type (needed for `starred_at` timestamps).
+ */
+async function ghFetch(
+  url: string,
+  accept: string,
+  revalidate: number,
+): Promise<Response | null> {
+  if (isBackedOff("github")) return null
+  try {
+    const token = await pickToken()
+    const doFetch = (auth?: string) =>
+      raceTimeout(
+        fetch(url, {
+          headers: {
+            Accept: accept,
+            ...(auth ? { Authorization: `Bearer ${auth}` } : {}),
+          },
+          next: { revalidate },
+        }),
+      )
+
+    let response = await doFetch(token)
+    if (!response) return null
+
+    if (response.status === 401 && token) {
+      await invalidateToken(token)
+      response = await doFetch()
+      if (!response) return null
+    }
+
+    if (isRateLimitResponse(response) || response.status === 503) {
+      recordBackoff("github", response.status)
+      return null
+    }
+    if (!response.ok) return null
+    clearBackoff("github")
+    return response
+  } catch {
+    return null
+  }
+}
+
+/** Fetch a single stargazers page; returns the `starred_at` timestamps. */
+async function fetchStarPage(
+  owner: string,
+  repo: string,
+  page: number,
+): Promise<string[] | null> {
+  const url = `https://api.github.com/repos/${owner}/${repo}/stargazers?per_page=100&page=${page}`
+  const res = await ghFetch(url, "application/vnd.github.v3.star+json", 60 * 60 * 6)
+  if (!res) return null
+  try {
+    const json = (await res.json()) as Array<{ starred_at?: string }>
+    if (!Array.isArray(json)) return null
+    return json
+      .map((s) => s.starred_at)
+      .filter((d): d is string => typeof d === "string")
+  } catch {
+    return null
+  }
+}
+
+/** Evenly spaced integers in [start, end] inclusive, length `count`. */
+function evenSpread(start: number, end: number, count: number): number[] {
+  if (count <= 1) return [start]
+  const out: number[] = []
+  for (let i = 0; i < count; i++) {
+    out.push(Math.round(start + ((end - start) * i) / (count - 1)))
+  }
+  return [...new Set(out)]
+}
+
+/** Uncached builder — see `getStarHistory` for the cached entrypoint. */
+async function buildStarHistory(
+  owner: string,
+  repo: string,
+): Promise<StarHistory | null> {
+  // 1. Repo metadata → total stars.
+  const repoRes = await ghFetch(
+    `https://api.github.com/repos/${owner}/${repo}`,
+    "application/vnd.github.v3+json",
+    60 * 60,
+  )
+  if (!repoRes) return null
+  let total = 0
+  try {
+    const meta = (await repoRes.json()) as { stargazers_count?: number }
+    total = typeof meta.stargazers_count === "number" ? meta.stargazers_count : 0
+  } catch {
+    return null
+  }
+
+  const now = new Date().toISOString()
+
+  // No stars yet — render a flat baseline.
+  if (total <= 0) {
+    return { owner, repo, total: 0, points: [{ date: now, value: 0 }] }
+  }
+
+  const pages = Math.min(MAX_PAGE, Math.max(1, Math.ceil(total / 100)))
+
+  // Small/medium repo: fetch every page for an exact curve.
+  if (pages <= MAX_POINTS) {
+    const pageNums = evenSpread(1, pages, pages)
+    const results = await Promise.all(
+      pageNums.map((p) => fetchStarPage(owner, repo, p)),
+    )
+    const dates: string[] = []
+    for (const r of results) {
+      if (r) dates.push(...r)
+    }
+    if (dates.length === 0) return null
+    dates.sort()
+
+    // Sample the full sorted list down to MAX_POINTS exact cumulative points.
+    const idxs = evenSpread(0, dates.length - 1, Math.min(MAX_POINTS, dates.length))
+    const points: StarPoint[] = idxs.map((i) => ({ date: dates[i], value: i + 1 }))
+    // Anchor the curve at "now" with the live total.
+    if (points[points.length - 1].value !== total) {
+      points.push({ date: now, value: total })
+    }
+    return { owner, repo, total, points }
+  }
+
+  // Large repo: sample pages evenly, read the first stargazer of each.
+  const sampledPages = evenSpread(1, pages, MAX_POINTS)
+  const results = await Promise.all(
+    sampledPages.map(async (p) => {
+      const r = await fetchStarPage(owner, repo, p)
+      if (!r || r.length === 0) return null
+      r.sort()
+      return { page: p, date: r[0] }
+    }),
+  )
+  const points: StarPoint[] = []
+  for (const r of results) {
+    if (!r) continue
+    points.push({ date: r.date, value: (r.page - 1) * 100 })
+  }
+  if (points.length === 0) return null
+  points.sort((a, b) => a.date.localeCompare(b.date))
+  // Anchor at "now" with the live total.
+  points.push({ date: now, value: total })
+  return { owner, repo, total, points }
+}
+
+/**
+ * Cached star-history series with last-known-good fallback. Returns null when
+ * the repo can't be resolved and there's no prior good value.
+ */
+export async function getStarHistory(
+  owner: string,
+  repo: string,
+): Promise<StarHistory | null> {
+  return cachedFetchStale(
+    "github",
+    `starhistory/${owner}/${repo}`,
+    () => buildStarHistory(owner, repo),
+    60 * 60 * 6, // fresh 6h — the curve barely moves and pagination is costly
+    60 * 60 * 24 * 30, // 30-day last-known-good
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Issues over time
+// ---------------------------------------------------------------------------
+
+/** GitHub Search API caps results at 1000 (10 pages of 100). */
+const SEARCH_MAX_PAGE = 10
+
+/** Uncached builder for cumulative issues-created over time. */
+async function buildIssueHistory(
+  owner: string,
+  repo: string,
+): Promise<StarHistory | null> {
+  // type:issue excludes PRs. The search API also returns total_count.
+  const q = encodeURIComponent(`repo:${owner}/${repo} type:issue`)
+  const countRes = await ghFetch(
+    `https://api.github.com/search/issues?q=${q}&per_page=1`,
+    "application/vnd.github.v3+json",
+    60 * 60,
+  )
+  if (!countRes) return null
+  let total = 0
+  try {
+    const meta = (await countRes.json()) as { total_count?: number }
+    total = typeof meta.total_count === "number" ? meta.total_count : 0
+  } catch {
+    return null
+  }
+
+  const now = new Date().toISOString()
+  if (total <= 0) {
+    return { owner, repo, total: 0, points: [{ date: now, value: 0 }] }
+  }
+
+  const pages = Math.min(SEARCH_MAX_PAGE, Math.max(1, Math.ceil(total / 100)))
+  const sampledPages = evenSpread(1, pages, Math.min(MAX_POINTS, pages))
+  const results = await Promise.all(
+    sampledPages.map(async (p) => {
+      const res = await ghFetch(
+        `https://api.github.com/search/issues?q=${q}&sort=created&order=asc&per_page=100&page=${p}`,
+        "application/vnd.github.v3+json",
+        60 * 60 * 6,
+      )
+      if (!res) return null
+      try {
+        const json = (await res.json()) as { items?: Array<{ created_at?: string }> }
+        const first = json.items?.[0]?.created_at
+        if (!first) return null
+        return { page: p, date: first }
+      } catch {
+        return null
+      }
+    }),
+  )
+
+  const points: StarPoint[] = []
+  for (const r of results) {
+    if (!r) continue
+    points.push({ date: r.date, value: (r.page - 1) * 100 })
+  }
+  if (points.length === 0) return null
+  points.sort((a, b) => a.date.localeCompare(b.date))
+  // Anchor at "now" with the live total (covers repos beyond the 1000 cap).
+  points.push({ date: now, value: total })
+  return { owner, repo, total, points }
+}
+
+/**
+ * Cached cumulative issues-created series with last-known-good fallback.
+ */
+export async function getIssueHistory(
+  owner: string,
+  repo: string,
+): Promise<StarHistory | null> {
+  return cachedFetchStale(
+    "github",
+    `issuehistory/${owner}/${repo}`,
+    () => buildIssueHistory(owner, repo),
+    60 * 60 * 6,
+    60 * 60 * 24 * 30,
+  )
+}

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -7,6 +7,11 @@
  */
 
 import { renderBadge, renderBadgeBase, renderErrorBadge } from "./badges/render"
+import { renderChart, resolveAccent, resolveFontFamily, type ChartSeries, type ChartPoint } from "./badges/render-chart"
+import { getStarHistory, getIssueHistory } from "./providers/starhistory"
+import { getNpmDownloadSeries } from "./providers/npm"
+import { formatCount } from "./format"
+import { JSONPath } from "jsonpath-plus"
 import { parseAnimate } from "./badges/animate"
 import { renderGif } from "./badges/gif"
 import { renderBadgeGroup, type GroupSegment, type GroupConfig } from "./badges/render-group"
@@ -1790,6 +1795,376 @@ async function handleBadgeGroup(
 }
 
 /**
+ * Clamp a numeric query param to a sane range, with a default.
+ */
+function clampNum(
+  raw: string | null,
+  min: number,
+  max: number,
+  fallback: number,
+): number {
+  if (raw === null) return fallback
+  const n = parseFloat(raw)
+  if (!Number.isFinite(n)) return fallback
+  return Math.min(max, Math.max(min, n))
+}
+
+/**
+ * Handle a chart request.
+ *
+ * URL format: /chart/github/stars/{owner}/{repo}.svg
+ * Query params: width, height, mode, theme, color, area, title.
+ */
+async function handleChart(
+  cleanSegments: string[],
+  searchParams: URLSearchParams,
+  format: Format,
+  options?: BadgeRequestOptions,
+): Promise<Response> {
+  const rest = cleanSegments.slice(1) // after "chart"
+  const mode = (searchParams.get("mode") === "light" ? "light" : "dark") as "light" | "dark"
+  const width = clampNum(searchParams.get("width"), 200, 2000, 800)
+  const height = clampNum(searchParams.get("height"), 120, 1200, 400)
+  const areaParam = searchParams.get("area")
+  const area = areaParam !== "false" && areaParam !== "0"
+  const accent = resolveAccent(searchParams.get("theme"), searchParams.get("color"))
+  const fillParam = resolveColor(searchParams.get("fill"))
+  const fill = fillParam ? `#${fillParam}` : undefined
+  const fontFamily = resolveFontFamily(searchParams.get("font"))
+  const logoParam = searchParams.get("logo")
+  const logo = logoParam !== "false" && logoParam !== "0" && logoParam !== "none"
+  const logoColorParam = resolveColor(searchParams.get("logoColor"))
+  const logoColor = logoColorParam ? `#${logoColorParam}` : undefined
+  const borderParam = searchParams.get("border")
+  const border = borderParam !== "false" && borderParam !== "0"
+  // Background: `transparent`, a hex color, or undefined (mode default surface).
+  const bgParam = searchParams.get("background") ?? searchParams.get("bg")
+  // Axis scale controls.
+  const yScale = searchParams.get("yScale") === "log" ? "log" as const : "linear" as const
+  const yMinRaw = searchParams.get("yMin")
+  const yMaxRaw = searchParams.get("yMax")
+  const yMin = yMinRaw !== null && Number.isFinite(parseFloat(yMinRaw)) ? parseFloat(yMinRaw) : undefined
+  const yMax = yMaxRaw !== null && Number.isFinite(parseFloat(yMaxRaw)) ? parseFloat(yMaxRaw) : undefined
+  const yTicks = searchParams.get("yTicks") !== null ? clampNum(searchParams.get("yTicks"), 1, 10, 4) : undefined
+  const xTicks = searchParams.get("xTicks") !== null ? clampNum(searchParams.get("xTicks"), 2, 12, 3) : undefined
+  let background: string | undefined
+  if (bgParam === "transparent" || bgParam === "none") {
+    background = "transparent"
+  } else {
+    const bgHex = resolveColor(bgParam)
+    if (bgHex) background = `#${bgHex}`
+  }
+
+  const fail = (msg: string, status: number): Response => {
+    if (format === "json") {
+      return Response.json({ error: msg }, { status, headers: ERROR_CACHE_HEADERS })
+    }
+    const svg = renderChart({
+      title: "chart",
+      subtitle: msg,
+      series: [],
+      width,
+      height,
+      mode,
+      area: false,
+      background,
+      border,
+      fontFamily,
+    })
+    return new Response(svg, {
+      headers: { "Content-Type": "image/svg+xml", ...ERROR_CACHE_HEADERS },
+    })
+  }
+
+  // Resolve the chart kind → data series.
+  const resolved = await resolveChartData(rest, searchParams)
+  if (!resolved.ok) return fail(resolved.msg, resolved.status)
+
+  if (format === "json") {
+    return Response.json(resolved.json, { headers: CACHE_HEADERS })
+  }
+
+  // Resolve an optional leading title icon. Explicit `?icon=` wins; otherwise
+  // a sensible per-kind default (github mark, npm mark). `?icon=false` hides it.
+  const iconParam = searchParams.get("icon")
+  const iconColorParam = resolveColor(searchParams.get("iconColor"))
+  let titleIcon:
+    | { path?: string; paths?: string[]; viewBox?: string; fillRule?: string; isStroke?: boolean; strokeWidth?: number; strokeLinecap?: string; strokeLinejoin?: string }
+    | undefined
+  if (iconParam !== "false" && iconParam !== "0" && iconParam !== "none") {
+    const defaultIcon =
+      resolved.provider === "github" ? "github"
+      : resolved.provider === "npm" ? "npm"
+      : undefined
+    const slug = iconParam || defaultIcon
+    if (slug) {
+      const si = await getSimpleIcon(slug, iconColorParam)
+      if (si) titleIcon = {
+        path: si.icon.path,
+        paths: si.icon.paths,
+        viewBox: si.icon.viewBox,
+        fillRule: si.icon.fillRule,
+        isStroke: si.icon.isStroke,
+        strokeWidth: si.icon.strokeWidth,
+        strokeLinecap: si.icon.strokeLinecap,
+        strokeLinejoin: si.icon.strokeLinejoin,
+      }
+    }
+  }
+  const titleIconColor = iconColorParam ? `#${iconColorParam}` : undefined
+
+  const series: ChartSeries[] = [
+    { label: resolved.seriesLabel, points: resolved.points, color: accent, fill },
+  ]
+  const svg = renderChart({
+    title: searchParams.get("title") || resolved.title,
+    subtitle: resolved.subtitle,
+    series,
+    width,
+    height,
+    mode,
+    area,
+    background,
+    border,
+    fontFamily,
+    yScale,
+    yMin,
+    yMax,
+    yTicks,
+    xTicks,
+    logo,
+    logoColor,
+    titleIcon,
+    titleIconColor,
+    link: resolved.link,
+  })
+
+  if (options?.onTrack) {
+    void options.onTrack({
+      name: "chart_rendered",
+      data: { provider: resolved.provider, kind: resolved.kind, format, mode, points: resolved.points.length },
+    })
+  }
+
+  if (format === "png") {
+    const { Resvg, initWasm } = await import("@resvg/resvg-wasm")
+    try {
+      let wasmLoaded = false
+      if (typeof process !== "undefined" && process.env.NODE_ENV === "production") {
+        try {
+          const fs = await import("node:fs")
+          const path = await import("node:path")
+          const candidates = [
+            path.join(process.cwd(), "node_modules", "@resvg", "resvg-wasm", "index_bg.wasm"),
+          ]
+          for (const p of candidates) {
+            if (fs.existsSync(p)) {
+              await initWasm(fs.readFileSync(p))
+              wasmLoaded = true
+              break
+            }
+          }
+        } catch { /* fs not available */ }
+      }
+      if (!wasmLoaded) {
+        await initWasm(fetch("https://unpkg.com/@resvg/resvg-wasm/index_bg.wasm"))
+      }
+    } catch { /* already initialized */ }
+    const resvg = new Resvg(svg)
+    const png = resvg.render().asPng()
+    return new Response(Buffer.from(png), {
+      headers: { "Content-Type": "image/png", ...CACHE_HEADERS },
+    })
+  }
+
+  return new Response(svg, {
+    headers: { "Content-Type": "image/svg+xml", ...CACHE_HEADERS },
+  })
+}
+
+/** Number formatter that never throws on weird input. */
+function formatCountSafe(n: number): string {
+  try {
+    return formatCount(n)
+  } catch {
+    return String(n)
+  }
+}
+
+/** Successful chart resolution. */
+interface ChartOk {
+  ok: true
+  provider: string
+  kind: string
+  title: string
+  subtitle?: string
+  seriesLabel: string
+  link?: string
+  points: ChartPoint[]
+  json: unknown
+}
+type ChartResolved = ChartOk | { ok: false; status: number; msg: string }
+
+/** Coerce an unknown JSONPath result into a finite number, or null. */
+function asNumber(v: unknown): number | null {
+  if (typeof v === "number" && Number.isFinite(v)) return v
+  if (typeof v === "string") {
+    const n = parseFloat(v)
+    if (Number.isFinite(n)) return n
+  }
+  return null
+}
+
+/**
+ * Resolve a `/chart/...` path + params into a renderable series.
+ *
+ * Supported kinds:
+ *   /chart/github/stars/{owner}/{repo}
+ *   /chart/github/issues/{owner}/{repo}
+ *   /chart/npm/{package}            (weekly downloads, last `days`)
+ *   /chart/json?values=1,2,3        (inline data)
+ *   /chart/json?url=...&query=...   (remote JSON array)
+ */
+async function resolveChartData(
+  rest: string[],
+  searchParams: URLSearchParams,
+): Promise<ChartResolved> {
+  const provider = rest[0]
+
+  // --- GitHub stars / issues over time ---
+  if (provider === "github" || provider === "stars" || provider === "issues") {
+    let kind: string | undefined
+    let owner: string | undefined
+    let repo: string | undefined
+    if (provider === "github" && (rest[1] === "stars" || rest[1] === "issues")) {
+      kind = rest[1]; owner = rest[2]; repo = rest[3]
+    } else if (provider === "stars" || provider === "issues") {
+      kind = provider; owner = rest[1]; repo = rest[2]
+    }
+    if (!kind || !owner || !repo) {
+      return { ok: false, status: 400, msg: "usage: /chart/github/{stars|issues}/{owner}/{repo}.svg" }
+    }
+    const history = kind === "issues"
+      ? await getIssueHistory(owner, repo)
+      : await getStarHistory(owner, repo)
+    if (!history) {
+      return { ok: false, status: 404, msg: `could not load ${kind} for ${owner}/${repo}` }
+    }
+    const noun = kind === "issues" ? "issues" : "stars"
+    return {
+      ok: true,
+      provider: "github",
+      kind,
+      title: `${owner}/${repo}`,
+      subtitle: `${formatCountSafe(history.total)} ${noun}`,
+      seriesLabel: `${owner}/${repo}`,
+      link: `https://github.com/${owner}/${repo}`,
+      points: history.points,
+      json: history,
+    }
+  }
+
+  // --- npm weekly downloads ---
+  if (provider === "npm") {
+    const pkg = rest.slice(1).join("/")
+    if (!pkg) {
+      return { ok: false, status: 400, msg: "usage: /chart/npm/{package}.svg" }
+    }
+    const days = clampNum(searchParams.get("days"), 30, 540, 365)
+    const series = await getNpmDownloadSeries(pkg, days)
+    if (!series) {
+      return { ok: false, status: 404, msg: `could not load downloads for ${pkg}` }
+    }
+    return {
+      ok: true,
+      provider: "npm",
+      kind: "downloads",
+      title: pkg,
+      subtitle: `${formatCountSafe(series.total)} downloads · ${days}d`,
+      seriesLabel: pkg,
+      link: `https://www.npmjs.com/package/${pkg}`,
+      points: series.points,
+      json: series,
+    }
+  }
+
+  // --- Generic JSON ---
+  if (provider === "json" || provider === "dynamic") {
+    const url = searchParams.get("url")
+    let values: number[] = []
+    let dates: (string | undefined)[] = []
+    let labels: (string | undefined)[] = []
+
+    if (url) {
+      // Remote JSON: `query` selects the value array, `dateQuery` (optional)
+      // selects a parallel date/label array.
+      const query = searchParams.get("query")
+      if (!query) {
+        return { ok: false, status: 400, msg: "json url charts need a ?query=" }
+      }
+      try {
+        const res = await raceTimeout(fetch(url, {
+          next: { revalidate: 300 },
+          headers: { Accept: "application/json", "User-Agent": "shieldcn/1.0" },
+        }))
+        if (!res || !res.ok) {
+          return { ok: false, status: 502, msg: `fetch failed (${res?.status ?? "timeout"})` }
+        }
+        const data = await res.json()
+        const rawValues = JSONPath({ path: query, json: data }) as unknown[]
+        values = (Array.isArray(rawValues) ? rawValues : [])
+          .map(asNumber)
+          .filter((n): n is number => n !== null)
+        const dateQuery = searchParams.get("dateQuery")
+        if (dateQuery) {
+          const rawDates = JSONPath({ path: dateQuery, json: data }) as unknown[]
+          dates = (Array.isArray(rawDates) ? rawDates : []).map((d) =>
+            typeof d === "string" || typeof d === "number" ? String(d) : undefined,
+          )
+        }
+      } catch {
+        return { ok: false, status: 502, msg: "fetch failed" }
+      }
+    } else {
+      // Inline data via ?values=, optional ?dates= / ?labels=.
+      const rawValues = searchParams.get("values") ?? searchParams.get("data")
+      if (!rawValues) {
+        return { ok: false, status: 400, msg: "usage: /chart/json.svg?values=1,2,3" }
+      }
+      values = rawValues.split(",").map((s) => asNumber(s.trim())).filter((n): n is number => n !== null)
+      const rawDates = searchParams.get("dates")
+      if (rawDates) dates = rawDates.split(",").map((s) => s.trim())
+      const rawLabels = searchParams.get("labels")
+      if (rawLabels) labels = rawLabels.split(",").map((s) => s.trim())
+    }
+
+    if (values.length === 0) {
+      return { ok: false, status: 400, msg: "no numeric data points" }
+    }
+
+    const points: ChartPoint[] = values.map((value, i) => {
+      const date = dates[i]
+      const isValidDate = date && !isNaN(new Date(date).getTime())
+      return { value, date: isValidDate ? new Date(date as string).toISOString() : undefined, label: labels[i] }
+    })
+    const total = values.reduce((a, b) => a + b, 0)
+    const label = searchParams.get("label") || "value"
+    return {
+      ok: true,
+      provider: "json",
+      kind: "json",
+      title: searchParams.get("title") || "chart",
+      subtitle: searchParams.get("subtitle") ?? `${formatCountSafe(total)} total`,
+      seriesLabel: label,
+      points,
+      json: { points },
+    }
+  }
+
+  return { ok: false, status: 400, msg: "unknown chart kind" }
+}
+
+/**
  * Handle a badge GET request.
  *
  * @param request - The incoming request
@@ -1852,6 +2227,14 @@ async function handleBadgeGETInner(
   // ---------------------------------------------------------------------------
   if (cleanSegments[0] === "group") {
     return handleBadgeGroup(cleanSegments, searchParams, format, options)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Charts: /chart/github/stars/{owner}/{repo}.svg
+  // Renders a shadcn-styled star-history line/area chart.
+  // ---------------------------------------------------------------------------
+  if (cleanSegments[0] === "chart") {
+    return handleChart(cleanSegments, searchParams, format, options)
   }
 
   // Fetch badge data from provider

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -3,6 +3,7 @@ import { SiteAnnouncement } from "@/components/site-announcement"
 import { HeroSubtext } from "@/components/hero-subtext"
 import { Separator } from "@/components/ui/separator"
 import { BadgeBuilder } from "@/components/badge-builder"
+import { HomeCharts } from "@/components/home-charts"
 import { GenHeroInput } from "@/components/gen-hero-input"
 import { HeroIconCloud } from "@/components/hero-icon-cloud"
 import { ScrollCta } from "@/components/scroll-cta"
@@ -11,9 +12,9 @@ import { pageMetadata } from "@/lib/metadata"
 import { websiteJsonLd, softwareAppJsonLd } from "@/lib/json-ld"
 
 export const metadata: Metadata = pageMetadata({
-  title: "shieldcn — Beautiful README Badges",
+  title: "shieldcn — Beautiful README Badges & Charts",
   description:
-    "Beautiful GitHub README badges styled as shadcn/ui buttons. Generate SVG and PNG badges for npm, GitHub, GitLab, Discord, NBA, and 45+ providers. 6 variants, 16 themes, 40,000+ icons. Free and open source.",
+    "Beautiful GitHub README badges and charts styled as shadcn/ui. Generate SVG and PNG badges for npm, GitHub, GitLab, Discord, NBA, and 45+ providers, plus star-history, issues, and npm-download charts. 6 variants, 16 themes, 40,000+ icons. Free and open source.",
   path: "/",
   ogTitle: "shieldcn — Beautiful README Badges",
 })
@@ -75,6 +76,10 @@ export default async function Home() {
             </div>
             <BadgeBuilder />
           </section>
+
+          <Separator />
+
+          <HomeCharts />
         </div>
       </main>
     </SiteShell>

--- a/packages/web/app/showcase/showcase-client.tsx
+++ b/packages/web/app/showcase/showcase-client.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react"
+import Link from "next/link"
 import { Search, X } from "lucide-react"
 import { BadgeGroupModal } from "@/components/badge-group-modal"
 import { BadgeModal } from "@/components/badge-modal"
@@ -231,7 +232,79 @@ export default function ShowcasePage() {
           </div>
         )}
       </section>
+
+      <ChartShowcase />
     </main>
+  )
+}
+
+const CHART_EXAMPLES: { title: string; description: string; src: string; href: string }[] = [
+  {
+    title: "GitHub stars over time",
+    description: "Star history for any repo — like starcharts, shadcn-styled.",
+    src: "/chart/github/stars/shadcn-ui/ui.svg?theme=blue",
+    href: "/docs/charts",
+  },
+  {
+    title: "GitHub issues over time",
+    description: "Cumulative issues opened, sampled from the search API.",
+    src: "/chart/github/issues/honojs/hono.svg?theme=rose",
+    href: "/docs/charts",
+  },
+  {
+    title: "npm downloads",
+    description: "Weekly downloads for the last year from the npm API.",
+    src: "/chart/npm/zod.svg?theme=emerald",
+    href: "/docs/charts",
+  },
+  {
+    title: "Inline JSON data",
+    description: "Bring your own numbers with ?values= — or a remote ?url=.",
+    src: "/chart/json.svg?values=120,180,150,210,260,240,300,280,340&title=Latency&label=ms&theme=violet",
+    href: "/docs/charts",
+  },
+]
+
+function ChartShowcase() {
+  const hydrated = useHydrated()
+  const { adaptUrl } = useBadgeMode()
+  return (
+    <section
+      id="chart-showcase"
+      aria-labelledby="chart-showcase-title"
+      className="mx-auto w-full max-w-7xl space-y-6 px-4 pb-16 md:px-8"
+    >
+      <div>
+        <h2 id="chart-showcase-title" className="font-heading text-2xl font-semibold tracking-tight md:text-3xl">
+          Charts
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Shadcn-styled graphs for GitHub stars, issues, npm downloads, and your own JSON data.
+        </p>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        {CHART_EXAMPLES.map((c) => (
+          <Link
+            key={c.src}
+            href={c.href}
+            className="group rounded-2xl border border-border bg-card p-3 transition-colors hover:border-foreground/20"
+          >
+            <div className="overflow-hidden rounded-lg border border-border/60 bg-muted/30">
+              {hydrated ? (
+                /* eslint-disable-next-line @next/next/no-img-element */
+                <img src={adaptUrl(c.src)} alt={c.title} className="w-full" />
+              ) : (
+                <div className="aspect-[2/1] w-full" />
+              )}
+            </div>
+            <div className="px-1 pt-3">
+              <p className="text-sm font-medium">{c.title}</p>
+              <p className="mt-1 text-xs text-muted-foreground">{c.description}</p>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
   )
 }
 

--- a/packages/web/components/chart-preview.tsx
+++ b/packages/web/components/chart-preview.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import { useState, useSyncExternalStore } from "react"
+import { Copy, Check } from "lucide-react"
+import { useBadgeMode } from "@/lib/use-badge-mode"
+
+/** Hydration flag without a setState-in-effect (lint-clean). */
+function useHydrated() {
+  return useSyncExternalStore(() => () => {}, () => true, () => false)
+}
+
+interface ChartPreviewProps {
+  /** Chart URL path (e.g. "/chart/github/stars/vercel/next.js.svg?area=true") */
+  src: string
+  /** Alt text for the chart */
+  alt?: string
+  /** Optional description shown below the chart */
+  description?: string
+  /** Code to display (defaults to markdown img syntax) */
+  code?: string
+}
+
+/**
+ * Full-width chart preview with a copy button. Unlike BadgePreview this does
+ * not force a fixed height — charts have their own aspect ratio.
+ */
+export function ChartPreview({ src, alt, description, code }: ChartPreviewProps) {
+  const [copied, setCopied] = useState(false)
+  const mounted = useHydrated()
+  const { adaptUrl } = useBadgeMode()
+
+  const adaptedSrc = adaptUrl(src)
+  const fullUrl = `https://shieldcn.dev${src}`
+  const displayCode = code ?? `![${alt || "chart"}](${fullUrl})`
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(displayCode)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className="rounded-lg border border-border overflow-hidden not-prose my-4">
+      <div className="flex items-center justify-center bg-muted/30 p-4">
+        {mounted ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={adaptedSrc} alt={alt || "chart preview"} className="w-full max-w-2xl rounded-md" />
+        ) : (
+          <div className="aspect-[2/1] w-full max-w-2xl" />
+        )}
+      </div>
+      <div className="relative border-t border-border bg-muted/50">
+        {description && (
+          <p className="px-4 pt-3 text-xs text-muted-foreground">{description}</p>
+        )}
+        <div className="flex items-center gap-2 px-4 py-3">
+          <code className="flex-1 text-xs font-mono text-muted-foreground break-all select-all">
+            {displayCode}
+          </code>
+          <button
+            onClick={handleCopy}
+            className="shrink-0 rounded-md p-1.5 text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+            aria-label="Copy code"
+          >
+            {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/web/components/chart-sandbox.tsx
+++ b/packages/web/components/chart-sandbox.tsx
@@ -1,0 +1,365 @@
+"use client"
+
+import { useState, useCallback, useId, useMemo, useSyncExternalStore } from "react"
+import { Copy, Check } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { ColorInput } from "@/components/color-input"
+import { Label } from "@/components/ui/label"
+import { Badge } from "@/components/ui/badge"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
+import { Separator } from "@/components/ui/separator"
+import { Checkbox } from "@/components/ui/checkbox"
+import { LogoPicker } from "@/components/logo-picker"
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type ChartKind = "stars" | "issues" | "npm" | "json"
+
+interface ChartSandboxProps {
+  /** Initial chart kind. */
+  kind?: ChartKind
+  /** Default path/data values keyed by field name. */
+  defaults?: Record<string, string>
+}
+
+const THEMES = ["_none", "zinc", "blue", "green", "rose", "orange", "amber", "violet", "purple", "cyan", "emerald"]
+const FONTS = ["inter", "geist", "geist-mono", "jetbrains-mono", "fira-code", "roboto", "space-grotesk"]
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function ChartSandbox({ kind: initialKind = "stars", defaults = {} }: ChartSandboxProps) {
+  const id = useId()
+
+  const [kind, setKind] = useState<ChartKind>(initialKind)
+
+  // Data inputs (interpretation depends on kind).
+  const [owner, setOwner] = useState(defaults.owner ?? "vercel")
+  const [repo, setRepo] = useState(defaults.repo ?? "next.js")
+  const [pkg, setPkg] = useState(defaults.package ?? "zod")
+  const [values, setValues] = useState(defaults.values ?? "10,25,40,30,60,55,80")
+  const [dataLabel, setDataLabel] = useState(defaults.label ?? "")
+
+  // Styling.
+  const [imageFormat, setImageFormat] = useState<"svg" | "png">("svg")
+  const [mode, setMode] = useState("dark")
+  const [theme, setTheme] = useState("_none")
+  const [font, setFont] = useState("inter")
+  const [color, setColor] = useState("")
+  const [fill, setFill] = useState("")
+  const [area, setArea] = useState(true)
+  const [transparent, setTransparent] = useState(false)
+  const [border, setBorder] = useState(true)
+  const [logo, setLogo] = useState(true)
+  const [width, setWidth] = useState("800")
+  const [height, setHeight] = useState("400")
+  const [title, setTitle] = useState("")
+  const [icon, setIcon] = useState("")
+  const [days, setDays] = useState("365")
+
+  // Axis controls.
+  const [yScale, setYScale] = useState("linear")
+  const [yMin, setYMin] = useState("")
+  const [yMax, setYMax] = useState("")
+  const [yTicks, setYTicks] = useState("")
+  const [xTicks, setXTicks] = useState("")
+
+  // Output.
+  const [format, setFormat] = useState("markdown")
+  const [copied, setCopied] = useState(false)
+
+  const baseUrl = useSyncExternalStore(
+    () => () => {},
+    () => window.location.origin,
+    () => "https://shieldcn.dev",
+  )
+
+  const handleFormatChange = useCallback((next: string) => {
+    setFormat(next)
+    setCopied(false)
+  }, [])
+
+  const endpoint = useMemo(() => {
+    switch (kind) {
+      case "stars": return "/chart/github/stars/:owner/:repo.svg"
+      case "issues": return "/chart/github/issues/:owner/:repo.svg"
+      case "npm": return "/chart/npm/:package.svg"
+      case "json": return "/chart/json.svg?values=…"
+    }
+  }, [kind])
+
+  const builtUrl = useMemo(() => {
+    const ext = imageFormat === "svg" ? ".svg" : ".png"
+    let path: string
+    if (kind === "stars" || kind === "issues") {
+      if (!owner || !repo) return null
+      path = `/chart/github/${kind}/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}${ext}`
+    } else if (kind === "npm") {
+      if (!pkg) return null
+      // Scoped packages keep their slash.
+      const encoded = pkg.split("/").map(encodeURIComponent).join("/")
+      path = `/chart/npm/${encoded}${ext}`
+    } else {
+      path = `/chart/json${ext}`
+    }
+
+    const qp = new URLSearchParams()
+    if (kind === "json") {
+      const cleaned = values.split(",").map(s => s.trim()).filter(Boolean).join(",")
+      if (!cleaned) return null
+      qp.set("values", cleaned)
+      if (dataLabel) qp.set("label", dataLabel)
+    }
+    if (kind === "npm" && days && days !== "365") qp.set("days", days)
+    if (mode !== "dark") qp.set("mode", mode)
+    if (theme && theme !== "_none") qp.set("theme", theme)
+    if (font && font !== "inter") qp.set("font", font)
+    if (color) qp.set("color", color)
+    if (fill) qp.set("fill", fill)
+    if (!area) qp.set("area", "false")
+    if (transparent) qp.set("bg", "transparent")
+    if (!border) qp.set("border", "false")
+    if (!logo) qp.set("logo", "false")
+    if (width && width !== "800") qp.set("width", width)
+    if (height && height !== "400") qp.set("height", height)
+    if (title) qp.set("title", title)
+    if (icon) qp.set("icon", icon)
+    if (yScale === "log") qp.set("yScale", "log")
+    if (yMin) qp.set("yMin", yMin)
+    if (yMax) qp.set("yMax", yMax)
+    if (yTicks) qp.set("yTicks", yTicks)
+    if (xTicks) qp.set("xTicks", xTicks)
+
+    const qs = qp.toString()
+    return `${baseUrl}${path}${qs ? `?${qs}` : ""}`
+  }, [kind, imageFormat, owner, repo, pkg, values, dataLabel, days, mode, theme, font, color, fill, area, transparent, border, logo, width, height, title, icon, yScale, yMin, yMax, yTicks, xTicks, baseUrl])
+
+  const formattedOutput = useMemo(() => {
+    if (!builtUrl) return ""
+    switch (format) {
+      case "markdown": return `![chart](${builtUrl})`
+      case "html": return `<img alt="chart" src="${builtUrl}">`
+      default: return builtUrl
+    }
+  }, [builtUrl, format])
+
+  const handleCopy = useCallback(() => {
+    if (!formattedOutput) return
+    navigator.clipboard.writeText(formattedOutput)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }, [formattedOutput])
+
+  return (
+    <div className="rounded-lg border border-border bg-card overflow-hidden not-prose">
+      <div className="border-b border-border bg-muted/30 px-4 py-3">
+        <div className="flex items-center gap-2 font-mono text-sm">
+          <Badge variant="outline" className="bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950 dark:text-emerald-400 dark:border-emerald-800 rounded-md font-semibold">
+            GET
+          </Badge>
+          <span className="text-muted-foreground break-all">{endpoint}</span>
+        </div>
+      </div>
+
+      <div className="p-4 space-y-4">
+        {/* Kind + data inputs */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <SField label="chart">
+            <Select value={kind} onValueChange={v => setKind(v as ChartKind)}>
+              <SelectTrigger aria-label="Chart kind" className="w-full"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="stars">GitHub stars</SelectItem>
+                <SelectItem value="issues">GitHub issues</SelectItem>
+                <SelectItem value="npm">npm downloads</SelectItem>
+                <SelectItem value="json">Inline JSON</SelectItem>
+              </SelectContent>
+            </Select>
+          </SField>
+
+          {(kind === "stars" || kind === "issues") && (
+            <>
+              <SField label="owner">
+                <Input id={`${id}-owner`} value={owner} onChange={e => setOwner(e.target.value)} placeholder="vercel" />
+              </SField>
+              <SField label="repo">
+                <Input id={`${id}-repo`} value={repo} onChange={e => setRepo(e.target.value)} placeholder="next.js" />
+              </SField>
+            </>
+          )}
+
+          {kind === "npm" && (
+            <>
+              <SField label="package">
+                <Input id={`${id}-pkg`} value={pkg} onChange={e => setPkg(e.target.value)} placeholder="react or @scope/name" />
+              </SField>
+              <SField label="days">
+                <Input id={`${id}-days`} value={days} onChange={e => setDays(e.target.value)} placeholder="365" />
+              </SField>
+            </>
+          )}
+
+          {kind === "json" && (
+            <>
+              <SField label="values">
+                <Input id={`${id}-values`} value={values} onChange={e => setValues(e.target.value)} placeholder="10,25,40,30" />
+              </SField>
+              <SField label="label">
+                <Input id={`${id}-data-label`} value={dataLabel} onChange={e => setDataLabel(e.target.value)} placeholder="value" />
+              </SField>
+            </>
+          )}
+        </div>
+
+        <Separator />
+
+        {/* Styling */}
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <SField label="format">
+            <Select value={imageFormat} onValueChange={v => setImageFormat(v as "svg" | "png")}>
+              <SelectTrigger aria-label="Image format" className="w-full"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="svg">SVG</SelectItem>
+                <SelectItem value="png">PNG</SelectItem>
+              </SelectContent>
+            </Select>
+          </SField>
+          <SField label="mode">
+            <Select value={mode} onValueChange={setMode}>
+              <SelectTrigger aria-label="Color mode" className="w-full"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="dark">dark</SelectItem>
+                <SelectItem value="light">light</SelectItem>
+              </SelectContent>
+            </Select>
+          </SField>
+          <SField label="theme">
+            <Select value={theme} onValueChange={setTheme}>
+              <SelectTrigger aria-label="Theme" className="w-full"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                {THEMES.map(t => <SelectItem key={t} value={t}>{t === "_none" ? "none" : t}</SelectItem>)}
+              </SelectContent>
+            </Select>
+          </SField>
+          <SField label="font">
+            <Select value={font} onValueChange={setFont}>
+              <SelectTrigger aria-label="Font" className="w-full"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                {FONTS.map(f => <SelectItem key={f} value={f}>{f}</SelectItem>)}
+              </SelectContent>
+            </Select>
+          </SField>
+        </div>
+
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <SField label="color"><ColorInput inputId={`${id}-color`} inputName="color" ariaLabel="Line color hex" value={color} onChange={setColor} placeholder="auto" /></SField>
+          <SField label="fill"><ColorInput inputId={`${id}-fill`} inputName="fill" ariaLabel="Fill color hex" value={fill} onChange={setFill} placeholder="auto" /></SField>
+          <SField label="width"><Input id={`${id}-w`} value={width} onChange={e => setWidth(e.target.value)} placeholder="800" /></SField>
+          <SField label="height"><Input id={`${id}-h`} value={height} onChange={e => setHeight(e.target.value)} placeholder="400" /></SField>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <SField label="icon"><LogoPicker value={icon} onChange={setIcon} /></SField>
+          <SField label="title"><Input id={`${id}-title`} value={title} onChange={e => setTitle(e.target.value)} placeholder="auto" /></SField>
+          <SField label="flags">
+            <div className="flex flex-wrap gap-x-4 gap-y-1 pt-1.5">
+              <label className="flex items-center gap-1.5 text-xs cursor-pointer">
+                <Checkbox aria-label="Area fill" checked={area} onCheckedChange={v => setArea(v === true)} />
+                <span className="font-mono text-muted-foreground">area</span>
+              </label>
+              <label className="flex items-center gap-1.5 text-xs cursor-pointer">
+                <Checkbox aria-label="Border" checked={border} onCheckedChange={v => setBorder(v === true)} />
+                <span className="font-mono text-muted-foreground">border</span>
+              </label>
+              <label className="flex items-center gap-1.5 text-xs cursor-pointer">
+                <Checkbox aria-label="Transparent background" checked={transparent} onCheckedChange={v => setTransparent(v === true)} />
+                <span className="font-mono text-muted-foreground">transparent</span>
+              </label>
+              <label className="flex items-center gap-1.5 text-xs cursor-pointer">
+                <Checkbox aria-label="Show watermark" checked={logo} onCheckedChange={v => setLogo(v === true)} />
+                <span className="font-mono text-muted-foreground">logo</span>
+              </label>
+            </div>
+          </SField>
+        </div>
+
+        <div className="grid grid-cols-2 sm:grid-cols-5 gap-3">
+          <SField label="yScale">
+            <Select value={yScale} onValueChange={setYScale}>
+              <SelectTrigger aria-label="Y axis scale" className="w-full"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="linear">linear</SelectItem>
+                <SelectItem value="log">log</SelectItem>
+              </SelectContent>
+            </Select>
+          </SField>
+          <SField label="yMin"><Input id={`${id}-ymin`} value={yMin} onChange={e => setYMin(e.target.value)} placeholder="auto" /></SField>
+          <SField label="yMax"><Input id={`${id}-ymax`} value={yMax} onChange={e => setYMax(e.target.value)} placeholder="auto" /></SField>
+          <SField label="yTicks"><Input id={`${id}-yticks`} value={yTicks} onChange={e => setYTicks(e.target.value)} placeholder="4" /></SField>
+          <SField label="xTicks"><Input id={`${id}-xticks`} value={xTicks} onChange={e => setXTicks(e.target.value)} placeholder="3" /></SField>
+        </div>
+
+        <Separator />
+
+        {/* Output */}
+        <Tabs value={format} onValueChange={handleFormatChange}>
+          <TabsList>
+            <TabsTrigger value="url">URL</TabsTrigger>
+            <TabsTrigger value="markdown">Markdown</TabsTrigger>
+            <TabsTrigger value="html">HTML</TabsTrigger>
+          </TabsList>
+          {["url", "markdown", "html"].map(key => (
+            <TabsContent key={key} value={key}>
+              {formattedOutput && (
+                <div className="group relative mt-2">
+                  <pre className="overflow-x-auto rounded-md border border-border bg-muted/50 p-3 font-mono text-xs leading-relaxed break-all whitespace-pre-wrap">
+                    {formattedOutput}
+                  </pre>
+                  <Button
+                    aria-label={copied ? "Copied output" : "Copy output"}
+                    variant="outline" size="icon-xs"
+                    onClick={handleCopy}
+                    className="absolute right-2 top-2 opacity-0 transition-opacity group-hover:opacity-100"
+                  >
+                    {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+                  </Button>
+                </div>
+              )}
+            </TabsContent>
+          ))}
+        </Tabs>
+
+        {/* Live preview */}
+        {builtUrl && (
+          <div className="overflow-hidden rounded-md border border-border bg-muted/30 p-3">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={builtUrl} alt="chart preview" className="w-full rounded" />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function SField({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1">
+      <Label className="font-mono text-[11px] text-muted-foreground">{label}</Label>
+      {children}
+    </div>
+  )
+}

--- a/packages/web/components/hero-subtext.tsx
+++ b/packages/web/components/hero-subtext.tsx
@@ -22,7 +22,7 @@ export function HeroSubtext() {
       >
         shadcn/ui
       </UnderlineToBackground>
-      . Unlimited combinations.
+      . Badges and charts. Unlimited combinations.
     </div>
   )
 }

--- a/packages/web/components/home-charts.tsx
+++ b/packages/web/components/home-charts.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import { useSyncExternalStore } from "react"
+import Link from "next/link"
+import { ArrowRight } from "lucide-react"
+import { useBadgeMode } from "@/lib/use-badge-mode"
+
+/** Hydration flag without a setState-in-effect (lint-clean). */
+function useHydrated() {
+  return useSyncExternalStore(() => () => {}, () => true, () => false)
+}
+
+const CHARTS: { src: string; alt: string }[] = [
+  { src: "/chart/github/stars/vercel/next.js.svg?theme=blue", alt: "GitHub star history" },
+  { src: "/chart/npm/zod.svg?theme=emerald", alt: "npm weekly downloads" },
+]
+
+export function HomeCharts() {
+  const hydrated = useHydrated()
+  const { adaptUrl } = useBadgeMode()
+
+  return (
+    <section id="charts" className="py-16 scroll-mt-16">
+      <div className="mb-8 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div className="max-w-lg">
+          <h2 className="text-2xl font-bold tracking-tight sm:text-3xl">Charts, too</h2>
+          <p className="mt-3 text-pretty text-muted-foreground">
+            Shadcn-styled star history, issues over time, npm downloads, and your own JSON
+            data — portable SVGs, no JavaScript.
+          </p>
+        </div>
+        <Link
+          href="/docs/charts"
+          className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline underline-offset-4"
+        >
+          Explore charts <ArrowRight className="size-3.5" />
+        </Link>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        {CHARTS.map((c) => (
+          <Link
+            key={c.src}
+            href="/docs/charts"
+            className="group overflow-hidden rounded-xl border border-border bg-card transition-colors hover:border-foreground/20"
+          >
+            {hydrated ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={adaptUrl(c.src)} alt={c.alt} className="w-full" />
+            ) : (
+              <div className="aspect-[2/1] w-full" />
+            )}
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/packages/web/components/sidebar.tsx
+++ b/packages/web/components/sidebar.tsx
@@ -73,6 +73,13 @@ const docsNav: NavGroup[] = [
     ],
   },
   {
+    title: "Charts",
+    alwaysOpen: true,
+    items: [
+      { title: "Overview", href: "/docs/charts" },
+    ],
+  },
+  {
     title: "Source Control",
     items: [
       { title: "GitHub", href: "/docs/badges/github" },

--- a/packages/web/components/site-announcement.tsx
+++ b/packages/web/components/site-announcement.tsx
@@ -11,8 +11,8 @@ export function SiteAnnouncement() {
     <Announcement>
       <AnnouncementBadge>New</AnnouncementBadge>
       <AnnouncementContent asChild>
-        <Link href="/docs/badges/skills" className="hover:underline underline-offset-4">
-          New: skills.sh badges — skill installs, rank &amp; audits
+        <Link href="/docs/charts" className="hover:underline underline-offset-4">
+          New: charts — star history, issues &amp; npm downloads
           <ArrowRight className="size-3" />
         </Link>
       </AnnouncementContent>

--- a/packages/web/content/docs/api-reference.mdx
+++ b/packages/web/content/docs/api-reference.mdx
@@ -123,6 +123,20 @@ Join any badge paths with `+`. Query params apply to all segments. See [Badge Gr
 | `/badge/{label}-{message}-{color}.svg` | Custom text badge |
 | `/badge/dynamic/json.svg?url=...&query=...` | Dynamic JSON badge |
 
+### Charts
+
+| Endpoint | Description |
+|----------|-------------|
+| `/chart/github/stars/{owner}/{repo}.svg` | GitHub star history |
+| `/chart/github/issues/{owner}/{repo}.svg` | GitHub issues over time |
+| `/chart/npm/{package}.svg` | npm weekly downloads |
+| `/chart/json.svg?values=1,2,3` | Inline JSON data |
+| `/chart/json.svg?url=...&query=...` | Remote JSON (JSONPath) |
+
+Shadcn-styled line/area charts. Support `mode`, `theme`, `color`, `fill`,
+`area`, `bg`, `border`, `font`, `width`, `height`, `title`, `days` (npm), and
+`values`/`dates`/`labels` or `url`/`query` (JSON). See [Charts docs](/docs/charts).
+
 ## Query parameters
 
 <ApiRefTable

--- a/packages/web/content/docs/charts/index.mdx
+++ b/packages/web/content/docs/charts/index.mdx
@@ -1,0 +1,175 @@
+---
+title: Charts
+description: Shadcn-styled graphs for GitHub stars, GitHub issues, npm downloads, and your own JSON data — rendered as portable SVGs.
+---
+
+Shadcn-styled line/area charts you can drop in a README, docs site, or anywhere
+an image works — plain SVG, no JavaScript, no iframe. Four kinds: GitHub star
+history (like [starcharts](https://github.com/caarlos0/starcharts)), GitHub
+issues over time, npm downloads, and arbitrary JSON.
+
+<ChartPreview
+  src="/chart/github/stars/vercel/next.js.svg"
+  alt="vercel/next.js star history"
+/>
+
+## Builder
+
+Pick a chart kind, tweak the styling, and copy the URL or markdown.
+
+<ChartSandbox kind="stars" />
+
+## URL format
+
+```
+/chart/github/stars/{owner}/{repo}.svg     → GitHub star history
+/chart/github/issues/{owner}/{repo}.svg    → GitHub issues over time
+/chart/npm/{package}.svg                    → npm weekly downloads
+/chart/json.svg?values=1,2,3                → inline JSON data
+/chart/json.svg?url=...&query=...           → remote JSON data
+```
+
+Every endpoint also serves `.png` and `.json` (the raw time series).
+
+Use it in markdown:
+
+```md
+![Star History](https://shieldcn.dev/chart/github/stars/vercel/next.js.svg)
+```
+
+Or as a clickable image linking back to the repo:
+
+```md
+[![Star History](https://shieldcn.dev/chart/github/stars/vercel/next.js.svg)](https://github.com/vercel/next.js)
+```
+
+## GitHub stars
+
+<ChartPreview
+  src="/chart/github/stars/shadcn-ui/ui.svg?theme=blue"
+  alt="shadcn-ui/ui star history"
+  description="Blue accent via theme"
+/>
+
+<ChartPreview
+  src="/chart/github/stars/withastro/astro.svg?bg=transparent&border=false&theme=orange"
+  alt="withastro/astro star history"
+  description="Transparent background, no border — drops onto any page"
+/>
+
+## GitHub issues over time
+
+Cumulative issues opened, sampled from the GitHub search API (pull requests
+excluded).
+
+```
+/chart/github/issues/{owner}/{repo}.svg
+```
+
+<ChartPreview
+  src="/chart/github/issues/honojs/hono.svg?theme=rose"
+  alt="honojs/hono issues over time"
+  description="Issues opened over time"
+/>
+
+## npm downloads
+
+Weekly download buckets over the last year (configurable with `?days=`).
+
+```
+/chart/npm/{package}.svg
+/chart/npm/@scope/{package}.svg
+```
+
+<ChartPreview
+  src="/chart/npm/zod.svg?theme=emerald"
+  alt="zod npm downloads"
+  description="Weekly npm downloads"
+/>
+
+## Your own data (JSON)
+
+Bring numbers inline with `?values=` (comma-separated). Add `?dates=` for a
+time axis or `?labels=` for category ticks — omit both and points are spaced
+evenly and labelled `1, 2, 3, …`.
+
+```
+/chart/json.svg?values=120,180,150,210,260&title=Latency&label=ms
+/chart/json.svg?values=10,20,30&dates=2024-01-01,2024-02-01,2024-03-01
+```
+
+<ChartPreview
+  src="/chart/json.svg?values=120,180,150,210,260,240,300,280,340&title=Latency&label=ms&theme=violet"
+  alt="inline JSON chart"
+  description="Inline values, evenly spaced index axis"
+/>
+
+Or pull from a remote endpoint with [JSONPath](https://github.com/JSONPath-Plus/JSONPath),
+exactly like the [dynamic JSON badge](/docs/badges/dynamic-json). `query`
+selects the value array; optional `dateQuery` selects a parallel date array.
+
+```
+/chart/json.svg?url=https://api.example.com/metrics.json&query=$.points[*].count&dateQuery=$.points[*].date
+```
+
+## Query parameters
+
+| Param | Values | Default | Description |
+|-------|--------|---------|-------------|
+| `mode` | `dark`, `light` | `dark` | Surface and text colors |
+| `theme` | `blue`, `green`, `rose`, `orange`, `violet`, `purple`, `cyan`, `emerald`, … | — | Accent color from the shadcn palette |
+| `color` | hex (no `#`) | `3b82f6` | Line + end-dot color (wins over `theme`) |
+| `fill` | hex (no `#`) | line color | Area fill color, independent of the line |
+| `area` | `true`, `false` | `true` | Show the gradient area fill under the line |
+| `bg` / `background` | `transparent`, hex | mode surface | Card background |
+| `border` | `true`, `false` | `true` | Draw the rounded card border |
+| `font` | `inter`, `geist`, `geist-mono`, `jetbrains-mono`, `fira-code`, `roboto`, `space-grotesk` | `inter` | Font-family stack (same keywords as badges) |
+| `logo` | `false` | shown | Show/hide the shieldcn corner watermark |
+| `logoColor` | hex (no `#`) | muted | Watermark color |
+| `icon` | SimpleIcons slug, `ri:Name`, `false` | auto (github/npm) | Icon left of the title |
+| `iconColor` | hex (no `#`) | title color | Title icon color |
+| `yScale` | `linear`, `log` | `linear` | Y-axis scale type |
+| `yMin` | number | `0` (auto) | Force the y-axis minimum |
+| `yMax` | number | auto | Force the y-axis maximum |
+| `yTicks` | 1–10 | `4` | Number of y-axis gridline intervals |
+| `xTicks` | 2–12 | `3` | Number of x-axis labels |
+| `width` | 200–2000 | `800` | Chart width in px |
+| `height` | 120–1200 | `400` | Chart height in px |
+| `title` | string | per kind | Override the chart title |
+| `days` | 30–540 | `365` | npm download window |
+| `values` | comma numbers | — | Inline JSON data points |
+| `dates` | comma dates | — | Inline JSON x-axis dates |
+| `labels` | comma strings | — | Inline JSON x-axis labels |
+| `url` + `query` | URL + JSONPath | — | Remote JSON data source |
+
+> **Note** — `font` only swaps the **family stack**. Charts are raw SVG (needed
+> for the line paths), and a sandboxed `<img>` SVG can't load embedded fonts —
+> so the rendered typeface depends on what's available to the viewer.
+
+## How star history works
+
+GitHub has no "stars over time" API. shieldcn reconstructs the curve from the
+stargazers endpoint, which (with the `star+json` media type) returns a
+`starred_at` timestamp per stargazer:
+
+- **Small / medium repos** — every page is fetched and the full list is sampled
+  down to ~30 points for an exact curve.
+- **Large repos** — pages are sampled evenly and the first stargazer of each is
+  read, then the curve is anchored to the live star count, exactly like
+  starcharts.
+
+Requests are distributed across the donated [token pool](/token-pool) and
+cached with a 6-hour fresh window plus a 30-day last-known-good fallback, so a
+transient rate limit never collapses the chart.
+
+## Data sources
+
+| Chart | Source | Cache |
+|-------|--------|-------|
+| Stars | [GitHub Stargazers API](https://docs.github.com/en/rest/activity/starring) | 6h fresh · 30d last-known-good |
+| Issues | [GitHub Search API](https://docs.github.com/en/rest/search) (`type:issue`) | 6h fresh · 30d last-known-good |
+| npm | [npm downloads API](https://github.com/npm/registry/blob/main/docs/download-counts.md) | 1h |
+| JSON | inline, or your `url` | 5m (remote) |
+
+GitHub requests are distributed across the donated [token pool](/token-pool)
+and serve a last-known-good copy if the upstream is briefly unavailable.

--- a/packages/web/content/docs/charts/meta.json
+++ b/packages/web/content/docs/charts/meta.json
@@ -1,0 +1,6 @@
+{
+  "title": "Charts",
+  "pages": [
+    "index"
+  ]
+}

--- a/packages/web/content/docs/meta.json
+++ b/packages/web/content/docs/meta.json
@@ -10,6 +10,8 @@
     "...customization",
     "---Badges---",
     "...badges",
+    "---Charts---",
+    "...charts",
     "---Registry---",
     "...registry",
     "---Reference---",

--- a/packages/web/mdx-components.tsx
+++ b/packages/web/mdx-components.tsx
@@ -1,6 +1,8 @@
 import type { MDXComponents } from "mdx/types"
 import { BadgeSandbox } from "@/components/badge-sandbox"
 import { BadgePreview, BadgePreviewGroup, BadgePreviewCard } from "@/components/badge-preview"
+import { ChartPreview } from "@/components/chart-preview"
+import { ChartSandbox } from "@/components/chart-sandbox"
 import { CodeBlock } from "@/components/code-block"
 import { CodeLine } from "@/components/code-line"
 import { ApiRefTable } from "@/components/api-ref-table"
@@ -18,6 +20,8 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     BadgePreview,
     BadgePreviewGroup,
     BadgePreviewCard,
+    ChartPreview,
+    ChartSandbox,
 
     // jalco-ui registry components
     CodeBlock,


### PR DESCRIPTION
## What

Adds shadcn-styled **charts** to shieldcn — portable SVG line/area graphs served through the shared core route handler (so they work on both the web app and the self-hosted engine with no extra wiring).

Four chart kinds:

| Endpoint | Data |
|---|---|
| `/chart/github/stars/{owner}/{repo}` | Star history (like [starcharts](https://github.com/caarlos0/starcharts)) |
| `/chart/github/issues/{owner}/{repo}` | Cumulative issues opened over time |
| `/chart/npm/{package}` | Weekly downloads, last year |
| `/chart/json?values=…` / `?url=…&query=…` | Inline or remote JSON (JSONPath) |

All serve `.svg`, `.png`, and `.json`.

## Why

A frequently-requested companion to badges: people want a shadcn-consistent star-history graph for READMEs without reaching for a third-party service. Reuses the existing token pool, cache, and icon pipeline.

## How

- **Renderer** (`packages/core/src/badges/render-chart.ts`) — hand-built SVG (no Satori, which has no line/path primitives) for many data points and a true shadcn chart look: card surface, gradient area fill, grid, time/index axes, dark+light, optional `shieldcn.dev` watermark, and a title icon.
- **Providers** — `starhistory.ts` (stars + issues, sampled & cached with last-known-good fallback) and an npm downloads time series in `npm.ts` (weekly buckets; drops the incomplete trailing week).
- **Route** — `chart` handling added to `route-handler.ts` with a generic `ChartPoint` and per-kind dispatch.
- **Props mirror the badge vocabulary** (`mode`, `theme`, `color`, `font`, `width`, `height`, `title`) plus chart-specific controls: `fill`, `area`, `bg`/`background`, `border`, `yScale` (linear/log), `yMin`/`yMax`, `yTicks`/`xTicks`, `icon` (SimpleIcons/React Icons/Lucide with per-kind defaults + stroke support), and `logo`/`logoColor` for the watermark.
- **Web** — `ChartPreview` + an interactive `ChartSandbox` builder (reuses the badge `LogoPicker`), docs page at `/docs/charts`, sidebar + API reference + README entries, and a Charts section in the showcase.

## Testing

- `pnpm --filter @shieldcn/core test` → **80 tests pass** (renderer unit tests incl. log scale + index axis; end-to-end route tests with stubbed GitHub fetch + inline JSON).
- `tsc --noEmit` clean for both `@shieldcn/core` and `@shieldcn/web`; web lint clean (pre-commit hook passed).
- Verified live against `next dev`: all four kinds render (stars/issues/npm/json), dark + light, transparent bg, log scale, icons from all three sources, and the watermark.

## Note on stacking

This branch builds on the unmerged `feat/showcase-bento-redesign` commits (the showcase Charts section depends on the bento showcase), so they appear in this diff. Merge/rebase order with that branch is up to you.

## Screenshots

_Star history, npm downloads (light), log scale, and title icons — rendered locally; see PR thread._
