### PR TITLE
feat(web): animated hero showcase with badge/chart cluster and glow

### DIFF
--- a/packages/core/src/badges/render.tsx
+++ b/packages/core/src/badges/render.tsx
@@ -386,7 +386,7 @@ export async function renderBadge(config: BadgeConfig): Promise<string> {
   const el = r.split ? renderSplit(r) : renderSingle(r)
   const fonts = getFonts(config.font)
   const raw = await satori(el, { height: r.height, fonts })
-  const svg = inlineDataUriImages(raw)
+  const svg = rgbaToHexOpacity(inlineDataUriImages(raw))
   const optimized = optimizeSvg(svg)
   const mode = config.animate ?? "none"
   if (mode === "none") return optimized
@@ -405,7 +405,7 @@ export async function renderBadgeBase(
   const el = r.split ? renderSplit(r) : renderSingle(r)
   const fonts = getFonts(config.font)
   const raw = await satori(el, { height: r.height, fonts })
-  const svg = optimizeSvg(inlineDataUriImages(raw))
+  const svg = optimizeSvg(rgbaToHexOpacity(inlineDataUriImages(raw)))
   return { svg, dotColor: r.dotColor }
 }
 
@@ -465,61 +465,131 @@ function optimizeSvg(svg: string): string {
 
 /**
  * Post-process SVG to inline data URI images as actual SVG elements.
- * Satori converts nested <svg> to <image href="data:image/svg+xml;...">.
- * Some renderers don't handle these well, so we convert them back to inline paths.
+ *
+ * Satori emits nested SVG content as <image href="data:image/svg+xml;...">
+ * (both the JSX <svg> icons it serializes as `utf8` data URIs, and the
+ * <img src="data:...;base64"> flags/emoji/custom logos we pass in). WebKit
+ * (Quick Look, browsers) renders an SVG embedded inside an <image>, but
+ * Photoshop / Illustrator / Figma do NOT — the logo silently disappears on
+ * import. Satori also wraps these <image> tags in `mask`/`clip-path`
+ * references that those editors handle poorly.
+ *
+ * So we decode every SVG data URI and splice its real markup back in as a
+ * positioned <g>. This preserves multi-color art (flags, emoji) verbatim and
+ * keeps the logo as a first-class part of the badge in any editor.
  */
 function inlineDataUriImages(svg: string): string {
-  // Match <image> tags with SVG data URIs
-  const imageRegex = /<image\s+x="([^"]+)"\s+y="([^"]+)"\s+width="([^"]+)"\s+height="([^"]+)"\s+href="data:image\/svg\+xml;[^"]+"[^>]*\/>/g
+  // Match any <image .../> regardless of attribute order.
+  const imageRegex = /<image\b([^>]*?)\/>/g
 
-  return svg.replace(imageRegex, (match, x, y, width, height) => {
-    // Extract the data URI content
-    const hrefMatch = match.match(/href="data:image\/svg\+xml;utf8,([^"]+)"/)
+  return svg.replace(imageRegex, (match, attrs: string) => {
+    // Only handle SVG data URIs — leave raster (png/jpeg) images alone.
+    const hrefMatch = attrs.match(/href="(data:image\/svg\+xml;[^"]+)"/)
     if (!hrefMatch) return match
+    const href = hrefMatch[1]
 
-    // Decode the URI-encoded SVG
+    // Decode the inner SVG — Satori uses `utf8` for serialized JSX icons and
+    // `base64` for the <img> data URIs we pass (flags, emoji, custom logos).
     let innerSvg: string
     try {
-      innerSvg = decodeURIComponent(hrefMatch[1])
+      if (/;base64,/.test(href)) {
+        const b64 = href.replace(/^data:image\/svg\+xml;base64,/, "")
+        innerSvg = Buffer.from(b64, "base64").toString("utf8")
+      } else {
+        const enc = href.replace(/^data:image\/svg\+xml;(?:charset=utf-8|utf8)?,?/, "")
+        innerSvg = decodeURIComponent(enc)
+      }
     } catch {
       return match
     }
+
+    // Position/size of the placed image (attribute order is not guaranteed).
+    const num = (name: string, fallback: number) => {
+      const m = attrs.match(new RegExp(`\\b${name}="([^"]+)"`))
+      const n = m ? parseFloat(m[1]) : NaN
+      return Number.isFinite(n) ? n : fallback
+    }
+    const x = num("x", 0)
+    const y = num("y", 0)
+    const width = num("width", 0)
+    const height = num("height", 0)
+    if (width <= 0 || height <= 0) return match
 
     // Extract viewBox from inner SVG. Guard against malformed values (a
     // user-supplied ?logo= data URI can carry a garbage viewBox) — a NaN or
     // zero dimension would otherwise produce scale(NaN) and a broken badge.
     const vbMatch = innerSvg.match(/viewBox="([^"]+)"/)
-    const viewBox = vbMatch ? vbMatch[1].split(/\s+/).map(Number) : [0, 0, 24, 24]
+    const viewBox = vbMatch ? vbMatch[1].split(/[\s,]+/).map(Number) : [0, 0, 24, 24]
     let [, , vbWidth, vbHeight] = viewBox
     if (!Number.isFinite(vbWidth) || vbWidth <= 0) vbWidth = 24
     if (!Number.isFinite(vbHeight) || vbHeight <= 0) vbHeight = 24
 
-    // Extract any <g transform="..."> wrapper from inner SVG (e.g. rotation)
-    const gTransformMatch = innerSvg.match(/<g\s+transform="([^"]+)">/)
-    const innerTransform = gTransformMatch ? gTransformMatch[1] : null
+    // Take the inner SVG's content verbatim (everything between the outer
+    // <svg> tags). This preserves nested groups, multiple fills, rotation
+    // transforms, etc. — exactly what makes flags/emoji multi-color.
+    let inner = innerSvg
+      .replace(/^[\s\S]*?<svg\b[^>]*>/, "")
+      .replace(/<\/svg>\s*$/, "")
+      .trim()
+    // Strip serialization artifacts: Satori writes undefined props out as the
+    // literal string "undefined" (e.g. fill-rule="undefined"), which is an
+    // invalid value that strict SVG parsers reject.
+    inner = inner.replace(/\s+[a-zA-Z-]+="undefined"/g, "")
+    if (!inner) return match
 
-    // Extract path(s) from inner SVG
-    const paths: string[] = []
-    const pathRegex = /<path\s+([^>]+)>/g
-    let pathMatch: RegExpExecArray | null
-    while ((pathMatch = pathRegex.exec(innerSvg)) !== null) {
-      paths.push(`<path ${pathMatch[1]}/>`)
+    // Respect the placement intent. Satori uses preserveAspectRatio="none"
+    // for <img> insets that should fill the box (flags), and the default
+    // meet behaviour for icons that should keep aspect (contain + center).
+    const par = (attrs.match(/preserveAspectRatio="([^"]+)"/)?.[1] ?? "").trim()
+    const scaleX = width / vbWidth
+    const scaleY = height / vbHeight
+
+    let transform: string
+    if (par === "none") {
+      transform = `translate(${x},${y}) scale(${scaleX},${scaleY})`
+    } else {
+      const scale = Math.min(scaleX, scaleY)
+      const tx = x + (width - vbWidth * scale) / 2
+      const ty = y + (height - vbHeight * scale) / 2
+      transform = `translate(${tx},${ty}) scale(${scale})`
     }
 
-    if (paths.length === 0) return match
-
-    // Calculate scale to fit width x height
-    const scaleX = parseFloat(width) / vbWidth
-    const scaleY = parseFloat(height) / vbHeight
-    const scale = Math.min(scaleX, scaleY)
-
-    // Create a group with transform to position and scale the paths
-    // If inner SVG had a transform (e.g. rotation), nest it inside
-    const pathContent = innerTransform
-      ? `<g transform="${innerTransform}">${paths.join("")}</g>`
-      : paths.join("")
-    return `<g transform="translate(${x},${y}) scale(${scale})">${pathContent}</g>`
+    return `<g transform="${transform}">${inner}</g>`
   })
+}
+
+/**
+ * Rewrite `rgba()` color values into editor-portable `#hex` + `*-opacity`.
+ *
+ * Satori bakes opacity into `fill="rgba(r,g,b,a)"` (we deliberately avoid the
+ * CSS `opacity` property because of a Satori bug). Browsers and Quick Look
+ * accept `rgba()` in a presentation attribute, but it is NOT valid SVG 1.1 —
+ * Photoshop / Illustrator drop the color and paint the element black or
+ * transparent. That is why downloaded badges "lose their colors" in editors.
+ *
+ * Converting to `fill="#rrggbb" fill-opacity="a"` is universally supported and
+ * renders identically everywhere.
+ */
+function rgbaToHexOpacity(svg: string): string {
+  let out = svg
+  for (const attr of ["fill", "stroke", "stop-color"] as const) {
+    const re = new RegExp(
+      `${attr}="rgba\\(\\s*([0-9.]+)\\s*,\\s*([0-9.]+)\\s*,\\s*([0-9.]+)\\s*,\\s*([0-9.]+)\\s*\\)"`,
+      "g",
+    )
+    out = out.replace(re, (_m, r: string, g: string, b: string, a: string) => {
+      const hex =
+        "#" +
+        [r, g, b]
+          .map((n) => Math.max(0, Math.min(255, Math.round(Number(n)))).toString(16).padStart(2, "0"))
+          .join("")
+      const alpha = Number(a)
+      if (!Number.isFinite(alpha) || alpha >= 1) return `${attr}="${hex}"`
+      const op = Math.max(0, alpha)
+      return `${attr}="${hex}" ${attr}-opacity="${+op.toFixed(3)}"`
+    })
+  }
+  return out
 }
 
 export async function renderErrorBadge(label: string, message: string): Promise<string> {

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -4,7 +4,9 @@ import { HeroSubtext } from "@/components/hero-subtext"
 import { Separator } from "@/components/ui/separator"
 import { BadgeBuilder } from "@/components/badge-builder"
 import { GenHeroInput } from "@/components/gen-hero-input"
-import { HeroIconCloud } from "@/components/hero-icon-cloud"
+import { HeroShowcase } from "@/components/hero-showcase"
+import { HeroGlow } from "@/components/hero-glow"
+import { HeroEntrance } from "@/components/hero-entrance"
 import { ScrollCta } from "@/components/scroll-cta"
 import { SiteShell } from "@/components/site-shell"
 import { pageMetadata } from "@/lib/metadata"
@@ -30,13 +32,13 @@ export default async function Home() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareAppJsonLd()) }}
       />
       <main className="min-w-0 flex-1">
-        {/* Hero — split layout */}
+        {/* Hero — split layout, staged page-transition-in (HeroEntrance) */}
         <section className="relative overflow-hidden px-6 py-10 md:px-10 md:py-16">
-          <div className="mx-auto flex max-w-6xl flex-col gap-8 lg:flex-row lg:items-center lg:gap-12">
-            {/* Left — text content */}
-            <div className="relative z-10 space-y-6 lg:w-1/2">
-              <SiteAnnouncement />
-
+          <HeroGlow />
+          <HeroEntrance
+            variant="unfold"
+            announcement={<SiteAnnouncement />}
+            heading={
               <h1 className="text-balance text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl">
                 The badges your{" "}
                 <span className="inline-flex items-baseline">
@@ -48,18 +50,12 @@ export default async function Home() {
                 </span>{" "}
                 crave.
               </h1>
-
-              <HeroSubtext />
-
-              <GenHeroInput />
-            </div>
-
-            {/* Right — 3D badge icon cloud (oversized, bleeds behind text) */}
-            <div className="relative z-0 hidden items-center justify-center md:flex lg:w-1/2 lg:-ml-20 lg:-mt-16">
-              <HeroIconCloud />
-            </div>
-          </div>
-          <ScrollCta targetId="builder" />
+            }
+            subtext={<HeroSubtext />}
+            input={<GenHeroInput />}
+            cloud={<HeroShowcase />}
+            scrollCta={<ScrollCta targetId="builder" />}
+          />
         </section>
 
         <div className="mx-auto max-w-6xl px-6 md:px-10">

--- a/packages/web/components/hero-entrance.tsx
+++ b/packages/web/components/hero-entrance.tsx
@@ -1,0 +1,210 @@
+/**
+ * shieldcn
+ * components/hero-entrance
+ *
+ * Homepage "page transition in". Stages the hero elements (announcement,
+ * heading, subtext, input, icon cloud, scroll cta) into view on mount using
+ * the Storyboard Animation pattern. Ships three variants (cascade / snap /
+ * unfold); each timing value is exposed as a live DialKit slider and the
+ * variant is switchable from a live DialKit dropdown.
+ */
+
+/* ─────────────────────────────────────────────────────────
+ * ANIMATION STORYBOARD
+ *
+ * Read top-to-bottom. Each `at` value is ms after mount.
+ *
+ * Timings below are the `cascade` variant (snap is faster, unfold slower).
+ *
+ *    0ms   hero hidden (opacity 0, slid down, blurred)
+ *  120ms   announcement pill fades up
+ *  260ms   heading fades up
+ *  420ms   subtext fades up
+ *  560ms   generate input fades up
+ *  300ms   icon cloud fades + scales in (runs alongside text)
+ *  760ms   scroll cta fades in last
+ * ───────────────────────────────────────────────────────── */
+
+"use client"
+
+import { useEffect, useState } from "react"
+import { motion, type Transition } from "motion/react"
+import { DialRoot } from "dialkit"
+import "dialkit/styles.css"
+
+// ---------------------------------------------------------------------------
+// Storyboard variants
+//
+// Each variant is a full preset: stage timings (ms after mount) + the motion
+// "feel" of the rising text column and the icon cloud. Switch live via the
+// DialKit "Variant" dropdown, or set the default per-page with the `variant`
+// prop.
+//
+//   cascade — smooth staggered rise + blur burn-off (the default)
+//   snap    — fast, tight, minimal travel; everything lands quickly
+//   unfold  — slow + cinematic; long travel, heavier blur, gentle bounce
+// ---------------------------------------------------------------------------
+
+type VariantConfig = {
+  /** Stage delays in ms after mount. The ONLY place timing values live. */
+  timing: {
+    announcement: number
+    heading: number
+    subtext: number
+    input: number
+    cloud: number
+    scrollCta: number
+  }
+  /** Rising text/input column reveal. */
+  rise: {
+    offsetY: number // px each element slides up from
+    blur: number //    px blur burned off as it settles
+    spring: { type: "spring"; visualDuration: number; bounce: number }
+  }
+  /** Icon cloud reveal (scales in rather than rising). */
+  cloud: {
+    initialScale: number
+    spring: { type: "spring"; stiffness: number; damping: number }
+  }
+}
+
+const VARIANTS = {
+  cascade: {
+    timing: { announcement: 120, heading: 260, subtext: 420, input: 560, cloud: 300, scrollCta: 760 },
+    rise: { offsetY: 16, blur: 8, spring: { type: "spring", visualDuration: 0.5, bounce: 0.15 } },
+    cloud: { initialScale: 0.92, spring: { type: "spring", stiffness: 260, damping: 28 } },
+  },
+  snap: {
+    timing: { announcement: 60, heading: 140, subtext: 220, input: 300, cloud: 160, scrollCta: 420 },
+    rise: { offsetY: 10, blur: 4, spring: { type: "spring", visualDuration: 0.3, bounce: 0.05 } },
+    cloud: { initialScale: 0.96, spring: { type: "spring", stiffness: 460, damping: 26 } },
+  },
+  unfold: {
+    timing: { announcement: 200, heading: 440, subtext: 700, input: 960, cloud: 360, scrollCta: 1240 },
+    rise: { offsetY: 28, blur: 14, spring: { type: "spring", visualDuration: 0.8, bounce: 0.3 } },
+    cloud: { initialScale: 0.85, spring: { type: "spring", stiffness: 170, damping: 22 } },
+  },
+} satisfies Record<string, VariantConfig>
+
+type VariantName = keyof typeof VARIANTS
+const DEFAULT_VARIANT: VariantName = "cascade"
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface HeroEntranceProps {
+  announcement: React.ReactNode
+  heading: React.ReactNode
+  subtext: React.ReactNode
+  input: React.ReactNode
+  cloud: React.ReactNode
+  scrollCta: React.ReactNode
+  /** Which entrance preset to play. Default: "cascade". */
+  variant?: VariantName
+  /**
+   * When true, the right (cloud) slot renders without the scale/opacity
+   * entrance wrapper. Use for a cloud that owns its own entrance (e.g. a
+   * self-assembling README) so the two animations don't fight.
+   */
+  cloudStatic?: boolean
+}
+
+export function HeroEntrance({ variant = DEFAULT_VARIANT, ...slots }: HeroEntranceProps) {
+  return (
+    <>
+      {/* One DialRoot for the whole hero — renders the Hero Glow / Hero
+          Showcase panels in dev. The entrance itself is not dial-tunable. */}
+      <DialRoot position="bottom-right" />
+      <HeroEntranceStage variant={variant} {...slots} />
+    </>
+  )
+}
+
+function HeroEntranceStage({
+  variant,
+  announcement,
+  heading,
+  subtext,
+  input,
+  cloud,
+  scrollCta,
+  cloudStatic = false,
+}: Omit<HeroEntranceProps, "variant"> & { variant: VariantName }) {
+  const preset = VARIANTS[variant]
+  const t = preset.timing
+  const riseCfg = preset.rise
+
+  // Single integer stage drives the whole sequence.
+  // 1: announcement  2: heading  3: subtext  4: input  5: cloud  6: scrollCta
+  const [stage, setStage] = useState(0)
+
+  useEffect(() => {
+    const timers: ReturnType<typeof setTimeout>[] = []
+    timers.push(setTimeout(() => setStage(s => Math.max(s, 1)), t.announcement))
+    timers.push(setTimeout(() => setStage(s => Math.max(s, 2)), t.heading))
+    timers.push(setTimeout(() => setStage(s => Math.max(s, 3)), t.subtext))
+    timers.push(setTimeout(() => setStage(s => Math.max(s, 4)), t.input))
+    timers.push(setTimeout(() => setStage(s => Math.max(s, 5)), t.cloud))
+    timers.push(setTimeout(() => setStage(s => Math.max(s, 6)), t.scrollCta))
+    return () => timers.forEach(clearTimeout)
+  }, [t.announcement, t.heading, t.subtext, t.input, t.cloud, t.scrollCta])
+
+  // Reusable reveal props for a rising column element at a given stage.
+  const rise = (atStage: number) => ({
+    initial: {
+      opacity: 0,
+      y: riseCfg.offsetY,
+      filter: `blur(${riseCfg.blur}px)`,
+    },
+    animate: {
+      opacity: stage >= atStage ? 1 : 0,
+      y: stage >= atStage ? 0 : riseCfg.offsetY,
+      filter: stage >= atStage ? "blur(0px)" : `blur(${riseCfg.blur}px)`,
+    },
+    transition: riseCfg.spring as Transition,
+  })
+
+  return (
+    <>
+      <div className="mx-auto flex max-w-6xl flex-col gap-8 lg:flex-row lg:items-center lg:gap-12">
+        {/* Left — text content */}
+        <div className="relative z-10 space-y-6 lg:w-1/2">
+          <motion.div {...rise(1)}>{announcement}</motion.div>
+          <motion.div {...rise(2)}>{heading}</motion.div>
+          <motion.div {...rise(3)}>{subtext}</motion.div>
+          <motion.div {...rise(4)}>{input}</motion.div>
+        </div>
+
+        {/* Right — visual slot. Either entrance-animated here, or static so it
+            can own its own entrance (cloudStatic). */}
+        {cloudStatic ? (
+          <div className="relative z-0 hidden items-center justify-center md:flex lg:w-1/2 lg:-ml-8">
+            {cloud}
+          </div>
+        ) : (
+          <motion.div
+            className="relative z-0 hidden items-center justify-center md:flex lg:w-1/2 lg:-ml-8"
+            initial={{ opacity: 0, scale: preset.cloud.initialScale }}
+            animate={{
+              opacity: stage >= 5 ? 1 : 0,
+              scale: stage >= 5 ? 1 : preset.cloud.initialScale,
+            }}
+            transition={preset.cloud.spring as Transition}
+          >
+            {cloud}
+          </motion.div>
+        )}
+      </div>
+
+      {/* Scroll cta — fades in last */}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: stage >= 6 ? 1 : 0 }}
+        transition={{ duration: 0.4 }}
+      >
+        {scrollCta}
+      </motion.div>
+    </>
+  )
+}

--- a/packages/web/components/hero-glow.tsx
+++ b/packages/web/components/hero-glow.tsx
@@ -1,0 +1,92 @@
+// shieldcn — components/hero-glow.tsx
+// Subtle ambient radial glow behind the hero showcase. Decorative only.
+// Fully tunable (intensity / size / position / hue) via DialKit — set
+// intensity to 0 to disable. Renders behind all hero content.
+
+"use client"
+
+import { useSyncExternalStore } from "react"
+import { useDialKit } from "dialkit"
+
+/** Hydration flag without setState-in-effect (lint-clean, mirrors HomeCharts). */
+function useHydrated() {
+  return useSyncExternalStore(() => () => {}, () => true, () => false)
+}
+
+/** #rgb | #rrggbb → rgba(r,g,b,a) */
+function hexToRgba(hex: string, alpha: number): string {
+  let h = hex.replace("#", "")
+  if (h.length === 3) h = h.split("").map(c => c + c).join("")
+  const n = parseInt(h, 16)
+  const r = (n >> 16) & 255
+  const g = (n >> 8) & 255
+  const b = n & 255
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`
+}
+
+export function HeroGlow() {
+  const hydrated = useHydrated()
+
+  const g = useDialKit("Hero Glow", {
+    intensity: [0.19, 0, 0.6, 0.01], // peak alpha at the center of the glow
+    sizeX: [49, 10, 100, 1], //         horizontal radius (% of hero)
+    sizeY: [55, 10, 100, 1], //         vertical radius (% of hero)
+    x: [70, 0, 100, 1], //              center X (%) — anchored over the showcase
+    y: [48, 0, 100, 1], //              center Y (%)
+    color: { type: "color", default: "#737373" }, // neutral grey wash
+    noise: [0.03, 0, 0.4, 0.01], //     film-grain overlay opacity (0 = off)
+    dither: [0.05, 0, 0.5, 0.01], //    ordered Bayer dither opacity (0 = off)
+  })
+
+  // Shared radial mask so both grain layers fade out exactly where the glow does.
+  const glowMask = `radial-gradient(${g.sizeX}% ${g.sizeY}% at ${g.x}% ${g.y}%, #000, transparent 70%)`
+
+  // Deterministic from defaults, but gate to avoid any hydration drift.
+  if (!hydrated) return null
+
+  return (
+    <div aria-hidden className="pointer-events-none absolute inset-0 z-0">
+      {/* Radial glow */}
+      <div
+        className="absolute inset-0"
+        style={{
+          background: `radial-gradient(${g.sizeX}% ${g.sizeY}% at ${g.x}% ${g.y}%, ${hexToRgba(g.color as string, g.intensity)}, transparent 70%)`,
+        }}
+      />
+      {/* Fractal-noise grain, masked to the glow so it only grains the lit area */}
+      <div
+        className="absolute inset-0 mix-blend-overlay"
+        style={{
+          opacity: g.noise,
+          backgroundImage: NOISE_URL,
+          WebkitMaskImage: glowMask,
+          maskImage: glowMask,
+        }}
+      />
+      {/* Ordered Bayer dither — crisp 1px grid, pixelated, masked to the glow */}
+      <div
+        className="absolute inset-0 mix-blend-overlay"
+        style={{
+          opacity: g.dither,
+          backgroundImage: DITHER_URL,
+          backgroundSize: "4px 4px",
+          imageRendering: "pixelated",
+          WebkitMaskImage: glowMask,
+          maskImage: glowMask,
+        }}
+      />
+    </div>
+  )
+}
+
+/** Tiling fractal-noise tile rendered by the browser (no asset needed). */
+const NOISE_URL =
+  "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E\")"
+
+/**
+ * 4x4 ordered Bayer pattern (black pixels at threshold cells < 8). Tiled at
+ * 4px with pixelated rendering, it reads as a crisp ordered dither that breaks
+ * up gradient banding.
+ */
+const DITHER_URL =
+  "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='4'%3E%3Cg fill='%23000'%3E%3Crect x='0' y='0' width='1' height='1'/%3E%3Crect x='2' y='0' width='1' height='1'/%3E%3Crect x='1' y='1' width='1' height='1'/%3E%3Crect x='3' y='1' width='1' height='1'/%3E%3Crect x='0' y='2' width='1' height='1'/%3E%3Crect x='2' y='2' width='1' height='1'/%3E%3Crect x='1' y='3' width='1' height='1'/%3E%3Crect x='3' y='3' width='1' height='1'/%3E%3C/g%3E%3C/svg%3E\")"

--- a/packages/web/components/hero-showcase.tsx
+++ b/packages/web/components/hero-showcase.tsx
@@ -1,0 +1,197 @@
+/**
+ * shieldcn
+ * components/hero-showcase
+ *
+ * Hero centerpiece that highlights BOTH product surfaces at once:
+ *   - Charts: two live chart cards (GitHub star history + npm downloads)
+ *   - Badges: a cluster of real badge SVGs floating over the cards
+ *
+ * Built with the Storyboard Animation pattern (single `stage` integer drives a
+ * staged entrance) plus a continuous idle float. Every layout + motion value is
+ * a named constant AND a live DialKit control.
+ */
+
+/* ─────────────────────────────────────────────────────────
+ * ANIMATION STORYBOARD  (defaults shown; all live via DialKit)
+ *
+ *    0ms   hidden (cards down + blurred, badges scaled to 0)
+ *  120ms   back chart card rises in
+ *  260ms   front chart card rises in
+ *  440ms   badges pop in, staggered (BADGES.stagger apart)
+ *   ∞      cards + badges idle-float on independent loops
+ * ───────────────────────────────────────────────────────── */
+
+"use client"
+
+import { useEffect, useState, useSyncExternalStore } from "react"
+import { motion, type Transition } from "motion/react"
+import { useDialKit } from "dialkit"
+import "dialkit/styles.css"
+import { useBadgeMode } from "@/lib/use-badge-mode"
+
+// ---------------------------------------------------------------------------
+// Storyboard constants
+// ---------------------------------------------------------------------------
+
+/** Two chart cards — the "charts" half of the story. */
+const CARDS = {
+  riseY: 26, //  px each card slides up from
+  blur: 12, //   px blur burned off on entrance
+  spring: { type: "spring" as const, visualDuration: 0.7, bounce: 0.28 },
+  floatAmp: 10, //   px idle vertical drift
+  floatSecs: 7, //   seconds per idle loop
+  items: [
+    {
+      key: "stars",
+      src: "/chart/github/stars/vercel/next.js.svg?theme=blue",
+      alt: "GitHub star history — vercel/next.js",
+      // position within the stage (% of container)
+      top: "9%",
+      left: "2%",
+      width: 320,
+      rotate: -5,
+      z: 20,
+    },
+    {
+      key: "downloads",
+      src: "/chart/npm/zod.svg?theme=emerald",
+      alt: "npm weekly downloads — zod",
+      top: "46%",
+      left: "30%",
+      width: 300,
+      rotate: 5,
+      z: 10,
+    },
+  ],
+}
+
+/** Floating badges — the "badges" half of the story. */
+const BADGES = {
+  initialScale: 0.4, // scale before popping in
+  stagger: 0.09, //    seconds between each badge pop
+  spring: { type: "spring" as const, visualDuration: 0.45, bounce: 0.45 },
+  floatAmp: 7, //      px idle vertical drift
+  floatSecs: 5, //     seconds per idle loop
+  items: [
+    { key: "npm", src: "/npm/zod.svg?variant=branded", alt: "npm zod badge", top: "3%", left: "40%", z: 40 },
+    { key: "build", src: "/badge/build-passing.svg?variant=branded&logo=githubactions", alt: "build passing badge", top: "26%", left: "63%", z: 40 },
+    { key: "stars", src: "/badge/stars-140k.svg?variant=branded&logo=github", alt: "GitHub stars badge", top: "34%", left: "0%", z: 40 },
+    { key: "typescript", src: "/badge/typescript-5.x.svg?variant=branded&logo=typescript", alt: "TypeScript badge", top: "56%", left: "2%", z: 40 },
+    { key: "license", src: "/badge/license-MIT.svg?variant=secondary", alt: "license MIT badge", top: "74%", left: "18%", z: 40 },
+    { key: "discord", src: "/badge/discord-online.svg?variant=branded&logo=discord", alt: "discord badge", top: "78%", left: "56%", z: 40 },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Hydration flag without setState-in-effect (lint-clean, mirrors HomeCharts).
+// ---------------------------------------------------------------------------
+
+function useHydrated() {
+  return useSyncExternalStore(() => () => {}, () => true, () => false)
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function HeroShowcase() {
+  const hydrated = useHydrated()
+  const { adaptUrl } = useBadgeMode()
+
+  // Live-tunable layout + motion. Defaults seed from the constants above.
+  const d = useDialKit("Hero Showcase", {
+    backCard: [520, 0, 2000, 10],
+    frontCard: [530, 0, 2000, 10],
+    badges: [800, 0, 2000, 10],
+    cards: {
+      riseY: [26, 0, 80, 1],
+      blur: [12, 0, 40, 1],
+      floatAmp: [10, 0, 40, 1],
+      floatSecs: [7, 1, 20, 0.5],
+      spring: { type: "spring", stiffness: 100, damping: 25, mass: 1.5 },
+    },
+    badgeGroup: {
+      scale: [1, 0.6, 1.6, 0.05],
+      stagger: [0.09, 0, 0.4, 0.01],
+      floatAmp: [7, 0, 30, 1],
+      floatSecs: [5, 1, 15, 0.5],
+      spring: { type: "spring", visualDuration: 0.45, bounce: 0.45 },
+    },
+  })
+
+  // Single integer stage drives the whole entrance.
+  // 1: back card  2: front card  3: badges
+  const [stage, setStage] = useState(0)
+
+  useEffect(() => {
+    // Reset so adjusting a DialKit timing replays the sequence.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setStage(0)
+    const timers: ReturnType<typeof setTimeout>[] = []
+    timers.push(setTimeout(() => setStage(s => Math.max(s, 1)), d.backCard))
+    timers.push(setTimeout(() => setStage(s => Math.max(s, 2)), d.frontCard))
+    timers.push(setTimeout(() => setStage(s => Math.max(s, 3)), d.badges))
+    return () => timers.forEach(clearTimeout)
+  }, [d.backCard, d.frontCard, d.badges])
+
+  // Keep the placeholder identical in size to avoid layout shift pre-hydration.
+  if (!hydrated) return <div className="h-[500px] w-full" />
+
+  return (
+    <div className="relative mx-auto h-[500px] w-full max-w-[460px] translate-y-10 lg:translate-y-20">
+        {/* ── Chart cards (the "charts" story) ── */}
+        {CARDS.items.map((card, i) => {
+          const atStage = i + 1 // back=1, front=2
+          return (
+            <motion.div
+              key={card.key}
+              className="absolute"
+              style={{ top: card.top, left: card.left, width: card.width, zIndex: card.z }}
+              initial={{ opacity: 0, y: d.cards.riseY, filter: `blur(${d.cards.blur}px)`, rotate: card.rotate }}
+              animate={{
+                opacity: stage >= atStage ? 1 : 0,
+                y: stage >= atStage ? 0 : d.cards.riseY,
+                filter: stage >= atStage ? "blur(0px)" : `blur(${d.cards.blur}px)`,
+                rotate: card.rotate,
+              }}
+              transition={d.cards.spring as Transition}
+            >
+              {/* idle float loop (separate layer so it never fights the entrance) */}
+              <motion.div
+                animate={{ y: stage >= atStage ? [0, -d.cards.floatAmp, 0] : 0 }}
+                transition={{ repeat: Infinity, duration: d.cards.floatSecs, ease: "easeInOut", delay: i * 0.6 }}
+                className="overflow-hidden rounded-xl border border-border bg-card shadow-xl shadow-black/20"
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src={adaptUrl(card.src)} alt={card.alt} className="w-full select-none" draggable={false} />
+              </motion.div>
+            </motion.div>
+          )
+        })}
+
+        {/* ── Floating badges (the "badges" story) ── */}
+        {BADGES.items.map((badge, i) => (
+          <motion.div
+            key={badge.key}
+            className="absolute"
+            style={{ top: badge.top, left: badge.left, zIndex: badge.z }}
+            initial={{ opacity: 0, scale: BADGES.initialScale }}
+            animate={{
+              opacity: stage >= 3 ? 1 : 0,
+              scale: stage >= 3 ? d.badgeGroup.scale : BADGES.initialScale,
+            }}
+            transition={{ ...(d.badgeGroup.spring as Transition), delay: stage >= 3 ? i * d.badgeGroup.stagger : 0 }}
+          >
+            <motion.div
+              animate={{ y: stage >= 3 ? [0, -d.badgeGroup.floatAmp, 0] : 0 }}
+              transition={{ repeat: Infinity, duration: d.badgeGroup.floatSecs, ease: "easeInOut", delay: i * 0.4 }}
+              className="drop-shadow-md"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={adaptUrl(badge.src)} alt={badge.alt} className="h-7 select-none" draggable={false} />
+            </motion.div>
+          </motion.div>
+        ))}
+      </div>
+    )
+  }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -20,6 +20,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "dialkit": "^1.2.1",
     "flexsearch": "^0.8.212",
     "fumadocs-core": "^16.8.2",
     "fumadocs-mdx": "^14.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      dialkit:
+        specifier: ^1.2.1
+        version: 1.2.1(motion@12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       flexsearch:
         specifier: ^0.8.212
         version: 0.8.212
@@ -3416,6 +3419,30 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  dialkit@1.2.1:
+    resolution: {integrity: sha512-iAAcTphycvqyRqFsD6hxNqG77MThdtBvttWJAwRt3btr6N+6FCf63l1A7sek33sn6LFg/u5kDccLrNcK52e/KA==}
+    peerDependencies:
+      motion: '>=11.0.0'
+      motion-v: '>=2.0.0'
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+      solid-js: '>=1.6.0'
+      svelte: '>=5.8.0'
+      vue: '>=3.3.0'
+    peerDependenciesMeta:
+      motion-v:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
@@ -9533,6 +9560,13 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  dialkit@1.2.1(motion@12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      motion: 12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   diff@8.0.4: {}
 
   doctrine@2.1.0:
@@ -9807,8 +9841,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.4
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
@@ -9830,7 +9864,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -9841,22 +9875,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9867,7 +9901,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## What

Replaces the static hero visual with an animated showcase: two tilted chart cards (star history + npm downloads) and a ring of real badges that stage in via a storyboard sequence, plus a subtle, tunable radial glow (noise + dither) behind it.

New components:
- `hero-entrance.tsx` — storyboard-staged entrance for the hero (left column + visual slot), `unfold` preset.
- `hero-showcase.tsx` — the floating badge + chart-card cluster.
- `hero-glow.tsx` — ambient radial glow with noise + ordered dither.

Entrance/showcase/glow values are exposed via DialKit panels in dev (no prod overhead — DialRoot returns null in production).

## Why

Communicate the full suite (badges **and** charts) in the hero, with motion polish.

## How

- Single-`stage` storyboard pattern drives the staged reveal; idle float loops layered separately.
- Adds the `dialkit` dependency.
- Showcase is desktop-only (`hidden md:flex`); mobile leads with headline + CTA.

## Testing

- `tsc --noEmit` and `eslint` clean on all touched files.
- Page returns 200 in dev; verified entrance + glow render.

## ⚠️ Dependency note

The showcase chart cards point at `/chart/...` endpoints that ship in the **charts** work (`feat/shadcn-charts`). On `main` those routes don't exist yet, so the two chart cards will 404 until charts merges. **This PR should land after (or together with) the charts PR.** Code compiles independently regardless.