### PR TITLE
fix(web): remove DialKit tuning panel from production hero

### DIFF
--- a/packages/web/components/hero-entrance.tsx
+++ b/packages/web/components/hero-entrance.tsx
@@ -5,8 +5,7 @@
  * Homepage "page transition in". Stages the hero elements (announcement,
  * heading, subtext, input, icon cloud, scroll cta) into view on mount using
  * the Storyboard Animation pattern. Ships three variants (cascade / snap /
- * unfold); each timing value is exposed as a live DialKit slider and the
- * variant is switchable from a live DialKit dropdown.
+ * unfold). Timings were tuned with DialKit and baked into the variant presets.
  */
 
 /* ─────────────────────────────────────────────────────────
@@ -29,16 +28,13 @@
 
 import { useEffect, useState } from "react"
 import { motion, type Transition } from "motion/react"
-import { DialRoot } from "dialkit"
-import "dialkit/styles.css"
 
 // ---------------------------------------------------------------------------
 // Storyboard variants
 //
 // Each variant is a full preset: stage timings (ms after mount) + the motion
-// "feel" of the rising text column and the icon cloud. Switch live via the
-// DialKit "Variant" dropdown, or set the default per-page with the `variant`
-// prop.
+// "feel" of the rising text column and the icon cloud. Set the default
+// per-page with the `variant` prop.
 //
 //   cascade — smooth staggered rise + blur burn-off (the default)
 //   snap    — fast, tight, minimal travel; everything lands quickly
@@ -111,14 +107,7 @@ interface HeroEntranceProps {
 }
 
 export function HeroEntrance({ variant = DEFAULT_VARIANT, ...slots }: HeroEntranceProps) {
-  return (
-    <>
-      {/* One DialRoot for the whole hero — renders the Hero Glow / Hero
-          Showcase panels in dev. The entrance itself is not dial-tunable. */}
-      <DialRoot position="bottom-right" />
-      <HeroEntranceStage variant={variant} {...slots} />
-    </>
-  )
+  return <HeroEntranceStage variant={variant} {...slots} />
 }
 
 function HeroEntranceStage({

--- a/packages/web/components/hero-glow.tsx
+++ b/packages/web/components/hero-glow.tsx
@@ -1,12 +1,11 @@
 // shieldcn — components/hero-glow.tsx
 // Subtle ambient radial glow behind the hero showcase. Decorative only.
-// Fully tunable (intensity / size / position / hue) via DialKit — set
+// Intensity / size / position / hue tuned with DialKit and baked in — set
 // intensity to 0 to disable. Renders behind all hero content.
 
 "use client"
 
 import { useSyncExternalStore } from "react"
-import { useDialKit } from "dialkit"
 
 /** Hydration flag without setState-in-effect (lint-clean, mirrors HomeCharts). */
 function useHydrated() {
@@ -27,16 +26,17 @@ function hexToRgba(hex: string, alpha: number): string {
 export function HeroGlow() {
   const hydrated = useHydrated()
 
-  const g = useDialKit("Hero Glow", {
-    intensity: [0.19, 0, 0.6, 0.01], // peak alpha at the center of the glow
-    sizeX: [49, 10, 100, 1], //         horizontal radius (% of hero)
-    sizeY: [55, 10, 100, 1], //         vertical radius (% of hero)
-    x: [70, 0, 100, 1], //              center X (%) — anchored over the showcase
-    y: [48, 0, 100, 1], //              center Y (%)
-    color: { type: "color", default: "#737373" }, // neutral grey wash
-    noise: [0.03, 0, 0.4, 0.01], //     film-grain overlay opacity (0 = off)
-    dither: [0.05, 0, 0.5, 0.01], //    ordered Bayer dither opacity (0 = off)
-  })
+  // Tuned values baked out of DialKit before shipping.
+  const g = {
+    intensity: 0.19, // peak alpha at the center of the glow
+    sizeX: 49, //      horizontal radius (% of hero)
+    sizeY: 55, //      vertical radius (% of hero)
+    x: 70, //          center X (%) — anchored over the showcase
+    y: 48, //          center Y (%)
+    color: "#737373", // neutral grey wash
+    noise: 0.03, //    film-grain overlay opacity (0 = off)
+    dither: 0.05, //   ordered Bayer dither opacity (0 = off)
+  }
 
   // Shared radial mask so both grain layers fade out exactly where the glow does.
   const glowMask = `radial-gradient(${g.sizeX}% ${g.sizeY}% at ${g.x}% ${g.y}%, #000, transparent 70%)`

--- a/packages/web/components/hero-showcase.tsx
+++ b/packages/web/components/hero-showcase.tsx
@@ -8,11 +8,11 @@
  *
  * Built with the Storyboard Animation pattern (single `stage` integer drives a
  * staged entrance) plus a continuous idle float. Every layout + motion value is
- * a named constant AND a live DialKit control.
+ * a named constant, tuned with DialKit and baked in.
  */
 
 /* ─────────────────────────────────────────────────────────
- * ANIMATION STORYBOARD  (defaults shown; all live via DialKit)
+ * ANIMATION STORYBOARD  (tuned with DialKit, baked in)
  *
  *    0ms   hidden (cards down + blurred, badges scaled to 0)
  *  120ms   back chart card rises in
@@ -25,8 +25,6 @@
 
 import { useEffect, useState, useSyncExternalStore } from "react"
 import { motion, type Transition } from "motion/react"
-import { useDialKit } from "dialkit"
-import "dialkit/styles.css"
 import { useBadgeMode } from "@/lib/use-badge-mode"
 
 // ---------------------------------------------------------------------------
@@ -98,33 +96,33 @@ export function HeroShowcase() {
   const hydrated = useHydrated()
   const { adaptUrl } = useBadgeMode()
 
-  // Live-tunable layout + motion. Defaults seed from the constants above.
-  const d = useDialKit("Hero Showcase", {
-    backCard: [520, 0, 2000, 10],
-    frontCard: [530, 0, 2000, 10],
-    badges: [800, 0, 2000, 10],
+  // Tuned layout + motion values baked out of DialKit before shipping.
+  const d = {
+    backCard: 520,
+    frontCard: 530,
+    badges: 800,
     cards: {
-      riseY: [26, 0, 80, 1],
-      blur: [12, 0, 40, 1],
-      floatAmp: [10, 0, 40, 1],
-      floatSecs: [7, 1, 20, 0.5],
+      riseY: 26,
+      blur: 12,
+      floatAmp: 10,
+      floatSecs: 7,
       spring: { type: "spring", stiffness: 100, damping: 25, mass: 1.5 },
     },
     badgeGroup: {
-      scale: [1, 0.6, 1.6, 0.05],
-      stagger: [0.09, 0, 0.4, 0.01],
-      floatAmp: [7, 0, 30, 1],
-      floatSecs: [5, 1, 15, 0.5],
+      scale: 1,
+      stagger: 0.09,
+      floatAmp: 7,
+      floatSecs: 5,
       spring: { type: "spring", visualDuration: 0.45, bounce: 0.45 },
     },
-  })
+  }
 
   // Single integer stage drives the whole entrance.
   // 1: back card  2: front card  3: badges
   const [stage, setStage] = useState(0)
 
   useEffect(() => {
-    // Reset so adjusting a DialKit timing replays the sequence.
+    // Reset so the entrance sequence replays on mount.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setStage(0)
     const timers: ReturnType<typeof setTimeout>[] = []

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -20,7 +20,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "dialkit": "^1.2.1",
     "flexsearch": "^0.8.212",
     "fumadocs-core": "^16.8.2",
     "fumadocs-mdx": "^14.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,9 +173,6 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      dialkit:
-        specifier: ^1.2.1
-        version: 1.2.1(motion@12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       flexsearch:
         specifier: ^0.8.212
         version: 0.8.212
@@ -3419,30 +3416,6 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
-
-  dialkit@1.2.1:
-    resolution: {integrity: sha512-iAAcTphycvqyRqFsD6hxNqG77MThdtBvttWJAwRt3btr6N+6FCf63l1A7sek33sn6LFg/u5kDccLrNcK52e/KA==}
-    peerDependencies:
-      motion: '>=11.0.0'
-      motion-v: '>=2.0.0'
-      react: '>=18.0.0'
-      react-dom: '>=18.0.0'
-      solid-js: '>=1.6.0'
-      svelte: '>=5.8.0'
-      vue: '>=3.3.0'
-    peerDependenciesMeta:
-      motion-v:
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-      solid-js:
-        optional: true
-      svelte:
-        optional: true
-      vue:
-        optional: true
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
@@ -9560,13 +9533,6 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  dialkit@1.2.1(motion@12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
-    dependencies:
-      motion: 12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-    optionalDependencies:
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-
   diff@8.0.4: {}
 
   doctrine@2.1.0:
@@ -9841,8 +9807,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.4
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
@@ -9864,7 +9830,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -9875,22 +9841,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9901,7 +9867,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## What

Bakes the DialKit-tuned hero values into plain constants and removes DialKit entirely from the hero.

## Why

The hero PR (#138) shipped DialKit live-tuning controls to `main`. A `<DialRoot position="bottom-right" />` panel renders for **all production visitors**, and `useDialKit` hooks drive the glow, entrance, and showcase animations. That debug UI should never ship.

## How

- `hero-glow.tsx`, `hero-showcase.tsx` — replace `useDialKit(...)` with plain constant objects holding the current tuned defaults (same shape, so all `d.*`/`g.*` reads are unchanged)
- `hero-entrance.tsx` — drop `<DialRoot>` and the dialkit imports
- `package.json` / `pnpm-lock.yaml` — remove the `dialkit` dependency
- Updated now-stale comments

## Testing

- `tsc --noEmit` passes
- eslint passes (pre-commit hook)
- Visual output unchanged — baked values equal the shipped DialKit defaults