### PR TITLE
feat: repository header image generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://shieldcn.dev">
-    <img src="./packages/web/brand/repo-header.png" alt="shieldcn" />
+    <img alt="shieldcn" src="https://shieldcn.dev/header/graph.svg?title=shieldcn&subtitle=badges%2C+headers%2C+and+charts+for+your+readme&logo=shieldcn&logoColor=848484&mode=dark&align=left&font=geist-mono&border=false" />
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,26 @@ Available as `.svg`, `.png`, and `.json`. Customize with `mode`, `theme`,
 `color`, `fill`, `area`, `bg`, `border`, `font`, `width`, `height`, and
 `title`. See the [Charts docs](https://shieldcn.dev/docs/charts).
 
+### Headers
+
+Repository header banners for the top of your README — your logo, a premade
+shadcn-styled background, a title, and a tagline, all from one image URL:
+
+<p>
+  <img src="https://shieldcn.dev/header/dots.svg?title=Acme+Toolkit&subtitle=A+delightful+component+library&logo=react" alt="Acme Toolkit repository header" />
+</p>
+
+```md
+![Header](https://shieldcn.dev/header/dots.svg?title=Acme+Toolkit&subtitle=A+delightful+component+library&logo=react)
+```
+
+Premade backgrounds: `surface`, `gradient`, `dots`, `grid`, `graph`, `glow`,
+`transparent`. Available as `.svg`, `.png`, and `.json`. Customize with `title`,
+`subtitle`, `logo`, `size`, `align`, `theme`, `gradient`, `bg` (incl.
+`transparent`), and more. Build one with the
+[header generator](https://shieldcn.dev/header) or see the
+[Headers docs](https://shieldcn.dev/docs/headers).
+
 ## Supported providers
 
 See the [docs](https://shieldcn.dev/docs) for full endpoint details, interactive sandboxes, and copy-paste examples.

--- a/packages/core/src/badges/fonts.ts
+++ b/packages/core/src/badges/fonts.ts
@@ -1,0 +1,59 @@
+/**
+ * shieldcn
+ * src/badges/fonts
+ *
+ * Loads the bundled TTF font buffers so resvg can rasterize text when a
+ * hand-built SVG (chart / header) is converted to PNG. SVG output relies on the
+ * viewer's system fonts; PNG output has no system fonts inside the wasm sandbox,
+ * so the buffers must be supplied explicitly.
+ */
+
+import { readFileSync, existsSync } from "node:fs"
+import { join, dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+
+/** Family name resvg should fall back to. Matches inter-medium.ttf. */
+export const DEFAULT_FONT_FAMILY = "Inter"
+
+const FONT_FILES = [
+  "inter-medium.ttf",
+  "geist-medium.ttf",
+  "geist-mono-medium.ttf",
+  "jetbrains-mono-medium.ttf",
+  "fira-code-medium.ttf",
+  "roboto-medium.ttf",
+  "space-grotesk-medium.ttf",
+]
+
+function findFontsDir(): string | null {
+  const candidates = [
+    join(dirname(fileURLToPath(import.meta.url)), "..", "fonts"),
+    join(process.cwd(), "packages", "core", "src", "fonts"),
+    join(process.cwd(), "..", "core", "src", "fonts"),
+    join(process.cwd(), "lib", "fonts"),
+  ]
+  for (const dir of candidates) {
+    if (existsSync(join(dir, "inter-medium.ttf"))) return dir
+  }
+  return null
+}
+
+let cache: Uint8Array[] | null = null
+
+/**
+ * Return the bundled font buffers for resvg's `font.fontBuffers`. Cached after
+ * the first read. Returns an empty array if the fonts can't be located (PNG
+ * text would then fall back to resvg's default — never throws).
+ */
+export function getFontBuffers(): Uint8Array[] {
+  if (cache) return cache
+  const dir = findFontsDir()
+  if (!dir) {
+    cache = []
+    return cache
+  }
+  cache = FONT_FILES.filter((f) => existsSync(join(dir, f))).map(
+    (f) => new Uint8Array(readFileSync(join(dir, f))),
+  )
+  return cache
+}

--- a/packages/core/src/badges/header-backgrounds.ts
+++ b/packages/core/src/badges/header-backgrounds.ts
@@ -1,0 +1,286 @@
+/**
+ * shieldcn
+ * src/badges/header-backgrounds
+ *
+ * Premade background presets for repository header images. Aligned to the
+ * shadcn aesthetic: neutral zinc surfaces, subtle texture (dots / grid / graph
+ * paper), a restrained themed accent (driven by the same `theme` vocabulary as
+ * badges), and a hairline card border. Loud, colorful backgrounds are still
+ * achievable via the `?gradient=` / `?bg=` props, but the premade set stays
+ * understated and on-brand.
+ *
+ * Everything resolves to inline SVG `<defs>` + full-canvas paint layers — no
+ * external CSS, no CSS variables — so it's safe inside a sandboxed `<img>` SVG.
+ */
+
+import { themes, type ThemeName } from "./themes"
+
+export type HeaderMode = "dark" | "light"
+
+/** Background style. Preset names map 1:1 to these. */
+export type HeaderStyle = "surface" | "gradient" | "dots" | "grid" | "graph" | "glow" | "transparent"
+
+/** Public list of preset names (for docs / builder UIs). */
+export const HEADER_PRESET_NAMES: HeaderStyle[] = [
+  "surface",
+  "gradient",
+  "dots",
+  "grid",
+  "graph",
+  "glow",
+  "transparent",
+]
+
+/** The default preset when the path carries no preset name. */
+export const DEFAULT_HEADER_PRESET: HeaderStyle = "surface"
+
+/** Neutral themes have no strong accent — they get a soft light/zinc glow. */
+const NEUTRAL_THEMES = new Set<string>(["zinc", "slate", "stone", "neutral", "gray"])
+
+/** shadcn surface tokens per mode. */
+interface Surface {
+  base: string
+  raised: string
+  border: string
+}
+const SURFACE: Record<HeaderMode, Surface> = {
+  dark: { base: "#09090b", raised: "#18181b", border: "#27272a" }, // zinc-950 / zinc-900 / zinc-800
+  light: { base: "#ffffff", raised: "#fafafa", border: "#e4e4e7" }, // white / zinc-50 / zinc-200
+}
+
+export interface HeaderBgInput {
+  /** Named preset (path segment). Falls back to the default when unknown. */
+  preset?: string | null
+  mode: HeaderMode
+  width: number
+  height: number
+  /** Corner radius (used to clip pattern/glow overflow cleanly). */
+  radius: number
+  /** shadcn theme name — drives the accent / glow tint. */
+  theme?: string | null
+  // Prop overrides:
+  /** Render with no background fill (blend into the host page). */
+  transparent?: boolean
+  /** Solid background color hex (no `#`). Replaces the base. */
+  bg?: string | null
+  /** Custom gradient: "c1,c2[,c3][,angle]" (hex without `#`). Replaces the base. */
+  gradient?: string | null
+  /** Overlay pattern: dots | grid | graph | none. */
+  pattern?: string | null
+  /** Spotlight glow color hex (no `#`). */
+  glow?: string | null
+  /** Accent color hex (no `#`). */
+  accent?: string | null
+}
+
+export interface ResolvedHeaderBg {
+  /** Markup to place inside the root `<defs>`. */
+  defs: string
+  /** Full-canvas paint layers (already clipped by the caller's clipPath). */
+  layers: string
+  /** Whether the resolved background reads as light (for text contrast). */
+  isLight: boolean
+  /** Accent color (#rrggbb). */
+  accent: string
+  /** Hairline border color (#rrggbb) matching the surface. */
+  border: string
+}
+
+const HEX_RE = /^[0-9a-fA-F]{3,8}$/
+
+function normHex(hex?: string | null): string | undefined {
+  if (!hex) return undefined
+  const h = hex.replace(/^#/, "")
+  if (!HEX_RE.test(h)) return undefined
+  return `#${h}`
+}
+
+function isLightHex(hex: string): boolean {
+  let h = hex.replace("#", "")
+  if (h.length === 3) h = h.split("").map((c) => c + c).join("")
+  const r = parseInt(h.substring(0, 2), 16)
+  const g = parseInt(h.substring(2, 4), 16)
+  const b = parseInt(h.substring(4, 6), 16)
+  if ([r, g, b].some((n) => Number.isNaN(n))) return false
+  return (0.299 * r + 0.587 * g + 0.114 * b) / 255 > 0.6
+}
+
+function rgba(hex: string, alpha: number): string {
+  let h = hex.replace("#", "")
+  if (h.length === 3) h = h.split("").map((c) => c + c).join("")
+  const r = parseInt(h.substring(0, 2), 16)
+  const g = parseInt(h.substring(2, 4), 16)
+  const b = parseInt(h.substring(4, 6), 16)
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`
+}
+
+function r2(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+/** Parse a "c1,c2[,c3][,angle]" gradient param into stops + angle. */
+function parseGradientSpec(raw: string): { stops: string[]; angle: number } | null {
+  const parts = raw.split(",").map((s) => s.trim()).filter(Boolean)
+  if (parts.length < 2) return null
+  let angle = 135
+  let colorParts = parts
+  const last = parts[parts.length - 1]
+  if (/^\d+(\.\d+)?$/.test(last)) {
+    const a = parseFloat(last)
+    if (a >= 0 && a <= 360) {
+      angle = a
+      colorParts = parts.slice(0, -1)
+    }
+  }
+  if (colorParts.length < 2) return null
+  if (!colorParts.every((c) => HEX_RE.test(c.replace(/^#/, "")))) return null
+  return { stops: colorParts.map((c) => `#${c.replace(/^#/, "")}`), angle }
+}
+
+/** CSS-style angle → objectBoundingBox gradient endpoints (0–1). */
+function angleToCoords(angle: number): { x1: number; y1: number; x2: number; y2: number } {
+  const rad = (angle * Math.PI) / 180
+  const dx = Math.sin(rad)
+  const dy = -Math.cos(rad)
+  return {
+    x1: r2(0.5 - dx / 2),
+    y1: r2(0.5 - dy / 2),
+    x2: r2(0.5 + dx / 2),
+    y2: r2(0.5 + dy / 2),
+  }
+}
+
+/** Resolve accent + glow tint from the shadcn theme name. */
+function resolveAccentTint(theme: string | null | undefined, mode: HeaderMode): { accent: string; glow: string } {
+  if (theme && theme in themes && !NEUTRAL_THEMES.has(theme)) {
+    const c = themes[theme as ThemeName].border
+    return { accent: c, glow: c }
+  }
+  return {
+    accent: mode === "dark" ? "#a1a1aa" : "#52525b", // zinc-400 / zinc-600
+    glow: mode === "dark" ? "#ffffff" : "#a1a1aa",
+  }
+}
+
+let gradSeq = 0
+
+/**
+ * Resolve a premade preset + prop overrides into renderable SVG fragments.
+ */
+export function resolveHeaderBackground(input: HeaderBgInput): ResolvedHeaderBg {
+  const { mode, width, height } = input
+  const surf = SURFACE[mode]
+  const style: HeaderStyle =
+    input.preset && (HEADER_PRESET_NAMES as string[]).includes(input.preset)
+      ? (input.preset as HeaderStyle)
+      : DEFAULT_HEADER_PRESET
+
+  const tint = resolveAccentTint(input.theme, mode)
+  const accent = normHex(input.accent) ?? tint.accent
+
+  const defs: string[] = []
+  const layers: string[] = []
+  const uid = `hb${(gradSeq = (gradSeq + 1) % 100000)}`
+
+  let isLight = mode === "light"
+
+  const transparent = !!input.transparent || style === "transparent"
+  const bgOverride = normHex(input.bg)
+  const gradOverride = input.gradient ? parseGradientSpec(input.gradient) : null
+
+  // --- Base fill ---
+  if (transparent && !bgOverride && !gradOverride) {
+    // No surface fill — blend into the host page. Text contrast follows mode.
+  } else if (gradOverride) {
+    const { x1, y1, x2, y2 } = angleToCoords(gradOverride.angle)
+    const id = `${uid}base`
+    const stops = gradOverride.stops
+      .map((c, i) => `<stop offset="${r2((i / (gradOverride.stops.length - 1)) * 100)}%" stop-color="${c}" />`)
+      .join("")
+    defs.push(`<linearGradient id="${id}" x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}">${stops}</linearGradient>`)
+    layers.push(`<rect x="0" y="0" width="${width}" height="${height}" fill="url(#${id})" />`)
+    isLight = isLightHex(gradOverride.stops[0])
+  } else if (bgOverride) {
+    layers.push(`<rect x="0" y="0" width="${width}" height="${height}" fill="${bgOverride}" />`)
+    isLight = isLightHex(bgOverride)
+  } else if (style === "gradient") {
+    // Subtle neutral vertical gradient (raised → base).
+    const { x1, y1, x2, y2 } = angleToCoords(160)
+    const id = `${uid}base`
+    defs.push(
+      `<linearGradient id="${id}" x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}">` +
+        `<stop offset="0%" stop-color="${surf.raised}" /><stop offset="100%" stop-color="${surf.base}" />` +
+        `</linearGradient>`,
+    )
+    layers.push(`<rect x="0" y="0" width="${width}" height="${height}" fill="url(#${id})" />`)
+  } else {
+    layers.push(`<rect x="0" y="0" width="${width}" height="${height}" fill="${surf.base}" />`)
+  }
+
+  // --- Pattern overlay (style default, overridable via ?pattern=) ---
+  let pattern: "dots" | "grid" | "graph" | null =
+    style === "dots" || style === "grid" || style === "graph" ? style : null
+  const patParam = input.pattern
+  if (patParam === "none" || patParam === "false" || patParam === "0") {
+    pattern = null
+  } else if (patParam === "dots" || patParam === "grid" || patParam === "graph") {
+    pattern = patParam
+  }
+  if (pattern) {
+    const lineColor = rgba(isLight ? "#000000" : "#ffffff", isLight ? 0.06 : 0.06)
+    const dotColor = rgba(isLight ? "#000000" : "#ffffff", isLight ? 0.1 : 0.09)
+    if (pattern === "dots") {
+      const id = `${uid}dots`
+      defs.push(
+        `<pattern id="${id}" width="22" height="22" patternUnits="userSpaceOnUse">` +
+          `<circle cx="1.5" cy="1.5" r="1.5" fill="${dotColor}" /></pattern>`,
+      )
+      layers.push(`<rect x="0" y="0" width="${width}" height="${height}" fill="url(#${id})" />`)
+    } else if (pattern === "grid") {
+      const id = `${uid}grid`
+      defs.push(
+        `<pattern id="${id}" width="32" height="32" patternUnits="userSpaceOnUse">` +
+          `<path d="M32 0H0V32" fill="none" stroke="${lineColor}" stroke-width="1" /></pattern>`,
+      )
+      layers.push(`<rect x="0" y="0" width="${width}" height="${height}" fill="url(#${id})" />`)
+    } else {
+      const fine = `${uid}graphF`
+      const coarse = `${uid}graphC`
+      const fineColor = rgba(isLight ? "#000000" : "#ffffff", 0.04)
+      defs.push(
+        `<pattern id="${fine}" width="16" height="16" patternUnits="userSpaceOnUse">` +
+          `<path d="M16 0H0V16" fill="none" stroke="${fineColor}" stroke-width="1" /></pattern>`,
+        `<pattern id="${coarse}" width="80" height="80" patternUnits="userSpaceOnUse">` +
+          `<path d="M80 0H0V80" fill="none" stroke="${lineColor}" stroke-width="1" /></pattern>`,
+      )
+      layers.push(`<rect x="0" y="0" width="${width}" height="${height}" fill="url(#${fine})" />`)
+      layers.push(`<rect x="0" y="0" width="${width}" height="${height}" fill="url(#${coarse})" />`)
+    }
+  }
+
+  // --- Spotlight glow (style "glow" default, or ?glow=). Skipped on a fully
+  // transparent background unless explicitly requested. ---
+  const glowColor = normHex(input.glow) ?? (style === "glow" && !transparent ? tint.glow : undefined)
+  if (glowColor) {
+    const id = `${uid}glow`
+    const cx = r2(width / 2)
+    const cy = 0
+    const rr = r2(Math.max(width, height) * 0.85)
+    const peak = isLight ? 0.3 : 0.16
+    defs.push(
+      `<radialGradient id="${id}" gradientUnits="userSpaceOnUse" cx="${cx}" cy="${cy}" r="${rr}">` +
+        `<stop offset="0%" stop-color="${rgba(glowColor, peak)}" />` +
+        `<stop offset="70%" stop-color="${rgba(glowColor, 0)}" />` +
+        `</radialGradient>`,
+    )
+    layers.push(`<rect x="0" y="0" width="${width}" height="${height}" fill="url(#${id})" />`)
+  }
+
+  return {
+    defs: defs.join(""),
+    layers: layers.join(""),
+    isLight,
+    accent,
+    border: surf.border,
+  }
+}

--- a/packages/core/src/badges/header-route.test.ts
+++ b/packages/core/src/badges/header-route.test.ts
@@ -1,0 +1,109 @@
+/**
+ * shieldcn
+ * src/badges/header-route.test
+ *
+ * End-to-end: handleBadgeGET routes /header/... through the header renderer.
+ * Icon resolution uses the local `simple-icons` package (no network).
+ */
+
+import { describe, it, expect } from "vitest"
+import { handleBadgeGET } from "../route-handler"
+
+describe("handleBadgeGET /header", () => {
+  it("renders a preset banner SVG with title + subtitle", async () => {
+    const req = new Request(
+      "https://x.dev/header/dots.svg?title=Acme%20Toolkit&subtitle=Build%20faster",
+    )
+    const res = await handleBadgeGET(req, ["header", "dots.svg"])
+    expect(res.status).toBe(200)
+    expect(res.headers.get("Content-Type")).toBe("image/svg+xml")
+    const svg = await res.text()
+    expect(svg.startsWith("<svg")).toBe(true)
+    expect(svg).toContain("Acme Toolkit")
+    expect(svg).toContain("Build faster")
+    expect(svg).not.toContain("NaN")
+  })
+
+  it("renders the default preset for a bare /header.svg", async () => {
+    const req = new Request("https://x.dev/header.svg?title=Hello")
+    const res = await handleBadgeGET(req, ["header.svg"])
+    expect(res.status).toBe(200)
+    const svg = await res.text()
+    expect(svg).toContain("Hello")
+  })
+
+  it("applies the social size preset (1280x640)", async () => {
+    const req = new Request("https://x.dev/header.svg?title=X&size=social")
+    const res = await handleBadgeGET(req, ["header.svg"])
+    const svg = await res.text()
+    expect(svg).toContain('width="1280"')
+    expect(svg).toContain('height="640"')
+  })
+
+  it("honors width/height overrides", async () => {
+    const req = new Request("https://x.dev/header.svg?title=X&width=800&height=300")
+    const res = await handleBadgeGET(req, ["header.svg"])
+    const svg = await res.text()
+    expect(svg).toContain('width="800"')
+    expect(svg).toContain('height="300"')
+  })
+
+  it("renders an icon logo from a SimpleIcons slug", async () => {
+    const req = new Request("https://x.dev/header.svg?title=React&logo=react")
+    const res = await handleBadgeGET(req, ["header.svg"])
+    const svg = await res.text()
+    // A path-based icon group is present.
+    expect(svg).toContain("<g transform=")
+    expect(svg).not.toContain("NaN")
+  })
+
+  it("left-aligns content with align=left", async () => {
+    const req = new Request("https://x.dev/header.svg?title=Left&align=left")
+    const res = await handleBadgeGET(req, ["header.svg"])
+    const svg = await res.text()
+    expect(svg).toContain('text-anchor="start"')
+  })
+
+  it("uses dark text in light mode", async () => {
+    const req = new Request("https://x.dev/header.svg?title=Light&mode=light")
+    const res = await handleBadgeGET(req, ["header.svg"])
+    const svg = await res.text()
+    expect(svg).toContain("#18181b")
+  })
+
+  it("renders with no surface fill when bg=transparent", async () => {
+    const req = new Request("https://x.dev/header.svg?title=Ghost&bg=transparent")
+    const res = await handleBadgeGET(req, ["header.svg"])
+    const svg = await res.text()
+    expect(svg).toContain("Ghost")
+    // No full-canvas surface rect (only the clip rect at x=0 inside defs).
+    expect(svg).not.toMatch(/<rect x="0" y="0" width="750" height="260" fill="#/)
+  })
+
+  it("tints the glow from the theme param", async () => {
+    const req = new Request("https://x.dev/header/glow.svg?title=Blue&theme=blue")
+    const res = await handleBadgeGET(req, ["header", "glow.svg"])
+    const svg = await res.text()
+    expect(svg).toContain("radialGradient")
+  })
+
+  it("returns header config JSON for .json", async () => {
+    const req = new Request("https://x.dev/header/glow.json?title=Hello&subtitle=World")
+    const res = await handleBadgeGET(req, ["header", "glow.json"])
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.type).toBe("header")
+    expect(data.preset).toBe("glow")
+    expect(data.title).toBe("Hello")
+    expect(data.subtitle).toBe("World")
+    expect(data.width).toBe(750) // default "banner" preset
+  })
+
+  it("applies a custom gradient override", async () => {
+    const req = new Request("https://x.dev/header.svg?title=Grad&gradient=ff0000,0000ff,90")
+    const res = await handleBadgeGET(req, ["header.svg"])
+    const svg = await res.text()
+    expect(svg).toContain("#ff0000")
+    expect(svg).toContain("#0000ff")
+  })
+})

--- a/packages/core/src/badges/render-header.test.ts
+++ b/packages/core/src/badges/render-header.test.ts
@@ -1,0 +1,192 @@
+/**
+ * shieldcn
+ * src/badges/render-header.test
+ *
+ * Unit tests for the repository header renderer + premade background presets.
+ * All pure — no network.
+ */
+
+import { describe, it, expect } from "vitest"
+import { renderHeader } from "./render-header"
+import {
+  resolveHeaderBackground,
+  HEADER_PRESET_NAMES,
+  DEFAULT_HEADER_PRESET,
+  type HeaderMode,
+} from "./header-backgrounds"
+
+function bg(opts: Partial<Parameters<typeof resolveHeaderBackground>[0]> = {}) {
+  return resolveHeaderBackground({
+    preset: opts.preset ?? null,
+    mode: (opts.mode ?? "dark") as HeaderMode,
+    width: opts.width ?? 1280,
+    height: opts.height ?? 400,
+    radius: opts.radius ?? 24,
+    theme: opts.theme ?? null,
+    bg: opts.bg ?? null,
+    gradient: opts.gradient ?? null,
+    pattern: opts.pattern ?? null,
+    glow: opts.glow ?? null,
+    accent: opts.accent ?? null,
+  })
+}
+
+describe("resolveHeaderBackground", () => {
+  it("ships a sensible default preset", () => {
+    expect(HEADER_PRESET_NAMES).toContain(DEFAULT_HEADER_PRESET)
+    const r = bg({ preset: null })
+    expect(r.layers).toContain("<rect")
+    expect(r.accent.startsWith("#")).toBe(true)
+  })
+
+  it("renders valid fragments for every preset in both modes", () => {
+    for (const name of HEADER_PRESET_NAMES) {
+      for (const mode of ["dark", "light"] as HeaderMode[]) {
+        const r = bg({ preset: name, mode })
+        // Every preset except `transparent` paints a full-canvas surface.
+        if (name !== "transparent") {
+          expect(r.layers, `${name}/${mode} layers`).toContain("<rect")
+        }
+        expect(r.layers).not.toContain("NaN")
+        expect(r.defs).not.toContain("NaN")
+        // Contrast follows the mode (neutral surfaces in both).
+        expect(r.isLight).toBe(mode === "light")
+        expect(r.border.startsWith("#")).toBe(true)
+      }
+    }
+  })
+
+  it("transparent preset paints no surface fill", () => {
+    const r = bg({ preset: "transparent" })
+    expect(r.layers).not.toContain("<rect")
+  })
+
+  it("derives a themed accent from the theme param", () => {
+    const blue = bg({ theme: "blue" })
+    const zinc = bg({ theme: "zinc" })
+    expect(blue.accent).not.toBe(zinc.accent)
+  })
+
+  it("applies a custom gradient override", () => {
+    const r = bg({ gradient: "ff0000,00ff00,45" })
+    expect(r.defs).toContain("linearGradient")
+    expect(r.defs).toContain("#ff0000")
+    expect(r.defs).toContain("#00ff00")
+  })
+
+  it("applies a solid bg override and recomputes contrast", () => {
+    const light = bg({ bg: "ffffff", mode: "dark" })
+    expect(light.layers).toContain("#ffffff")
+    expect(light.isLight).toBe(true)
+    const dark = bg({ bg: "000000", mode: "light" })
+    expect(dark.isLight).toBe(false)
+  })
+
+  it("supports pattern overrides and pattern=none", () => {
+    const dots = bg({ pattern: "dots" })
+    expect(dots.defs).toContain("<pattern")
+    expect(dots.defs).toContain("<circle")
+    const grid = bg({ pattern: "grid" })
+    expect(grid.defs).toContain("<pattern")
+    const none = bg({ preset: "dots", pattern: "none" })
+    expect(none.defs).not.toContain("<pattern")
+  })
+
+  it("adds a spotlight glow via ?glow", () => {
+    const r = bg({ glow: "3b82f6" })
+    expect(r.defs).toContain("radialGradient")
+  })
+
+  it("falls back to the default preset for an unknown name", () => {
+    const unknown = bg({ preset: "definitely-not-a-preset" })
+    const def = bg({ preset: DEFAULT_HEADER_PRESET })
+    expect(unknown.accent).toBe(def.accent)
+  })
+})
+
+describe("renderHeader", () => {
+  function render(over: Partial<Parameters<typeof renderHeader>[0]> = {}) {
+    return renderHeader({
+      title: over.title ?? "My Project",
+      subtitle: over.subtitle,
+      width: over.width ?? 1280,
+      height: over.height ?? 400,
+      mode: over.mode ?? "dark",
+      align: over.align ?? "center",
+      radius: over.radius ?? 24,
+      background: over.background ?? bg(),
+      logo: over.logo,
+      fontFamily: over.fontFamily,
+      titleColor: over.titleColor,
+      subtitleColor: over.subtitleColor,
+      border: over.border,
+      watermark: over.watermark,
+    })
+  }
+
+  it("renders a valid SVG with the title", () => {
+    const svg = render({ title: "Acme Toolkit", subtitle: "Build faster" })
+    expect(svg.startsWith("<svg")).toBe(true)
+    expect(svg).toContain('role="img"')
+    expect(svg).toContain("Acme Toolkit")
+    expect(svg).toContain("Build faster")
+    expect(svg).not.toContain("NaN")
+    expect(svg).toContain('width="1280"')
+    expect(svg).toContain('height="400"')
+  })
+
+  it("escapes special characters in title/subtitle", () => {
+    const svg = render({ title: "A & B", subtitle: "<x>" })
+    expect(svg).toContain("A &amp; B")
+    expect(svg).toContain("&lt;x&gt;")
+    expect(svg).not.toContain("<x>")
+  })
+
+  it("centers by default and left-aligns on request", () => {
+    expect(render({ align: "center" })).toContain('text-anchor="middle"')
+    expect(render({ align: "left" })).toContain('text-anchor="start"')
+  })
+
+  it("uses dark text on light backgrounds", () => {
+    const svg = render({ background: bg({ mode: "light" }), mode: "light" })
+    expect(svg).toContain("#18181b")
+  })
+
+  it("uses light text on dark backgrounds", () => {
+    const svg = render({ background: bg({ mode: "dark" }), mode: "dark" })
+    expect(svg).toContain("#fafafa")
+  })
+
+  it("embeds an image logo via data URI", () => {
+    const svg = render({
+      logo: { imageDataUri: "data:image/png;base64,AAAA" },
+    })
+    expect(svg).toContain("<image")
+    expect(svg).toContain("data:image/png;base64,AAAA")
+  })
+
+  it("embeds a path icon logo with the given color", () => {
+    const svg = render({
+      logo: { icon: { viewBox: "0 0 24 24", path: "M0 0h24v24H0z" }, color: "ff0000" },
+    })
+    expect(svg).toContain("M0 0h24v24H0z")
+    expect(svg).toContain("#ff0000")
+  })
+
+  it("wraps and ellipsizes an overly long title", () => {
+    const longTitle = "word ".repeat(60).trim()
+    const svg = render({ title: longTitle, width: 600, height: 300 })
+    expect(svg).toContain("…")
+    expect(svg).not.toContain("NaN")
+  })
+
+  it("adds a watermark only when requested", () => {
+    expect(render({ watermark: true })).toContain("shieldcn.dev")
+    expect(render({ watermark: false })).not.toContain("shieldcn.dev")
+  })
+
+  it("respects the corner radius in the clip path", () => {
+    const svg = render({ radius: 0 })
+    expect(svg).toContain('rx="0"')
+  })
+})

--- a/packages/core/src/badges/render-header.ts
+++ b/packages/core/src/badges/render-header.ts
@@ -1,0 +1,276 @@
+/**
+ * shieldcn
+ * src/badges/render-header
+ *
+ * Repository header / banner image renderer. Hand-built SVG (like the chart
+ * renderer) so the result is safe inside a sandboxed `<img>` SVG — no external
+ * CSS, no CSS variables, no embedded font (system font stacks via the shared
+ * `font` vocabulary).
+ *
+ * A header is: a premade (or prop-driven) background, an optional logo, a big
+ * title, and an optional subtitle. Layout is either centered or left-aligned.
+ * Everything is driven by the image URL.
+ */
+
+import type { IconData } from "./icons"
+import { resolveFontFamily } from "./render-chart"
+import type { ResolvedHeaderBg } from "./header-backgrounds"
+
+export type HeaderAlign = "center" | "left"
+
+export interface HeaderLogoInput {
+  /** Path-based icon (SimpleIcons / React Icons / custom SVG). */
+  icon?: IconData
+  /** Ready-to-embed raster/vector data URI (a user's own logo). */
+  imageDataUri?: string
+  /** Fill color for path icons (#rrggbb). Ignored for image logos. */
+  color?: string
+}
+
+export interface HeaderConfig {
+  title: string
+  subtitle?: string
+  width: number
+  height: number
+  mode: "dark" | "light"
+  align: HeaderAlign
+  /** Corner radius in px. */
+  radius: number
+  /** Resolved premade/prop background. */
+  background: ResolvedHeaderBg
+  logo?: HeaderLogoInput
+  /** font-family stack (resolved from the `font` keyword). */
+  fontFamily?: string
+  /** Title color override (#rrggbb). */
+  titleColor?: string
+  /** Subtitle color override (#rrggbb). */
+  subtitleColor?: string
+  /** Draw a 1px hairline border around the card. */
+  border?: boolean
+  /** Show a subtle shieldcn.dev watermark (bottom corner). Default false. */
+  watermark?: boolean
+}
+
+/** shieldcn logo glyph (viewBox 0 0 512 512). */
+const SHIELDCN_LOGO =
+  '<path d="M148.02,363.76c-4.48,0-8.64-2.42-10.86-6.32l-54.29-95.68c-2.15-3.8-2.15-8.52,0-12.32l54.29-95.68c2.21-3.9,6.37-6.32,10.86-6.32h18.51c4.44,0,8.45,2.28,10.73,6.09,2.27,3.82,2.37,8.43.25,12.33l-42.23,77.99c-3.98,7.36-3.98,16.14,0,23.49l22.22,41.02c4.25,7.85,12.43,12.8,21.36,12.92,0,0,45.08.61,45.11.61,8.68,0,16.83-4.64,21.26-12.12l24.87-41.99c2.23-3.77,6.34-6.11,10.72-6.12l19.47-.04c4.48,0,8.49,2.29,10.76,6.12,2.27,3.83,2.35,8.45.21,12.35l-42.2,77.17c-2.19,4-6.39,6.49-10.95,6.49h-110.08Z"/><path d="M346.7,363.69c-4.44,0-8.45-2.28-10.73-6.09-2.27-3.82-2.37-8.43-.25-12.33l42.23-77.99c3.98-7.35,3.98-16.14,0-23.49l-22.22-41.02c-4.25-7.85-12.44-12.8-21.36-12.92,0,0-46.51-.63-46.53-.63-8.88,0-17.12,4.81-21.48,12.54l-23.35,41.36c-2.2,3.9-6.36,6.34-10.84,6.35l-19.21.04c-4.48,0-8.49-2.29-10.76-6.12-2.27-3.83-2.35-8.45-.22-12.36l42.2-77.17c2.19-4.01,6.39-6.5,10.95-6.5h110.08c4.48,0,8.64,2.42,10.86,6.32l54.29,95.68c2.16,3.8,2.16,8.52,0,12.32l-54.29,95.68c-2.21,3.9-6.37,6.32-10.86,6.32h-18.51Z"/>'
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+}
+
+function r2(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, n))
+}
+
+/**
+ * Greedy word-wrap with an approximate character-width model (no font metrics
+ * available in a pure SVG string). Respects explicit newlines, caps the number
+ * of lines, and ellipsizes the final line when content overflows.
+ */
+function wrapText(
+  text: string,
+  maxWidth: number,
+  fontSize: number,
+  maxLines: number,
+  charFactor = 0.56,
+): string[] {
+  const charW = fontSize * charFactor
+  const maxChars = Math.max(4, Math.floor(maxWidth / charW))
+
+  // Build every wrapped line first (respecting explicit newlines + hard-breaks),
+  // then truncate to `maxLines` with an ellipsis if the content overflows.
+  const all: string[] = []
+  for (const seg of text.split(/\r?\n/)) {
+    const words = seg.split(/\s+/).filter(Boolean)
+    if (words.length === 0) continue
+    let line = ""
+    for (let word of words) {
+      // Hard-break a single word longer than a full line.
+      while (word.length > maxChars) {
+        if (line) {
+          all.push(line)
+          line = ""
+        }
+        all.push(word.slice(0, maxChars))
+        word = word.slice(maxChars)
+      }
+      if (!word) continue
+      const candidate = line ? `${line} ${word}` : word
+      if (candidate.length <= maxChars) {
+        line = candidate
+      } else {
+        if (line) all.push(line)
+        line = word
+      }
+    }
+    if (line) all.push(line)
+  }
+
+  if (all.length === 0) return [text.slice(0, maxChars)]
+  if (all.length <= maxLines) return all
+
+  // Overflow: keep `maxLines` and ellipsize the last visible line.
+  const kept = all.slice(0, maxLines)
+  let last = kept[maxLines - 1]
+  if (last.length > maxChars - 1) last = last.slice(0, maxChars - 1)
+  kept[maxLines - 1] = last.replace(/[\s…]+$/, "") + "…"
+  return kept
+}
+
+/** Build the `<g>` markup for a path-based icon scaled to `size` px. */
+function renderIconLogo(icon: IconData, size: number, x: number, y: number, color: string): {
+  svg: string
+  width: number
+  height: number
+} {
+  const vb = (icon.viewBox || "0 0 24 24").split(/\s+/).map(Number)
+  const vbW = vb[2] && vb[2] > 0 ? vb[2] : 24
+  const vbH = vb[3] && vb[3] > 0 ? vb[3] : 24
+  const scale = r2(size / Math.max(vbW, vbH))
+  const scaledW = r2(vbW * scale)
+  const scaledH = r2(vbH * scale)
+  const pathSvg =
+    icon.paths && icon.paths.length
+      ? icon.paths.map((d) => `<path d="${d}" />`).join("")
+      : `<path d="${icon.path}" />`
+  const paint = icon.isStroke
+    ? `fill="none" stroke="${color}" stroke-width="${icon.strokeWidth ?? 2}" stroke-linecap="${icon.strokeLinecap ?? "round"}" stroke-linejoin="${icon.strokeLinejoin ?? "round"}"`
+    : `fill="${color}"${icon.fillRule ? ` fill-rule="${icon.fillRule}"` : ""}`
+  const svg = `<g transform="translate(${r2(x)}, ${r2(y)}) scale(${scale})" ${paint}>${pathSvg}</g>`
+  return { svg, width: scaledW, height: scaledH }
+}
+
+/**
+ * Render a repository header to an SVG string.
+ */
+export function renderHeader(cfg: HeaderConfig): string {
+  const { width, height, background: bg, align } = cfg
+  const fontStack = cfg.fontFamily ?? resolveFontFamily("inter")
+  const radius = clamp(cfg.radius, 0, Math.min(width, height) / 2)
+  const isLight = bg.isLight
+
+  const fg = cfg.titleColor ? `#${cfg.titleColor.replace(/^#/, "")}` : isLight ? "#18181b" : "#fafafa"
+  const muted = cfg.subtitleColor
+    ? `#${cfg.subtitleColor.replace(/^#/, "")}`
+    : isLight
+      ? "rgba(24,24,27,0.72)"
+      : "rgba(250,250,250,0.74)"
+
+  const padX = clamp(Math.round(width * 0.075), 32, 128)
+  const availW = width - padX * 2
+
+  // Type scale derived from canvas height.
+  const titleSize = clamp(Math.round(height * 0.155), 26, 66)
+  const subtitleSize = clamp(Math.round(titleSize * 0.42), 14, 28)
+  const logoSize = clamp(Math.round(height * 0.22), 40, 132)
+
+  const titleLines = cfg.title ? wrapText(cfg.title, availW, titleSize, 2, 0.56) : []
+  const subtitleLines = cfg.subtitle ? wrapText(cfg.subtitle, availW, subtitleSize, 2, 0.54) : []
+
+  const hasLogo = !!(cfg.logo && (cfg.logo.icon || cfg.logo.imageDataUri))
+
+  // Vertical rhythm.
+  const titleLineH = r2(titleSize * 1.12)
+  const subLineH = r2(subtitleSize * 1.3)
+  const logoGap = hasLogo ? r2(titleSize * 0.5) : 0
+  const titleGap = subtitleLines.length ? r2(titleSize * 0.32) : 0
+
+  const logoH = hasLogo ? logoSize : 0
+  const titleBlockH = titleLines.length * titleLineH
+  const subBlockH = subtitleLines.length * subLineH
+  const totalH = logoH + logoGap + titleBlockH + titleGap + subBlockH
+
+  let cursorY = r2((height - totalH) / 2)
+
+  const cx = align === "center" ? width / 2 : padX
+  const anchor = align === "center" ? "middle" : "start"
+
+  const parts: string[] = []
+
+  // --- Logo ---
+  if (hasLogo && cfg.logo) {
+    if (cfg.logo.imageDataUri) {
+      const x = align === "center" ? r2(cx - logoSize / 2) : padX
+      parts.push(
+        `<image href="${cfg.logo.imageDataUri}" x="${x}" y="${r2(cursorY)}" width="${logoSize}" height="${logoSize}" preserveAspectRatio="xMidYMid meet" />`,
+      )
+    } else if (cfg.logo.icon) {
+      const color = cfg.logo.color ? `#${cfg.logo.color.replace(/^#/, "")}` : fg
+      // Measure first so we can horizontally center non-square glyphs.
+      const measured = renderIconLogo(cfg.logo.icon, logoSize, 0, 0, color)
+      const x = align === "center" ? r2(cx - measured.width / 2) : padX
+      // Vertically center within the reserved logo box.
+      const y = r2(cursorY + (logoSize - measured.height) / 2)
+      parts.push(renderIconLogo(cfg.logo.icon, logoSize, x, y, color).svg)
+    }
+    cursorY += logoH + logoGap
+  }
+
+  // --- Title ---
+  if (titleLines.length) {
+    // Baseline of the first line.
+    let ty = r2(cursorY + titleSize * 0.86)
+    for (const line of titleLines) {
+      parts.push(
+        `<text x="${r2(cx)}" y="${ty}" text-anchor="${anchor}" font-size="${titleSize}" font-weight="700" fill="${fg}" font-family="${fontStack}" letter-spacing="-0.02em">${esc(line)}</text>`,
+      )
+      ty = r2(ty + titleLineH)
+    }
+    cursorY += titleBlockH + titleGap
+  }
+
+  // --- Subtitle ---
+  if (subtitleLines.length) {
+    let sy = r2(cursorY + subtitleSize * 0.82)
+    for (const line of subtitleLines) {
+      parts.push(
+        `<text x="${r2(cx)}" y="${sy}" text-anchor="${anchor}" font-size="${subtitleSize}" font-weight="400" fill="${muted}" font-family="${fontStack}">${esc(line)}</text>`,
+      )
+      sy = r2(sy + subLineH)
+    }
+  }
+
+  // --- Watermark ---
+  let watermark = ""
+  if (cfg.watermark) {
+    const wmColor = isLight ? "rgba(24,24,27,0.5)" : "rgba(250,250,250,0.5)"
+    const wmSize = 14
+    const lx = width - 20 - wmSize
+    const ly = height - 20 - wmSize
+    watermark =
+      `<g>` +
+      `<text x="${lx - 6}" y="${r2(ly + wmSize / 2 + 4)}" text-anchor="end" font-size="${wmSize}" font-weight="500" fill="${wmColor}" font-family="${fontStack}">shieldcn.dev</text>` +
+      `<g transform="translate(${lx}, ${ly}) scale(${r2(wmSize / 512)})" fill="${wmColor}">${SHIELDCN_LOGO}</g>` +
+      `</g>`
+  }
+
+  const clipId = "headerClip"
+  const borderColor = bg.border || (isLight ? "#e4e4e7" : "#27272a")
+  const border = cfg.border
+    ? `<rect x="0.5" y="0.5" width="${width - 1}" height="${height - 1}" rx="${Math.max(0, radius - 0.5)}" fill="none" stroke="${borderColor}" stroke-width="1" />`
+    : ""
+
+  const ariaLabel = esc([cfg.title, cfg.subtitle].filter(Boolean).join(" — ") || "header")
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-label="${ariaLabel}">
+  <defs>
+    <clipPath id="${clipId}"><rect x="0" y="0" width="${width}" height="${height}" rx="${radius}" /></clipPath>
+    ${bg.defs}
+  </defs>
+  <g clip-path="url(#${clipId})">
+    ${bg.layers}
+    ${parts.join("\n    ")}
+  </g>
+  ${border}
+  ${watermark}
+</svg>`
+}

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -8,6 +8,8 @@
 
 import { renderBadge, renderBadgeBase, renderErrorBadge } from "./badges/render"
 import { renderChart, resolveAccent, resolveFontFamily, type ChartSeries, type ChartPoint } from "./badges/render-chart"
+import { renderHeader, type HeaderLogoInput } from "./badges/render-header"
+import { resolveHeaderBackground } from "./badges/header-backgrounds"
 import { getStarHistory, getIssueHistory } from "./providers/starhistory"
 import { getNpmDownloadSeries } from "./providers/npm"
 import { formatCount } from "./format"
@@ -1982,6 +1984,222 @@ async function handleChart(
   })
 }
 
+// ---------------------------------------------------------------------------
+// Repository headers
+// ---------------------------------------------------------------------------
+
+/**
+ * Named canvas size presets [width, height]. `banner` (the default) is sized to
+ * the GitHub README content column (~750px) so it renders crisp without being
+ * downscaled; the larger presets are explicit opt-ins for full-width heroes and
+ * social cards.
+ */
+const HEADER_SIZE_PRESETS: Record<string, [number, number]> = {
+  banner: [750, 260], // default — README header at content width
+  wide: [1280, 400], // full-width hero
+  social: [1280, 640], // GitHub repository social-preview slot (2:1)
+  square: [640, 640],
+}
+
+/**
+ * Resolve a `?logo=` value into renderable logo data for a header.
+ * Supports: SimpleIcons/React Icons/Lucide slugs, `data:` URIs (svg or raster),
+ * and remote `http(s)` image/SVG URLs (fetched + embedded). `false`/`none`
+ * hides the logo.
+ */
+async function resolveHeaderLogo(
+  logoParam: string | null,
+  logoColorRaw: string | null,
+): Promise<HeaderLogoInput | undefined> {
+  if (!logoParam || logoParam === "false" || logoParam === "none" || logoParam === "0") {
+    return undefined
+  }
+  const logoColor = resolveColor(logoColorRaw)
+
+  // Inline data URI.
+  if (logoParam.startsWith("data:")) {
+    if (logoParam.startsWith("data:image/svg+xml")) {
+      const decoded = decodeSvgDataUri(logoParam)
+      const parsed = decoded ? parseSvg(decoded) : null
+      if (parsed) return { icon: parsed.icon, color: logoColor }
+    }
+    return { imageDataUri: logoParam }
+  }
+
+  // Remote image / SVG — fetch and embed (never hot-link from a sandboxed img).
+  if (/^https?:\/\//.test(logoParam)) {
+    try {
+      const res = await raceTimeout(
+        fetch(logoParam, {
+          next: { revalidate: 86400 },
+          headers: { Accept: "image/svg+xml,image/png,image/*", "User-Agent": "shieldcn/1.0" },
+        }),
+      )
+      if (res?.ok) {
+        const ct = res.headers.get("content-type")?.split(";")[0] || "image/png"
+        if (ct.includes("svg")) {
+          const text = await res.text()
+          const parsed = parseSvg(text)
+          if (parsed) return { icon: parsed.icon, color: logoColor }
+          return { imageDataUri: `data:image/svg+xml;base64,${Buffer.from(text).toString("base64")}` }
+        }
+        const bytes = Buffer.from(await res.arrayBuffer())
+        return { imageDataUri: `data:${ct};base64,${bytes.toString("base64")}` }
+      }
+    } catch {
+      // No logo art — render without a logo.
+    }
+    return undefined
+  }
+
+  // Icon slug (SimpleIcons / React Icons / Lucide / custom).
+  const si = await getSimpleIcon(logoParam, logoColor)
+  if (!si) return undefined
+  // `?logoColor=brand` paints the icon in its SimpleIcons brand color.
+  let color = logoColor
+  if (logoColorRaw === "brand") color = si.defaultColor.replace(/^#/, "")
+  return { icon: si.icon, color }
+}
+
+async function handleHeader(
+  cleanSegments: string[],
+  searchParams: URLSearchParams,
+  format: Format,
+  options?: BadgeRequestOptions,
+): Promise<Response> {
+  const rest = cleanSegments.slice(1) // after "header"
+  const preset = rest[0] || searchParams.get("preset") || undefined
+  const mode = (searchParams.get("mode") === "light" ? "light" : "dark") as "light" | "dark"
+
+  // Canvas: size preset (default "banner") + width/height overrides.
+  const sizeParam = searchParams.get("size")
+  const [baseW, baseH] = (sizeParam && HEADER_SIZE_PRESETS[sizeParam]) || HEADER_SIZE_PRESETS.banner
+  const width = clampNum(searchParams.get("width"), 240, 2400, baseW)
+  const height = clampNum(searchParams.get("height"), 100, 1600, baseH)
+
+  const align = (searchParams.get("align") === "left" ? "left" : "center") as "left" | "center"
+  const radius = clampNum(searchParams.get("radius"), 0, 120, 12)
+  const fontFamily = resolveFontFamily(searchParams.get("font"))
+  const falsy = (v: string | null) => v === "false" || v === "0"
+  const truthy = (v: string | null) => v === "true" || v === "1"
+  // Border defaults ON (shadcn card hairline); watermark defaults OFF.
+  const border = !falsy(searchParams.get("border"))
+  const watermark = truthy(searchParams.get("watermark"))
+
+  const title = searchParams.get("title") ?? ""
+  const subtitle = searchParams.get("subtitle") ?? searchParams.get("description") ?? undefined
+  const titleColor = resolveColor(searchParams.get("titleColor"))
+  const subtitleColor = resolveColor(searchParams.get("subtitleColor"))
+
+  // Background color: `transparent`/`none` blends into the host page; otherwise
+  // a named/hex color resolves to hex. Checked before resolveColor (which only
+  // understands colors, not the transparent keyword).
+  const bgRaw = searchParams.get("bg") ?? searchParams.get("background")
+  const transparent = bgRaw === "transparent" || bgRaw === "none"
+
+  const background = resolveHeaderBackground({
+    preset,
+    mode,
+    width,
+    height,
+    radius,
+    theme: searchParams.get("theme"),
+    transparent,
+    bg: transparent ? null : resolveColor(bgRaw),
+    gradient: searchParams.get("gradient"),
+    pattern: searchParams.get("pattern"),
+    glow: resolveColor(searchParams.get("glow")),
+    accent: resolveColor(searchParams.get("accent")),
+  })
+
+  const logo = await resolveHeaderLogo(searchParams.get("logo"), searchParams.get("logoColor"))
+
+  if (format === "json") {
+    return Response.json(
+      {
+        type: "header",
+        preset: preset ?? "surface",
+        title,
+        subtitle: subtitle ?? null,
+        width,
+        height,
+        mode,
+        align,
+        hasLogo: !!logo,
+      },
+      { headers: CACHE_HEADERS },
+    )
+  }
+
+  const svg = renderHeader({
+    title,
+    subtitle,
+    width,
+    height,
+    mode,
+    align,
+    radius,
+    background,
+    logo,
+    fontFamily,
+    titleColor,
+    subtitleColor,
+    border,
+    watermark,
+  })
+
+  if (options?.onTrack) {
+    void options.onTrack({
+      name: "header_rendered",
+      data: { preset: preset ?? "surface", format, mode, size: sizeParam ?? "banner", hasLogo: !!logo },
+    })
+  }
+
+  if (format === "png") {
+    const { Resvg, initWasm } = await import("@resvg/resvg-wasm")
+    try {
+      let wasmLoaded = false
+      if (typeof process !== "undefined" && process.env.NODE_ENV === "production") {
+        try {
+          const fs = await import("node:fs")
+          const path = await import("node:path")
+          const candidates = [
+            path.join(process.cwd(), "node_modules", "@resvg", "resvg-wasm", "index_bg.wasm"),
+          ]
+          for (const p of candidates) {
+            if (fs.existsSync(p)) {
+              await initWasm(fs.readFileSync(p))
+              wasmLoaded = true
+              break
+            }
+          }
+        } catch { /* fs not available */ }
+      }
+      if (!wasmLoaded) {
+        await initWasm(fetch("https://unpkg.com/@resvg/resvg-wasm/index_bg.wasm"))
+      }
+    } catch { /* already initialized */ }
+    // Headers are text-centric: supply the bundled fonts so resvg can
+    // rasterize the title/subtitle (the wasm sandbox has no system fonts).
+    const { getFontBuffers, DEFAULT_FONT_FAMILY } = await import("./badges/fonts")
+    const resvg = new Resvg(svg, {
+      font: {
+        fontBuffers: getFontBuffers(),
+        defaultFontFamily: DEFAULT_FONT_FAMILY,
+        loadSystemFonts: false,
+      },
+    })
+    const png = resvg.render().asPng()
+    return new Response(Buffer.from(png), {
+      headers: { "Content-Type": "image/png", ...CACHE_HEADERS },
+    })
+  }
+
+  return new Response(svg, {
+    headers: { "Content-Type": "image/svg+xml", ...CACHE_HEADERS },
+  })
+}
+
 /** Number formatter that never throws on weird input. */
 function formatCountSafe(n: number): string {
   try {
@@ -2235,6 +2453,14 @@ async function handleBadgeGETInner(
   // ---------------------------------------------------------------------------
   if (cleanSegments[0] === "chart") {
     return handleChart(cleanSegments, searchParams, format, options)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Repository headers: /header/{preset}.svg?title=…&logo=…&subtitle=…
+  // Renders a premade/prop-driven banner image (logo + title + subtitle).
+  // ---------------------------------------------------------------------------
+  if (cleanSegments[0] === "header") {
+    return handleHeader(cleanSegments, searchParams, format, options)
   }
 
   // Fetch badge data from provider

--- a/packages/web/app/header/page.tsx
+++ b/packages/web/app/header/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { SiteShell } from "@/components/site-shell"
+import { HeaderBuilder } from "@/components/header-builder"
+import { pageMetadata } from "@/lib/metadata"
+
+export const metadata: Metadata = pageMetadata({
+  title: "Repository Header Generator",
+  description:
+    "Generate beautiful repository header banners for your GitHub README — your logo, premade shadcn-styled backgrounds, a title and tagline, all served from a single image URL. SVG and PNG, dark and light.",
+  path: "/header",
+})
+
+export default function HeaderPage() {
+  return (
+    <SiteShell>
+      <main className="min-w-0 flex-1">
+        <div className="px-6 py-8 md:px-10 md:py-10">
+          <div className="mb-6 flex flex-wrap items-end justify-between gap-3">
+            <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">Repository headers</h1>
+            <Link
+              href="/docs/headers"
+              className="text-sm font-medium text-muted-foreground underline underline-offset-4 hover:text-foreground"
+            >
+              Docs &amp; parameters
+            </Link>
+          </div>
+
+          <HeaderBuilder />
+        </div>
+      </main>
+    </SiteShell>
+  )
+}

--- a/packages/web/app/showcase/showcase-client.tsx
+++ b/packages/web/app/showcase/showcase-client.tsx
@@ -234,7 +234,79 @@ export default function ShowcasePage() {
       </section>
 
       <ChartShowcase />
+      <HeaderShowcase />
     </main>
+  )
+}
+
+const HEADER_EXAMPLES: { title: string; description: string; src: string; href: string }[] = [
+  {
+    title: "Surface",
+    description: "A clean zinc card — the default, logo plus title and tagline.",
+    src: "/header/surface.svg?title=Acme+Toolkit&subtitle=A+delightful+component+library&logo=react",
+    href: "/header",
+  },
+  {
+    title: "Glow",
+    description: "A soft themed spotlight from the top — here with the blue theme.",
+    src: "/header/glow.svg?title=Lumen&subtitle=Illuminate+your+data&logo=react&theme=blue",
+    href: "/header",
+  },
+  {
+    title: "Dots",
+    description: "A subtle dot grid, the shadcn-docs look.",
+    src: "/header/dots.svg?title=shieldcn&subtitle=Headers+for+your+README&logo=shieldcn",
+    href: "/header",
+  },
+  {
+    title: "Grid, left aligned",
+    description: "A hairline grid with left-aligned content.",
+    src: "/header/grid.svg?title=Blueprint&subtitle=Design+tokens+for+engineers&logo=figma&align=left",
+    href: "/header",
+  },
+]
+
+function HeaderShowcase() {
+  const hydrated = useHydrated()
+  const { adaptUrl } = useBadgeMode()
+  return (
+    <section
+      id="header-showcase"
+      aria-labelledby="header-showcase-title"
+      className="mx-auto w-full max-w-7xl space-y-6 px-4 pb-16 md:px-8"
+    >
+      <div>
+        <h2 id="header-showcase-title" className="font-heading text-2xl font-semibold tracking-tight md:text-3xl">
+          Headers
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Banner images for the top of your README — your logo, a premade
+          background, a title, and a tagline.
+        </p>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        {HEADER_EXAMPLES.map((h) => (
+          <Link
+            key={h.src}
+            href={h.href}
+            className="group rounded-2xl border border-border bg-card p-3 transition-colors hover:border-foreground/20"
+          >
+            <div className="overflow-hidden rounded-lg border border-border/60 bg-muted/30">
+              {hydrated ? (
+                /* eslint-disable-next-line @next/next/no-img-element */
+                <img src={adaptUrl(h.src)} alt={h.title} className="w-full" />
+              ) : (
+                <div className="aspect-[750/260] w-full" />
+              )}
+            </div>
+            <div className="px-1 pt-3">
+              <p className="text-sm font-medium">{h.title}</p>
+              <p className="mt-1 text-xs text-muted-foreground">{h.description}</p>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
   )
 }
 

--- a/packages/web/components/animated-header.tsx
+++ b/packages/web/components/animated-header.tsx
@@ -94,6 +94,7 @@ const NAV = {
   items: [
     { href: "/docs", label: "Docs" },
     { href: "/showcase", label: "Showcase" },
+    { href: "/header", label: "Headers" },
     { href: "/gen", label: "Generator" },
     { href: "/migrate", label: "Migrate" },
   ],

--- a/packages/web/components/header-builder.tsx
+++ b/packages/web/components/header-builder.tsx
@@ -1,0 +1,301 @@
+/**
+ * shieldcn
+ * components/header-builder
+ *
+ * Interactive repository-header generator. Pick a background preset, logo,
+ * title/subtitle, size, theme, and alignment; preview live; copy the URL as
+ * Markdown / HTML / plain URL. Everything resolves to a /header/{preset}.svg
+ * image served from the server.
+ */
+
+"use client"
+
+import { useState, useCallback, useMemo, useSyncExternalStore } from "react"
+import { Copy, Check } from "lucide-react"
+import { useTheme } from "next-themes"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Checkbox as ShadcnCheckbox } from "@/components/ui/checkbox"
+import { LogoPicker } from "@/components/logo-picker"
+import { ColorSwatch } from "@/components/color-input"
+import { cn } from "@/lib/utils"
+import {
+  HEADER_DEFAULTS,
+  HEADER_PRESETS,
+  HEADER_PRESET_LABELS,
+  HEADER_SIZES,
+  HEADER_SIZE_LABELS,
+  HEADER_FONTS,
+  HEADER_THEMES,
+  buildHeaderUrl,
+  type HeaderState,
+} from "@/lib/header-builder-shared"
+
+type CopyFormat = "markdown" | "html" | "url"
+
+function formatOutput(url: string, format: CopyFormat, alt: string): string {
+  switch (format) {
+    case "markdown":
+      return `![${alt}](${url})`
+    case "html":
+      return `<img alt="${alt}" src="${url}">`
+    case "url":
+      return url
+  }
+}
+
+const COPY_FORMATS: { value: CopyFormat; label: string }[] = [
+  { value: "markdown", label: "Markdown" },
+  { value: "html", label: "HTML" },
+  { value: "url", label: "URL" },
+]
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+  return <Label className="text-xs text-muted-foreground">{children}</Label>
+}
+
+export function HeaderBuilder() {
+  const [s, setS] = useState<HeaderState>(HEADER_DEFAULTS)
+  const [copied, setCopied] = useState(false)
+  const [copyError, setCopyError] = useState(false)
+  const [copyFormat, setCopyFormat] = useState<CopyFormat>("markdown")
+  const { resolvedTheme } = useTheme()
+
+  // Read the origin on the client without a setState-in-effect (hydration-safe).
+  const baseUrl = useSyncExternalStore(
+    () => () => {},
+    () => window.location.origin,
+    () => "https://shieldcn.dev",
+  )
+  // Header mode follows the site theme — derived during render, not stored.
+  const mode: "dark" | "light" = resolvedTheme === "light" ? "light" : "dark"
+
+  const set = useCallback(<K extends keyof HeaderState>(key: K, value: HeaderState[K]) => {
+    setS((prev) => ({ ...prev, [key]: value }))
+  }, [])
+
+  const url = useMemo(() => buildHeaderUrl({ ...s, mode }, baseUrl), [s, mode, baseUrl])
+  const altText = s.title || "repository header"
+  const output = useMemo(() => formatOutput(url, copyFormat, altText), [url, copyFormat, altText])
+
+  const handleCopy = useCallback(() => {
+    if (!output) return
+    navigator.clipboard.writeText(output).then(
+      () => {
+        setCopied(true)
+        setTimeout(() => setCopied(false), 2000)
+      },
+      () => {
+        setCopyError(true)
+        setTimeout(() => setCopyError(false), 2000)
+      },
+    )
+  }, [output])
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[340px_minmax(0,1fr)]">
+      {/* ─── Preview + output (right on desktop, first on mobile) ─── */}
+      <div className="order-1 flex flex-col gap-4 lg:order-2">
+        <div
+          className="flex min-h-[300px] flex-1 items-center justify-center rounded-xl border border-border p-6 transition-colors md:p-10"
+          style={{
+            backgroundColor: mode === "light" ? "#f4f4f5" : "#0c0c0e",
+            backgroundImage:
+              mode === "light"
+                ? "radial-gradient(circle, #d4d4d8 1px, transparent 1px)"
+                : "radial-gradient(circle, #27272a 1px, transparent 1px)",
+            backgroundSize: "20px 20px",
+          }}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            key={url}
+            src={url}
+            alt="header preview"
+            className="w-full max-w-[760px] select-none"
+            draggable={false}
+          />
+        </div>
+
+        {/* Copy output */}
+        <div className="space-y-3">
+          <ToggleGroup
+            type="single"
+            value={copyFormat}
+            onValueChange={(v) => v && setCopyFormat(v as CopyFormat)}
+            variant="outline"
+            size="sm"
+            className="w-full max-w-md"
+          >
+            {COPY_FORMATS.map((f) => (
+              <ToggleGroupItem key={f.value} value={f.value} className="flex-1 text-xs">
+                {f.label}
+              </ToggleGroupItem>
+            ))}
+          </ToggleGroup>
+          <div className="flex items-start gap-2">
+            <code className="flex-1 rounded-lg border border-border bg-muted/30 px-3 py-2.5 text-[11px] font-mono break-all text-muted-foreground leading-relaxed min-h-[2.5rem]">
+              {output}
+            </code>
+            <Button variant="outline" size="sm" onClick={handleCopy} className="shrink-0 h-9">
+              {copied ? (
+                <>
+                  <Check className="size-3.5 text-success" /> Copied
+                </>
+              ) : copyError ? (
+                <>
+                  <Copy className="size-3.5 text-destructive" /> Failed
+                </>
+              ) : (
+                <>
+                  <Copy className="size-3.5" /> Copy
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* ─── Controls sidebar (left on desktop) ─── */}
+      <div className="order-2 lg:order-1 space-y-5 rounded-xl border border-border bg-card p-5">
+        {/* Background preset */}
+        <div className="space-y-2">
+          <FieldLabel>Background</FieldLabel>
+          <div className="grid grid-cols-2 gap-1.5">
+            {HEADER_PRESETS.map((p) => (
+              <button
+                key={p}
+                onClick={() => set("preset", p)}
+                aria-pressed={s.preset === p}
+                className={cn(
+                  "rounded-lg px-1 py-2 text-xs transition-colors",
+                  s.preset === p
+                    ? "bg-primary/10 ring-1 ring-primary text-foreground"
+                    : "hover:bg-muted/60 text-muted-foreground",
+                )}
+              >
+                {HEADER_PRESET_LABELS[p]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Title + subtitle */}
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <FieldLabel>Title</FieldLabel>
+            <Input
+              value={s.title}
+              onChange={(e) => set("title", e.target.value)}
+              placeholder="Your Project"
+              className="h-9 text-sm"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <FieldLabel>Subtitle</FieldLabel>
+            <Input
+              value={s.subtitle}
+              onChange={(e) => set("subtitle", e.target.value)}
+              placeholder="A short tagline"
+              className="h-9 text-sm"
+            />
+          </div>
+        </div>
+
+        {/* Logo */}
+        <div className="space-y-2">
+          <FieldLabel>Logo</FieldLabel>
+          <div className="flex gap-2">
+            <div className="flex-1">
+              <LogoPicker value={s.logo} onChange={(v) => set("logo", v)} />
+            </div>
+            <ColorSwatch label="Logo color" value={s.logoColor} onChange={(v) => set("logoColor", v)} />
+          </div>
+        </div>
+
+        {/* Selects */}
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1.5">
+            <FieldLabel>Size</FieldLabel>
+            <Select value={s.size} onValueChange={(v) => set("size", v as HeaderState["size"])}>
+              <SelectTrigger className="h-9 w-full text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {HEADER_SIZES.map((v) => (
+                  <SelectItem key={v} value={v}>
+                    {HEADER_SIZE_LABELS[v]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5">
+            <FieldLabel>Theme</FieldLabel>
+            <Select value={s.theme || "_none"} onValueChange={(v) => set("theme", v === "_none" ? "" : v)}>
+              <SelectTrigger className="h-9 w-full text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="_none">None</SelectItem>
+                {HEADER_THEMES.map((v) => (
+                  <SelectItem key={v} value={v}>
+                    {v}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5">
+            <FieldLabel>Align</FieldLabel>
+            <Select value={s.align} onValueChange={(v) => set("align", v as HeaderState["align"])}>
+              <SelectTrigger className="h-9 w-full text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="center">Center</SelectItem>
+                <SelectItem value="left">Left</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5">
+            <FieldLabel>Font</FieldLabel>
+            <Select value={s.font} onValueChange={(v) => set("font", v)}>
+              <SelectTrigger className="h-9 w-full text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {HEADER_FONTS.map((v) => (
+                  <SelectItem key={v} value={v}>
+                    {v}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        {/* Toggles */}
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <ShadcnCheckbox checked={s.border} onCheckedChange={(v) => set("border", v === true)} />
+            <span className="text-xs">Border</span>
+          </label>
+          <label className="flex items-center gap-2 cursor-pointer">
+            <ShadcnCheckbox checked={s.watermark} onCheckedChange={(v) => set("watermark", v === true)} />
+            <span className="text-xs">Watermark</span>
+          </label>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/web/components/hero-showcase.tsx
+++ b/packages/web/components/hero-showcase.tsx
@@ -44,9 +44,9 @@ const CARDS = {
       src: "/header/dots.svg?title=shieldcn&subtitle=Headers for your README&logo=shieldcn",
       alt: "repository header banner — shieldcn",
       // position within the stage (% of container)
-      top: "2%",
-      left: "2%",
-      width: 330,
+      top: "10%",
+      left: "3%",
+      width: 312,
       rotate: -3,
       z: 30,
     },
@@ -54,9 +54,9 @@ const CARDS = {
       key: "stars",
       src: "/chart/github/stars/vercel/next.js.svg?theme=blue",
       alt: "GitHub star history — vercel/next.js",
-      top: "30%",
-      left: "-2%",
-      width: 260,
+      top: "40%",
+      left: "3%",
+      width: 244,
       rotate: -5,
       z: 20,
     },
@@ -64,9 +64,9 @@ const CARDS = {
       key: "downloads",
       src: "/chart/npm/zod.svg?theme=emerald",
       alt: "npm weekly downloads — zod",
-      top: "54%",
-      left: "34%",
-      width: 250,
+      top: "58%",
+      left: "35%",
+      width: 236,
       rotate: 5,
       z: 10,
     },
@@ -81,14 +81,13 @@ const BADGES = {
   floatAmp: 7, //      px idle vertical drift
   floatSecs: 5, //     seconds per idle loop
   items: [
-    { key: "npm", src: "/badge/npm-3.24.1.svg?variant=branded&logo=npm", alt: "npm version badge", top: "4%", left: "68%", z: 40 },
-    { key: "build", src: "/badge/build-passing.svg?variant=branded&logo=githubactions", alt: "build passing badge", top: "24%", left: "60%", z: 40 },
-    { key: "stars", src: "/badge/stars-140k.svg?variant=branded&logo=github", alt: "GitHub stars badge", top: "44%", left: "-2%", z: 40 },
-    { key: "coverage", src: "/badge/coverage-98%25.svg?variant=branded&logo=codecov", alt: "coverage badge", top: "46%", left: "70%", z: 40 },
-    { key: "typescript", src: "/badge/typescript-5.x.svg?variant=branded&logo=typescript", alt: "TypeScript badge", top: "74%", left: "2%", z: 40 },
-    { key: "license", src: "/badge/license-MIT.svg?variant=secondary", alt: "license MIT badge", top: "86%", left: "26%", z: 40 },
-    { key: "prs", src: "/badge/PRs-welcome.svg?variant=outline", alt: "PRs welcome badge", top: "70%", left: "72%", z: 40 },
-    { key: "discord", src: "/badge/discord-online.svg?variant=branded&logo=discord", alt: "discord badge", top: "88%", left: "54%", z: 40 },
+    { key: "npm", src: "/badge/npm-3.24.1.svg?variant=branded&logo=npm", alt: "npm version badge", top: "14%", left: "64%", z: 40 },
+    { key: "build", src: "/badge/build-passing.svg?variant=branded&logo=githubactions", alt: "build passing badge", top: "30%", left: "56%", z: 40 },
+    { key: "stars", src: "/badge/stars-140k.svg?variant=branded&logo=github", alt: "GitHub stars badge", top: "46%", left: "4%", z: 40 },
+    { key: "coverage", src: "/badge/coverage-98%25.svg?variant=branded&logo=codecov", alt: "coverage badge", top: "60%", left: "64%", z: 40 },
+    { key: "typescript", src: "/badge/typescript-5.x.svg?variant=branded&logo=typescript", alt: "TypeScript badge", top: "74%", left: "4%", z: 40 },
+    { key: "license", src: "/badge/license-MIT.svg?variant=secondary", alt: "license MIT badge", top: "84%", left: "30%", z: 40 },
+    { key: "discord", src: "/badge/discord-online.svg?variant=branded&logo=discord", alt: "discord badge", top: "82%", left: "56%", z: 40 },
   ],
 }
 
@@ -150,7 +149,7 @@ export function HeroShowcase() {
   if (!hydrated) return <div className="h-[500px] w-full" />
 
   return (
-    <div className="relative mx-auto h-[500px] w-full max-w-[460px] -translate-y-2 lg:-translate-y-6">
+    <div className="relative mx-auto h-[440px] w-full max-w-[440px] translate-y-0">
         {/* ── Chart cards (the "charts" story) ── */}
         {CARDS.items.map((card, i) => {
           const atStage = i + 1 // back=1, front=2

--- a/packages/web/components/hero-showcase.tsx
+++ b/packages/web/components/hero-showcase.tsx
@@ -31,7 +31,7 @@ import { useBadgeMode } from "@/lib/use-badge-mode"
 // Storyboard constants
 // ---------------------------------------------------------------------------
 
-/** Two chart cards — the "charts" half of the story. */
+/** Surface cards — the header banner + two chart cards. */
 const CARDS = {
   riseY: 26, //  px each card slides up from
   blur: 12, //   px blur burned off on entrance
@@ -40,13 +40,23 @@ const CARDS = {
   floatSecs: 7, //   seconds per idle loop
   items: [
     {
+      key: "header",
+      src: "/header/dots.svg?title=shieldcn&subtitle=Headers for your README&logo=shieldcn",
+      alt: "repository header banner — shieldcn",
+      // position within the stage (% of container)
+      top: "2%",
+      left: "2%",
+      width: 330,
+      rotate: -3,
+      z: 30,
+    },
+    {
       key: "stars",
       src: "/chart/github/stars/vercel/next.js.svg?theme=blue",
       alt: "GitHub star history — vercel/next.js",
-      // position within the stage (% of container)
-      top: "9%",
-      left: "2%",
-      width: 320,
+      top: "30%",
+      left: "-2%",
+      width: 260,
       rotate: -5,
       z: 20,
     },
@@ -54,9 +64,9 @@ const CARDS = {
       key: "downloads",
       src: "/chart/npm/zod.svg?theme=emerald",
       alt: "npm weekly downloads — zod",
-      top: "46%",
-      left: "30%",
-      width: 300,
+      top: "54%",
+      left: "34%",
+      width: 250,
       rotate: 5,
       z: 10,
     },
@@ -71,12 +81,14 @@ const BADGES = {
   floatAmp: 7, //      px idle vertical drift
   floatSecs: 5, //     seconds per idle loop
   items: [
-    { key: "npm", src: "/npm/zod.svg?variant=branded", alt: "npm zod badge", top: "3%", left: "40%", z: 40 },
-    { key: "build", src: "/badge/build-passing.svg?variant=branded&logo=githubactions", alt: "build passing badge", top: "26%", left: "63%", z: 40 },
-    { key: "stars", src: "/badge/stars-140k.svg?variant=branded&logo=github", alt: "GitHub stars badge", top: "34%", left: "0%", z: 40 },
-    { key: "typescript", src: "/badge/typescript-5.x.svg?variant=branded&logo=typescript", alt: "TypeScript badge", top: "56%", left: "2%", z: 40 },
-    { key: "license", src: "/badge/license-MIT.svg?variant=secondary", alt: "license MIT badge", top: "74%", left: "18%", z: 40 },
-    { key: "discord", src: "/badge/discord-online.svg?variant=branded&logo=discord", alt: "discord badge", top: "78%", left: "56%", z: 40 },
+    { key: "npm", src: "/badge/npm-3.24.1.svg?variant=branded&logo=npm", alt: "npm version badge", top: "4%", left: "68%", z: 40 },
+    { key: "build", src: "/badge/build-passing.svg?variant=branded&logo=githubactions", alt: "build passing badge", top: "24%", left: "60%", z: 40 },
+    { key: "stars", src: "/badge/stars-140k.svg?variant=branded&logo=github", alt: "GitHub stars badge", top: "44%", left: "-2%", z: 40 },
+    { key: "coverage", src: "/badge/coverage-98%25.svg?variant=branded&logo=codecov", alt: "coverage badge", top: "46%", left: "70%", z: 40 },
+    { key: "typescript", src: "/badge/typescript-5.x.svg?variant=branded&logo=typescript", alt: "TypeScript badge", top: "74%", left: "2%", z: 40 },
+    { key: "license", src: "/badge/license-MIT.svg?variant=secondary", alt: "license MIT badge", top: "86%", left: "26%", z: 40 },
+    { key: "prs", src: "/badge/PRs-welcome.svg?variant=outline", alt: "PRs welcome badge", top: "70%", left: "72%", z: 40 },
+    { key: "discord", src: "/badge/discord-online.svg?variant=branded&logo=discord", alt: "discord badge", top: "88%", left: "54%", z: 40 },
   ],
 }
 
@@ -98,9 +110,10 @@ export function HeroShowcase() {
 
   // Tuned layout + motion values baked out of DialKit before shipping.
   const d = {
-    backCard: 520,
-    frontCard: 530,
-    badges: 800,
+    card1: 200,
+    card2: 380,
+    card3: 540,
+    badges: 760,
     cards: {
       riseY: 26,
       blur: 12,
@@ -126,17 +139,18 @@ export function HeroShowcase() {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setStage(0)
     const timers: ReturnType<typeof setTimeout>[] = []
-    timers.push(setTimeout(() => setStage(s => Math.max(s, 1)), d.backCard))
-    timers.push(setTimeout(() => setStage(s => Math.max(s, 2)), d.frontCard))
-    timers.push(setTimeout(() => setStage(s => Math.max(s, 3)), d.badges))
+    timers.push(setTimeout(() => setStage(s => Math.max(s, 1)), d.card1))
+    timers.push(setTimeout(() => setStage(s => Math.max(s, 2)), d.card2))
+    timers.push(setTimeout(() => setStage(s => Math.max(s, 3)), d.card3))
+    timers.push(setTimeout(() => setStage(s => Math.max(s, 4)), d.badges))
     return () => timers.forEach(clearTimeout)
-  }, [d.backCard, d.frontCard, d.badges])
+  }, [d.card1, d.card2, d.card3, d.badges])
 
   // Keep the placeholder identical in size to avoid layout shift pre-hydration.
   if (!hydrated) return <div className="h-[500px] w-full" />
 
   return (
-    <div className="relative mx-auto h-[500px] w-full max-w-[460px] translate-y-10 lg:translate-y-20">
+    <div className="relative mx-auto h-[500px] w-full max-w-[460px] -translate-y-2 lg:-translate-y-6">
         {/* ── Chart cards (the "charts" story) ── */}
         {CARDS.items.map((card, i) => {
           const atStage = i + 1 // back=1, front=2
@@ -175,13 +189,13 @@ export function HeroShowcase() {
             style={{ top: badge.top, left: badge.left, zIndex: badge.z }}
             initial={{ opacity: 0, scale: BADGES.initialScale }}
             animate={{
-              opacity: stage >= 3 ? 1 : 0,
-              scale: stage >= 3 ? d.badgeGroup.scale : BADGES.initialScale,
+              opacity: stage >= 4 ? 1 : 0,
+              scale: stage >= 4 ? d.badgeGroup.scale : BADGES.initialScale,
             }}
-            transition={{ ...(d.badgeGroup.spring as Transition), delay: stage >= 3 ? i * d.badgeGroup.stagger : 0 }}
+            transition={{ ...(d.badgeGroup.spring as Transition), delay: stage >= 4 ? i * d.badgeGroup.stagger : 0 }}
           >
             <motion.div
-              animate={{ y: stage >= 3 ? [0, -d.badgeGroup.floatAmp, 0] : 0 }}
+              animate={{ y: stage >= 4 ? [0, -d.badgeGroup.floatAmp, 0] : 0 }}
               transition={{ repeat: Infinity, duration: d.badgeGroup.floatSecs, ease: "easeInOut", delay: i * 0.4 }}
               className="drop-shadow-md"
             >

--- a/packages/web/components/sidebar.tsx
+++ b/packages/web/components/sidebar.tsx
@@ -172,6 +172,14 @@ const docsNav: NavGroup[] = [
     items: [{ title: "Overview", href: "/docs/charts" }],
   },
   {
+    title: "Headers",
+    alwaysOpen: true,
+    items: [
+      { title: "Overview", href: "/docs/headers" },
+      { title: "Generator", href: "/header" },
+    ],
+  },
+  {
     title: "Registry",
     items: [
       { title: "Overview", href: "/docs/registry" },

--- a/packages/web/components/site-announcement.tsx
+++ b/packages/web/components/site-announcement.tsx
@@ -105,8 +105,8 @@ export function SiteAnnouncement() {
 
       <AnnouncementBadge>New</AnnouncementBadge>
       <AnnouncementContent asChild>
-        <Link href="/docs/charts" className="hover:underline underline-offset-4">
-          Charts — star history, issues &amp; npm downloads
+        <Link href="/header" className="hover:underline underline-offset-4">
+          Headers — banner images for your README
           <ArrowRight className={`size-3 ${ARROW.ease} ${ARROW.nudge}`} />
         </Link>
       </AnnouncementContent>

--- a/packages/web/content/docs/api-reference.mdx
+++ b/packages/web/content/docs/api-reference.mdx
@@ -137,6 +137,22 @@ Shadcn-styled line/area charts. Support `mode`, `theme`, `color`, `fill`,
 `area`, `bg`, `border`, `font`, `width`, `height`, `title`, `days` (npm), and
 `values`/`dates`/`labels` or `url`/`query` (JSON). See [Charts docs](/docs/charts).
 
+### Headers
+
+| Endpoint | Description |
+|----------|-------------|
+| `/header/{preset}.svg` | Repository header banner |
+| `/header.svg` | Default preset (`surface`) |
+| `/header/{preset}.png` | PNG banner |
+| `/header/{preset}.json` | Resolved header config |
+
+Premade backgrounds: `surface`, `gradient`, `dots`, `grid`, `graph`, `glow`,
+`transparent`. Support `title`, `subtitle`, `logo`, `logoColor`, `size`
+(`banner`, `wide`, `social`, `square`), `width`, `height`, `align`, `bg`,
+`gradient`, `glow`, `accent`, `titleColor`, `subtitleColor`, `radius`, `border`,
+`watermark`, `pattern`, plus `mode`, `theme`, and `font`. See
+[Headers docs](/docs/headers).
+
 ## Query parameters
 
 <ApiRefTable

--- a/packages/web/content/docs/headers/index.mdx
+++ b/packages/web/content/docs/headers/index.mdx
@@ -1,0 +1,177 @@
+---
+title: Headers
+description: Repository header banners for your README — your logo, a premade shadcn-styled background, a title, and a tagline, all from one image URL.
+---
+
+Repository headers are banner images for the top of your README. You get a
+logo, a premade background, a title, and a tagline, rendered as a portable SVG
+(or PNG) served entirely from shieldcn. Everything is encoded in the image URL,
+so the banner works anywhere a Markdown image does and never needs a build step.
+
+<HeaderPreview
+  src="/header/dots.svg?title=Acme+Toolkit&subtitle=A+delightful+component+library&logo=react"
+  alt="Acme Toolkit repository header"
+/>
+
+## Builder
+
+The fastest way to make a header is the interactive generator. Pick a
+background, add your logo and text, choose a size and theme, then copy the
+Markdown.
+
+[Open the header generator](/header)
+
+## URL format
+
+Headers follow the same pattern as the rest of shieldcn. The preset is an
+optional path segment, and every option is a query parameter.
+
+```
+/header/{preset}.svg     SVG banner
+/header/{preset}.png     PNG banner
+/header/{preset}.json    resolved config (JSON)
+/header.svg              default preset (surface)
+```
+
+Drop it into your README with a Markdown image:
+
+```md
+![Acme Toolkit](https://shieldcn.dev/header/dots.svg?title=Acme+Toolkit&subtitle=A+delightful+component+library&logo=react)
+```
+
+Or center it with an HTML block:
+
+```html
+<p align="center">
+  <img src="https://shieldcn.dev/header/glow.svg?title=Acme+Toolkit&subtitle=A+delightful+component+library&logo=react&theme=blue" alt="Acme Toolkit" />
+</p>
+```
+
+## Backgrounds
+
+Seven premade backgrounds ship out of the box. Each is built on a neutral zinc
+surface and works in both dark and light mode. Set the preset as the path
+segment, for example `/header/glow.svg`.
+
+| Preset | Description |
+| --- | --- |
+| `surface` | Clean flat zinc surface. The default. |
+| `gradient` | Subtle neutral vertical gradient. |
+| `dots` | Dot grid over the surface. |
+| `grid` | Line grid over the surface. |
+| `graph` | Fine and coarse graph paper. |
+| `glow` | Soft themed spotlight from the top. |
+| `transparent` | No surface fill — blends into the page. |
+
+<HeaderPreview
+  src="/header/glow.svg?title=Lumen&subtitle=Illuminate+your+data&logo=react&theme=blue"
+  alt="glow preset with a blue theme"
+  description="glow preset, blue theme"
+/>
+
+<HeaderPreview
+  src="/header/grid.svg?title=Blueprint&subtitle=Design+tokens+for+engineers&logo=figma&align=left"
+  alt="grid preset, left aligned"
+  description="grid preset, left aligned"
+/>
+
+<HeaderPreview
+  src="/header/transparent.svg?title=Ghost&subtitle=Blends+into+the+README&logo=react"
+  alt="transparent preset"
+  description="transparent preset — only the border and content render"
+/>
+
+## Sizes
+
+Use the `size` parameter for a named canvas, or set `width` and `height`
+directly. The default `banner` is sized to the GitHub README content column so
+it renders crisply without being downscaled.
+
+| Size | Dimensions | Use |
+| --- | --- | --- |
+| `banner` | 750 × 260 | README header. The default. |
+| `wide` | 1280 × 400 | Full-width hero. |
+| `social` | 1280 × 640 | GitHub social-preview slot. |
+| `square` | 640 × 640 | Avatar or card. |
+
+```md
+![Header](https://shieldcn.dev/header/dots.svg?title=Acme&size=social)
+```
+
+## Logo
+
+The `logo` parameter accepts the same sources as badges: a SimpleIcons slug
+(`react`), a React Icons name (`ri:FaReact`), a Lucide name (`lu:Rocket`), a
+`data:` URI, or a remote `https://` image URL. Remote images and data URIs let
+you use your own logo.
+
+```md
+![Header](https://shieldcn.dev/header/surface.svg?title=My+App&logo=https://example.com/logo.png)
+```
+
+Set `logoColor` to a hex value (without `#`) to recolor a path-based icon, or
+use `logoColor=brand` to paint a SimpleIcon in its brand color. Pass
+`logo=false` to hide the logo.
+
+## Themes and colors
+
+The `theme` parameter tints the accent — the glow on the `glow` preset and the
+default logo accent — using the same vocabulary as badges: `zinc`, `slate`,
+`blue`, `green`, `rose`, `orange`, `violet`, `purple`, `cyan`, and `emerald`.
+
+For full control, override colors directly:
+
+- `bg` — a solid background color, or `transparent`.
+- `gradient` — comma-separated hex stops with an optional trailing angle, for
+  example `gradient=6366f1,8b5cf6,135`.
+- `titleColor` and `subtitleColor` — text colors.
+- `glow` — the spotlight color.
+
+```md
+![Header](https://shieldcn.dev/header/surface.svg?title=Sunset&gradient=7c2d12,9f1239,86198f,120)
+```
+
+## Alignment and layout
+
+Headers are centered by default. Set `align=left` to left-align the logo,
+title, and subtitle. The hairline card border is on by default — pass
+`border=false` to remove it, and `watermark=true` to add a small `shieldcn.dev`
+mark in the corner.
+
+## Light and dark mode
+
+Every header reads correctly in both modes. Pass `mode=light` or `mode=dark`,
+or pair two images in a `<picture>` element so the banner follows the reader's
+GitHub theme. See [Light & Dark Mode](customization/light-dark-mode).
+
+## Parameters
+
+All header parameters, in addition to the shared `mode`, `theme`, and `font`
+parameters from the [API reference](api-reference).
+
+| Parameter | Values | Default |
+| --- | --- | --- |
+| `title` | string | — |
+| `subtitle` | string | — |
+| `logo` | slug, `ri:Name`, `lu:Name`, `data:` URI, `https://…`, or `false` | — |
+| `logoColor` | hex without `#`, or `brand` | auto |
+| `size` | `banner`, `wide`, `social`, `square` | `banner` |
+| `width` | 240–2400 (px) | per size |
+| `height` | 100–1600 (px) | per size |
+| `align` | `center`, `left` | `center` |
+| `bg` | hex without `#`, or `transparent` | preset |
+| `gradient` | comma-separated hex stops, optional trailing angle | — |
+| `glow` | hex without `#` | per preset |
+| `accent` | hex without `#` | theme |
+| `titleColor` | hex without `#` | auto |
+| `subtitleColor` | hex without `#` | auto |
+| `radius` | 0–120 (px) | 12 |
+| `border` | `true`, `false` | `true` |
+| `watermark` | `true`, `false` | `false` |
+| `pattern` | `dots`, `grid`, `graph`, `none` | preset |
+
+## Data source
+
+Headers are rendered on demand from the URL — there is no external data fetch,
+so they are fast and never rate-limited. Remote `logo` images are fetched once
+and cached for 24 hours.

--- a/packages/web/content/docs/headers/meta.json
+++ b/packages/web/content/docs/headers/meta.json
@@ -1,0 +1,6 @@
+{
+  "title": "Headers",
+  "pages": [
+    "index"
+  ]
+}

--- a/packages/web/content/docs/meta.json
+++ b/packages/web/content/docs/meta.json
@@ -12,6 +12,8 @@
     "...badges",
     "---Charts---",
     "...charts",
+    "---Headers---",
+    "...headers",
     "---Registry---",
     "...registry",
     "---Reference---",

--- a/packages/web/lib/header-builder-shared.ts
+++ b/packages/web/lib/header-builder-shared.ts
@@ -1,0 +1,112 @@
+/**
+ * shieldcn
+ * lib/header-builder-shared
+ *
+ * Shared state + URL builder for the repository-header generator UI.
+ * Mirrors badge-builder-shared but for /header/{preset}.svg images.
+ */
+
+export const HEADER_PRESETS = [
+  "surface",
+  "gradient",
+  "dots",
+  "grid",
+  "graph",
+  "glow",
+  "transparent",
+] as const
+export type HeaderPreset = (typeof HEADER_PRESETS)[number]
+
+export const HEADER_PRESET_LABELS: Record<HeaderPreset, string> = {
+  surface: "Surface",
+  gradient: "Gradient",
+  dots: "Dots",
+  grid: "Grid",
+  graph: "Graph",
+  glow: "Glow",
+  transparent: "Transparent",
+}
+
+export const HEADER_SIZES = ["banner", "wide", "social", "square"] as const
+export type HeaderSize = (typeof HEADER_SIZES)[number]
+
+export const HEADER_SIZE_LABELS: Record<HeaderSize, string> = {
+  banner: "Banner",
+  wide: "Wide",
+  social: "Social",
+  square: "Square",
+}
+
+export const HEADER_ALIGN = ["center", "left"] as const
+export const HEADER_FONTS = [
+  "inter",
+  "geist",
+  "geist-mono",
+  "jetbrains-mono",
+  "fira-code",
+  "roboto",
+  "space-grotesk",
+] as const
+export const HEADER_THEMES = [
+  "zinc",
+  "slate",
+  "blue",
+  "green",
+  "rose",
+  "orange",
+  "violet",
+  "purple",
+  "cyan",
+  "emerald",
+] as const
+
+export interface HeaderState {
+  preset: HeaderPreset
+  title: string
+  subtitle: string
+  logo: string
+  logoColor: string
+  size: HeaderSize
+  mode: "dark" | "light"
+  theme: string
+  align: "center" | "left"
+  font: string
+  border: boolean
+  watermark: boolean
+}
+
+export const HEADER_DEFAULTS: HeaderState = {
+  preset: "surface",
+  title: "Acme Toolkit",
+  subtitle: "A delightful component library",
+  logo: "",
+  logoColor: "",
+  size: "banner",
+  mode: "dark",
+  theme: "",
+  align: "center",
+  font: "inter",
+  border: true,
+  watermark: false,
+}
+
+/** Build the `/header/{preset}.svg?...` URL from builder state. */
+export function buildHeaderUrl(s: HeaderState, baseUrl: string): string {
+  const params = new URLSearchParams()
+  if (s.title) params.set("title", s.title)
+  if (s.subtitle) params.set("subtitle", s.subtitle)
+  if (s.logo) params.set("logo", s.logo)
+  if (s.logo && s.logoColor) params.set("logoColor", s.logoColor)
+  if (s.size && s.size !== "banner") params.set("size", s.size)
+  // Always include mode so the URL changes with the site theme (cache-safe).
+  params.set("mode", s.mode)
+  if (s.theme) params.set("theme", s.theme)
+  if (s.align && s.align !== "center") params.set("align", s.align)
+  if (s.font && s.font !== "inter") params.set("font", s.font)
+  if (s.watermark) params.set("watermark", "true")
+  if (!s.border) params.set("border", "false")
+
+  const preset = s.preset || "surface"
+  const qs = params.toString()
+  return `${baseUrl}/header/${preset}.svg${qs ? `?${qs}` : ""}`
+}

--- a/packages/web/mdx-components.tsx
+++ b/packages/web/mdx-components.tsx
@@ -22,6 +22,8 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     BadgePreviewCard,
     ChartPreview,
     ChartSandbox,
+    // Headers reuse the generic full-width image preview.
+    HeaderPreview: ChartPreview,
 
     // jalco-ui registry components
     CodeBlock,


### PR DESCRIPTION
## What

Adds **repository headers** — a URL-driven banner image generator for the top of a README. Users pick a premade shadcn-styled background, add their logo, a title, and a tagline, and embed a single image served entirely from shieldcn. Premade and prop-based, all encoded in the image URL — the same model as badges and charts.

```md
![header](https://shieldcn.dev/header/dots.svg?title=Acme+Toolkit&subtitle=A+delightful+component+library&logo=react)
```

## Why

Extends shieldcn from badges + charts to full README hero banners, served from the same engine. The repo's own README banner now uses a live `/header` image.

Closes #

## Type

- [x] `feat` — New feature

## How

**Core engine (`packages/core`)**
- `badges/render-header.ts` — hand-built SVG renderer (logo + title + subtitle), centered/left, height-scaled type, word-wrap + ellipsis, hairline card border, optional watermark.
- `badges/header-backgrounds.ts` — 7 shadcn-aligned premade presets (`surface`, `gradient`, `dots`, `grid`, `graph`, `glow`, `transparent`) on neutral zinc with a themed accent. Overrides: `bg` (incl. `transparent`), `gradient`, `pattern`, `glow`, `accent`, `theme`.
- `route-handler.ts` — `/header/{preset}.svg|.png|.json` branch: logo resolution (SimpleIcons / React Icons / Lucide, data URIs, remote images), size presets (`banner` 750×260 default, `wide`, `social`, `square`) plus `width`/`height`, `align`/`mode`/`radius`/`border`/`watermark`, analytics hook. Works for web and engine.
- `badges/fonts.ts` — bundles the TTFs into resvg so PNG output renders text inside the wasm sandbox.

**Web (`packages/web`)**
- `/header` — full-width two-pane generator (sidebar controls + filling live preview + Markdown/HTML/URL copy).
- Hero showcase features a header banner as a third product surface (compact, vertically centered with the heading); the "New" pill points to the generator.
- Docs at `/docs/headers`, API reference endpoints, sidebar + top-nav entries, a showcase section, and a README section.

## Testing

- 30 new tests (renderer unit + route e2e); full core suite green (110 passing).
- `tsc --noEmit` clean for `core` and `web`; `eslint --max-warnings 0` clean on all changed files.
- Visually verified in a browser: every preset in SVG + PNG (dark and light), the builder page, the hero, the docs page, and the showcase.

## Notes

- New components avoid the pre-existing `react-hooks/set-state-in-effect` debt (in `badge-builder.tsx`, unrelated and untouched) by using `useSyncExternalStore` + derived state.

## Screenshots

The banner at the top of this repo's README is itself a live shieldcn header. Hero, builder, docs, and showcase captures are available on request.
