### PR TITLE
feat(web): add README Studio visual builder

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,54 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Open-source maintainers and developers assembling a GitHub README, npm page, or
+docs site. They are technical, comfortable with Markdown, and value speed and
+correctness over hand-holding. The job to be done: compose a complete README
+(headers, badges, charts, tables, images, and prose) visually, then export
+clean, copy-paste Markdown they trust.
+
+## Product Purpose
+
+shieldcn serves styled SVG/PNG badges and charts rendered as shadcn/ui
+components. The README Studio (`/studio`) is the visual composer: a Figma-style
+editor with a block document, a live preview, and a property inspector that maps
+to the real badge/header/chart props. Success is a maintainer building and
+exporting a README in minutes without writing badge URLs by hand, with output
+that renders identically on GitHub.
+
+## Brand Personality
+
+Precise, technical, quietly confident. The product is a dev tool, so it should
+feel like Linear or Raycast: familiar, fast, and out of the way. Three words:
+exact, calm, legible. It practices what it preaches by being styled exactly like
+the shadcn/ui components it generates.
+
+## Anti-references
+
+Generic SaaS landing-page slop: gradient-text hero metrics, decorative
+glassmorphism, marketing buzzwords, oversized fluid display type in tool chrome,
+invented affordances for standard actions (custom modals/scrollbars). No
+playful/illustrative app aesthetic; this is a developer instrument.
+
+## Design Principles
+
+- Earned familiarity: standard editor patterns (layers, inspector, canvas) so a
+  user fluent in Figma/Notion trusts it immediately.
+- Practice what you preach: the studio is built from the same shadcn/ui tokens
+  and components it generates.
+- The tool disappears into the task: motion conveys state only; density where
+  it helps; no choreography that makes users wait.
+- Output integrity: the preview matches the exported Markdown, and the export is
+  clean GitHub-flavored Markdown.
+
+## Accessibility & Inclusion
+
+WCAG 2.1 AA. Body text ≥ 4.5:1, large/UI text ≥ 3:1. Every interactive control
+keyboard-operable with a visible focus indicator. Respect
+`prefers-reduced-motion`. Icon-only controls carry accessible names and
+tooltips. Badge output must remain readable in both light and dark modes.

--- a/packages/web/app/studio/page.tsx
+++ b/packages/web/app/studio/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import { SiteHeader } from "@/components/site-header"
+import { Studio } from "@/components/studio/studio"
+import { pageMetadata } from "@/lib/metadata"
+
+export const metadata: Metadata = pageMetadata({
+  title: "README Studio — Build your README visually",
+  description:
+    "A Figma-style studio for building your entire GitHub README. Compose Markdown text, header banners, badge rows, and charts with a live preview and a property inspector, then export clean Markdown.",
+  path: "/studio",
+  ogTitle: "shieldcn README Studio",
+})
+
+export default function StudioPage() {
+  return (
+    <div className="flex h-screen flex-col bg-background">
+      <SiteHeader />
+      <div className="min-h-0 flex-1">
+        <Studio />
+      </div>
+    </div>
+  )
+}

--- a/packages/web/components/animated-header.tsx
+++ b/packages/web/components/animated-header.tsx
@@ -93,6 +93,7 @@ const NAV = {
   spring: { type: "spring" as const, visualDuration: 0.4, bounce: 0.3 },
   items: [
     { href: "/docs", label: "Docs" },
+    { href: "/studio", label: "Studio" },
     { href: "/showcase", label: "Showcase" },
     { href: "/header", label: "Headers" },
     { href: "/gen", label: "Generator" },

--- a/packages/web/components/studio/canvas.tsx
+++ b/packages/web/components/studio/canvas.tsx
@@ -1,0 +1,152 @@
+/**
+ * shieldcn
+ * components/studio/canvas
+ *
+ * Live preview canvas for the README Studio. Renders the block document the way
+ * GitHub would: Markdown via react-markdown (GFM), and header/badge/chart/image
+ * blocks as live <img> elements. Each block is a selectable, Figma-style frame.
+ *
+ * Mode behavior: each image block renders in its OWN mode (default dark) and is
+ * NOT affected by the site light/dark toggle — unless `themeAware` is on, in
+ * which case the preview follows the site theme to demonstrate the <picture>
+ * swap that the exported Markdown will produce.
+ */
+
+"use client"
+
+import { memo } from "react"
+import ReactMarkdown from "react-markdown"
+import remarkGfm from "remark-gfm"
+import { withBadgeMode } from "@/lib/use-badge-mode"
+import { cn } from "@/lib/utils"
+import { buildBadgeUrl } from "@/lib/badge-builder-shared"
+import { buildHeaderUrl } from "@/lib/header-builder-shared"
+import {
+  buildChartUrl,
+  tableToGfm,
+  type Alignment,
+  type Block,
+} from "@/lib/studio-shared"
+
+const ALIGN_CLASS: Record<Alignment, string> = {
+  left: "justify-start text-left",
+  center: "justify-center text-center",
+  right: "justify-end text-right",
+}
+
+/** Ensure a `mode=` query param is present so the badge/chart mode is pinned. */
+function ensureMode(url: string, mode: "dark" | "light"): string {
+  if (/[?&]mode=/.test(url)) return url
+  return url + (url.includes("?") ? "&" : "?") + "mode=" + mode
+}
+
+function BlockContent({ block, siteMode, themeAware }: { block: Block; siteMode: "dark" | "light"; themeAware: boolean }) {
+  switch (block.type) {
+    case "markdown":
+      return (
+        <div className={cn(
+          "prose prose-sm dark:prose-invert max-w-none prose-headings:scroll-m-0 prose-pre:bg-muted prose-pre:text-foreground",
+          block.align === "center" && "text-center",
+          block.align === "right" && "text-right",
+        )}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{block.content || "*Empty text block — edit it in the inspector.*"}</ReactMarkdown>
+        </div>
+      )
+
+    case "header": {
+      const mode = themeAware ? siteMode : block.state.mode
+      const url = buildHeaderUrl({ ...block.state, mode }, "")
+      return (
+        <div className="flex justify-center">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={url} alt={block.alt} className="max-w-full rounded-md" />
+        </div>
+      )
+    }
+
+    case "badges": {
+      if (block.badges.length === 0) {
+        return <p className="text-sm text-muted-foreground italic">No badges yet — add one in the inspector.</p>
+      }
+      return (
+        <div className={cn("flex flex-wrap items-center gap-2", ALIGN_CLASS[block.align])}>
+          {block.badges.map(b => {
+            const mode = themeAware ? siteMode : (b.state.mode as "dark" | "light")
+            const url = withBadgeMode(buildBadgeUrl({ ...b.state, mode }, ""), mode)
+            return (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img key={b.id} src={url} alt={b.alt} className="h-[var(--badge-h,1.75rem)]" />
+            )
+          })}
+        </div>
+      )
+    }
+
+    case "table": {
+      const gfm = tableToGfm(block)
+      return (
+        <div className={cn(
+          "prose prose-sm dark:prose-invert max-w-none prose-table:my-0",
+          block.align === "center" && "flex justify-center",
+          block.align === "right" && "flex justify-end",
+        )}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{gfm}</ReactMarkdown>
+        </div>
+      )
+    }
+
+    case "image": {
+      if (!block.src) return <p className="text-sm text-muted-foreground italic">Add an image URL or path in the inspector.</p>
+      return (
+        <div className={cn("flex", ALIGN_CLASS[block.align ?? "left"])}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={block.src}
+            alt={block.alt}
+            style={block.width ? { width: `${block.width}px` } : undefined}
+            className="max-w-full rounded-md"
+          />
+        </div>
+      )
+    }
+
+    case "chart": {
+      const mode = themeAware ? siteMode : block.state.mode
+      const built = buildChartUrl({ ...block.state, mode }, "")
+      if (!built) return <p className="text-sm text-muted-foreground italic">Fill in the chart inputs in the inspector.</p>
+      const url = ensureMode(built, mode)
+      return (
+        <div className={cn("flex", ALIGN_CLASS[block.align])}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={url} alt={block.alt} className="max-w-full rounded-md" />
+        </div>
+      )
+    }
+  }
+}
+
+interface BlockFrameProps {
+  block: Block
+  selected: boolean
+  siteMode: "dark" | "light"
+  themeAware: boolean
+  onSelect: () => void
+}
+
+export const BlockFrame = memo(function BlockFrame({ block, selected, siteMode, themeAware, onSelect }: BlockFrameProps) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onSelect}
+      onKeyDown={e => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onSelect() } }}
+      className={cn(
+        "group relative cursor-pointer rounded-lg border-2 border-transparent px-4 py-3 transition-colors",
+        "hover:border-border/70 hover:bg-muted/30",
+        selected && "border-primary bg-primary/[0.03] hover:border-primary",
+      )}
+    >
+      <BlockContent block={block} siteMode={siteMode} themeAware={themeAware} />
+    </div>
+  )
+})

--- a/packages/web/components/studio/canvas.tsx
+++ b/packages/web/components/studio/canvas.tsx
@@ -143,6 +143,7 @@ export const BlockFrame = memo(function BlockFrame({ block, selected, siteMode, 
       className={cn(
         "group relative cursor-pointer rounded-lg border-2 border-transparent px-4 py-3 transition-colors",
         "hover:border-border/70 hover:bg-muted/30",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         selected && "border-primary bg-primary/[0.03] hover:border-primary",
       )}
     >

--- a/packages/web/components/studio/inspectors.tsx
+++ b/packages/web/components/studio/inspectors.tsx
@@ -796,7 +796,7 @@ export function TableInspector({ block, onChange }: { block: TableBlock; onChang
           {block.headers.map((_, c) => (
             <Tip key={`del-${c}`} label="Delete column">
               <button
-                className="flex h-5 items-center justify-center rounded text-muted-foreground/50 hover:text-destructive disabled:opacity-30"
+                className="flex h-5 items-center justify-center rounded text-muted-foreground/50 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-30"
                 onClick={() => removeColumn(c)}
                 disabled={cols <= 1}
                 aria-label={`Delete column ${c + 1}`}
@@ -820,7 +820,7 @@ export function TableInspector({ block, onChange }: { block: TableBlock; onChang
             return (
               <Tip key={`a-${c}`} label={`Column alignment: ${a} — click to change`}>
                 <button
-                  className="flex h-6 items-center justify-center gap-1 rounded border border-border bg-muted/40 text-[10px] text-muted-foreground hover:text-foreground"
+                  className="flex h-6 items-center justify-center gap-1 rounded border border-border bg-muted/40 text-[10px] text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
                   onClick={() => setAlign(c)}
                   aria-label={`Column ${c + 1} alignment: ${a}`}
                 >
@@ -839,7 +839,7 @@ export function TableInspector({ block, onChange }: { block: TableBlock; onChang
               ))}
               <Tip label="Delete row">
                 <button
-                  className="flex items-center justify-center rounded text-muted-foreground/50 hover:text-destructive disabled:opacity-30"
+                  className="flex items-center justify-center rounded text-muted-foreground/50 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-30"
                   onClick={() => removeRow(r)}
                   disabled={block.rows.length <= 1}
                   aria-label={`Delete row ${r + 1}`}

--- a/packages/web/components/studio/inspectors.tsx
+++ b/packages/web/components/studio/inspectors.tsx
@@ -1,0 +1,906 @@
+/**
+ * shieldcn
+ * components/studio/inspectors
+ *
+ * Property-editor panels for the README Studio inspector. One panel per block
+ * type (markdown, header, badges, chart). Each panel reads a block and emits an
+ * updated block via onChange. All controls use shadcn primitives + the project's
+ * shared pickers (LogoPicker, ColorInput).
+ */
+
+"use client"
+
+import { Fragment, useCallback, useMemo, useRef, useState } from "react"
+import { Plus, Trash2, GripVertical, Bold, Italic, Link2, Heading, List, Table, Shuffle, AlignLeft, AlignCenter, AlignRight } from "lucide-react"
+import { LogoPicker } from "@/components/logo-picker"
+import { ColorInput } from "@/components/color-input"
+import { SearchablePicker, type SearchablePickerFilter, type SearchablePickerSection } from "@/components/searchable-picker"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { Switch } from "@/components/ui/switch"
+import { Separator } from "@/components/ui/separator"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { cn } from "@/lib/utils"
+import {
+  BADGE_PRESETS,
+  resolveTemplate,
+  resolveDefaultLinkUrl,
+  VARIANTS,
+  VARIANT_LABELS,
+  allowedVariantsForPath,
+  SIZES,
+  FONTS,
+  THEMES,
+  type BadgePreset,
+  type BuilderState,
+} from "@/lib/badge-builder-shared"
+import {
+  HEADER_PRESETS,
+  HEADER_PRESET_LABELS,
+  HEADER_SIZES,
+  HEADER_SIZE_LABELS,
+  HEADER_FONTS,
+  HEADER_THEMES,
+  type HeaderState,
+} from "@/lib/header-builder-shared"
+import {
+  CHART_THEMES,
+  CHART_FONTS,
+  makeBadgeItem,
+  type Alignment,
+  type BadgeItem,
+  type BadgesBlock,
+  type ChartBlock,
+  randomPlaceholder,
+  PLACEHOLDER_IMAGE,
+  type ChartState,
+  type HeaderBlock,
+  type ImageBlock,
+  type MarkdownBlock,
+  type TableBlock,
+} from "@/lib/studio-shared"
+
+// ---------------------------------------------------------------------------
+// Small layout helpers
+// ---------------------------------------------------------------------------
+
+function Field({ label, children, htmlFor }: { label: string; children: React.ReactNode; htmlFor?: string }) {
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={htmlFor} className="text-xs font-medium text-muted-foreground">{label}</Label>
+      {children}
+    </div>
+  )
+}
+
+function Row({ children }: { children: React.ReactNode }) {
+  return <div className="grid grid-cols-2 gap-2">{children}</div>
+}
+
+function ToggleField({ label, checked, onCheckedChange }: { label: string; checked: boolean; onCheckedChange: (v: boolean) => void }) {
+  return (
+    <div className="flex items-center justify-between gap-2 py-0.5">
+      <Label className="text-xs font-medium text-muted-foreground">{label}</Label>
+      <Switch checked={checked} onCheckedChange={onCheckedChange} />
+    </div>
+  )
+}
+
+/** Wrap an interactive element with an accessible tooltip. */
+export function Tip({ label, children }: { label: string; children: React.ReactElement }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  )
+}
+
+function ToolBtn({ title, onClick, children }: { title: string; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <Tip label={title}>
+      <Button type="button" variant="ghost" size="icon" className="size-7 text-muted-foreground hover:text-foreground" aria-label={title} onClick={onClick}>
+        {children}
+      </Button>
+    </Tip>
+  )
+}
+
+function AlignControl({ value, onChange }: { value: Alignment; onChange: (v: Alignment) => void }) {
+  return (
+    <Field label="Alignment">
+      <ToggleGroup
+        type="single"
+        value={value}
+        onValueChange={v => v && onChange(v as Alignment)}
+        variant="outline"
+        size="sm"
+        className="w-full"
+      >
+        <ToggleGroupItem value="left" className="flex-1">Left</ToggleGroupItem>
+        <ToggleGroupItem value="center" className="flex-1">Center</ToggleGroupItem>
+        <ToggleGroupItem value="right" className="flex-1">Right</ToggleGroupItem>
+      </ToggleGroup>
+    </Field>
+  )
+}
+
+// Grouped preset options for the searchable badge type picker (index-based,
+// mirroring the homepage badge builder).
+const PRESET_GROUPS: Map<string, BadgePreset[]> = (() => {
+  const m = new Map<string, BadgePreset[]>()
+  for (const p of BADGE_PRESETS) {
+    const list = m.get(p.group) || []
+    list.push(p)
+    m.set(p.group, list)
+  }
+  return m
+})()
+
+const PRESET_GROUP_ORDER = [
+  "Custom", "Package", "GitHub", "Social", "Community", "Quality",
+  "Funding", "Editor marketplaces", "App stores", "Localization",
+  "Game/modding", "Other", "Group",
+]
+
+const PRESET_GROUP_NAMES = [
+  ...PRESET_GROUP_ORDER.filter(g => PRESET_GROUPS.has(g)),
+  ...Array.from(PRESET_GROUPS.keys()).filter(g => !PRESET_GROUP_ORDER.includes(g)),
+]
+
+function getPresetService(p: BadgePreset): string {
+  return p.service ?? p.group
+}
+
+function presetDisplay(p: BadgePreset): string {
+  const svc = getPresetService(p)
+  if (!svc || p.label.toLowerCase().startsWith(svc.toLowerCase())) return p.label
+  return `${svc} ${p.label}`
+}
+
+const PRESET_FILTERS: SearchablePickerFilter[] = (() => {
+  const order = ["Custom", "npm", "GitHub", "Docker", "PyPI", "Crates.io", "JSR", "Discord", "NBA", "Reddit", "X", "YouTube", "Country flag", "Group"]
+  const services = Array.from(new Set(BADGE_PRESETS.map(getPresetService)))
+  const ordered = [
+    ...order.filter(s => services.includes(s)),
+    ...services.filter(s => !order.includes(s)),
+  ]
+  return [{ value: "all", label: "All" }, ...ordered.map(s => ({ value: s, label: s }))]
+})()
+
+function presetMatchesSearch(p: BadgePreset, search: string, serviceFilter: string): boolean {
+  const service = getPresetService(p)
+  if (serviceFilter !== "all" && service !== serviceFilter) return false
+  const q = search.trim().toLowerCase()
+  if (!q) return true
+  const haystack = [
+    p.label, service, p.group, p.template,
+    ...(p.searchKeywords ?? []),
+    ...p.params.flatMap(param => [param.key, param.label, param.placeholder]),
+  ].join(" ").toLowerCase()
+  return haystack.includes(q)
+}
+
+/** Reverse-match a badge path back to a preset index + param values. */
+function findPresetForPath(path: string): { preset: BadgePreset; idx: number; values: Record<string, string> } | null {
+  const clean = path.replace(/\?.*$/, "")
+  for (let idx = 0; idx < BADGE_PRESETS.length; idx++) {
+    const preset = BADGE_PRESETS[idx]
+    if (preset.customResolver === "static") continue
+    let pattern = preset.template.replace(/\./g, "\\.").replace(/\{([^}]+)\}/g, "([^/]+)")
+    pattern = `^${pattern}$`
+    const match = clean.match(new RegExp(pattern))
+    if (match) {
+      const values: Record<string, string> = {}
+      preset.params.forEach((p, i) => { values[p.key] = match[i + 1] || p.default })
+      return { preset, idx, values }
+    }
+  }
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Markdown inspector
+// ---------------------------------------------------------------------------
+
+export function MarkdownInspector({ block, onChange }: { block: MarkdownBlock; onChange: (b: MarkdownBlock) => void }) {
+  const ref = useRef<HTMLTextAreaElement>(null)
+
+  // Wrap the current selection (or insert at caret) with before/after tokens.
+  const surround = useCallback((before: string, after = before, placeholder = "text") => {
+    const el = ref.current
+    if (!el) return
+    const start = el.selectionStart
+    const end = el.selectionEnd
+    const value = block.content
+    const selected = value.slice(start, end) || placeholder
+    const next = value.slice(0, start) + before + selected + after + value.slice(end)
+    onChange({ ...block, content: next })
+    requestAnimationFrame(() => {
+      el.focus()
+      el.selectionStart = start + before.length
+      el.selectionEnd = start + before.length + selected.length
+    })
+  }, [block, onChange])
+
+  // Prefix the start of the current line(s) with a token (headings, lists).
+  const prefixLine = useCallback((token: string) => {
+    const el = ref.current
+    if (!el) return
+    const start = el.selectionStart
+    const value = block.content
+    const lineStart = value.lastIndexOf("\n", start - 1) + 1
+    const next = value.slice(0, lineStart) + token + value.slice(lineStart)
+    onChange({ ...block, content: next })
+    requestAnimationFrame(() => {
+      el.focus()
+      el.selectionStart = el.selectionEnd = start + token.length
+    })
+  }, [block, onChange])
+
+  // Insert a standalone block snippet at the caret, padded with blank lines so
+  // GitHub-flavored Markdown (tables, etc.) parses correctly.
+  const insertSnippet = useCallback((snippet: string) => {
+    const el = ref.current
+    if (!el) return
+    const start = el.selectionStart
+    const value = block.content
+    const before = value.slice(0, start)
+    const after = value.slice(start)
+    const lead = before && !before.endsWith("\n\n") ? (before.endsWith("\n") ? "\n" : "\n\n") : ""
+    const trail = after && !after.startsWith("\n") ? "\n\n" : ""
+    const insertion = lead + snippet + trail
+    const next = before + insertion + after
+    onChange({ ...block, content: next })
+    requestAnimationFrame(() => {
+      el.focus()
+      const pos = start + insertion.length
+      el.selectionStart = el.selectionEnd = pos
+    })
+  }, [block, onChange])
+
+  const insertTable = useCallback(() => {
+    insertSnippet("| Column | Column |\n| --- | --- |\n| Cell | Cell |\n| Cell | Cell |")
+  }, [insertSnippet])
+
+  const insertLink = useCallback(() => {
+    const el = ref.current
+    if (!el) return
+    const start = el.selectionStart
+    const end = el.selectionEnd
+    const selected = block.content.slice(start, end) || "link text"
+    const snippet = `[${selected}](https://)`
+    const next = block.content.slice(0, start) + snippet + block.content.slice(end)
+    onChange({ ...block, content: next })
+    requestAnimationFrame(() => {
+      el.focus()
+      // Select the URL placeholder so the user can type it immediately.
+      const urlStart = start + selected.length + 3
+      el.selectionStart = urlStart
+      el.selectionEnd = urlStart + 8
+    })
+  }, [block, onChange])
+
+  return (
+    <div className="space-y-4">
+      <Field label="Alignment">
+        <ToggleGroup
+          type="single"
+          value={block.align ?? "left"}
+          onValueChange={v => v && onChange({ ...block, align: v as Alignment })}
+          variant="outline"
+          size="sm"
+          className="w-full"
+        >
+          <ToggleGroupItem value="left" className="flex-1" aria-label="Align left"><AlignLeft className="size-3.5" /></ToggleGroupItem>
+          <ToggleGroupItem value="center" className="flex-1" aria-label="Align center"><AlignCenter className="size-3.5" /></ToggleGroupItem>
+          <ToggleGroupItem value="right" className="flex-1" aria-label="Align right"><AlignRight className="size-3.5" /></ToggleGroupItem>
+        </ToggleGroup>
+      </Field>
+
+      <Field label="Markdown" htmlFor="md-content">
+        <div className="flex items-center gap-0.5 rounded-md border border-border bg-muted/30 p-1">
+          <ToolBtn title="Bold" onClick={() => surround("**")}><Bold className="size-3.5" /></ToolBtn>
+          <ToolBtn title="Italic" onClick={() => surround("_")}><Italic className="size-3.5" /></ToolBtn>
+          <ToolBtn title="Link" onClick={insertLink}><Link2 className="size-3.5" /></ToolBtn>
+          <Separator orientation="vertical" className="mx-0.5 h-4" />
+          <ToolBtn title="Heading" onClick={() => prefixLine("## ")}><Heading className="size-3.5" /></ToolBtn>
+          <ToolBtn title="List item" onClick={() => prefixLine("- ")}><List className="size-3.5" /></ToolBtn>
+          <ToolBtn title="Table" onClick={insertTable}><Table className="size-3.5" /></ToolBtn>
+          <ToolBtn title="Inline code" onClick={() => surround("`", "`", "code")}><span className="font-mono text-xs">{"</>"}</span></ToolBtn>
+        </div>
+        <Textarea
+          ref={ref}
+          id="md-content"
+          value={block.content}
+          onChange={e => onChange({ ...block, content: e.target.value })}
+          rows={14}
+          className="mt-1.5 font-mono text-xs leading-relaxed resize-y"
+          placeholder="## Heading&#10;&#10;Write GitHub-flavored Markdown…"
+        />
+      </Field>
+      <p className="text-xs text-muted-foreground">
+        Select text and use the toolbar, or write GitHub-flavored Markdown directly. Centering exports as an aligned <code className="text-foreground">&lt;div&gt;</code>.
+      </p>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Header inspector
+// ---------------------------------------------------------------------------
+
+export function HeaderInspector({ block, onChange }: { block: HeaderBlock; onChange: (b: HeaderBlock) => void }) {
+  const s = block.state
+  const set = useCallback((patch: Partial<HeaderState>) => onChange({ ...block, state: { ...block.state, ...patch } }), [block, onChange])
+
+  return (
+    <div className="space-y-4">
+      <Field label="Style">
+        <Select value={s.preset} onValueChange={v => set({ preset: v as HeaderState["preset"] })}>
+          <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+          <SelectContent>
+            {HEADER_PRESETS.map(p => (
+              <SelectItem key={p} value={p}>{HEADER_PRESET_LABELS[p]}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </Field>
+
+      <Field label="Title" htmlFor="hdr-title">
+        <Input id="hdr-title" value={s.title} onChange={e => set({ title: e.target.value })} placeholder="Acme Toolkit" />
+      </Field>
+      <Field label="Subtitle" htmlFor="hdr-sub">
+        <Textarea
+          id="hdr-sub"
+          value={s.subtitle}
+          onChange={e => set({ subtitle: e.target.value })}
+          placeholder="A delightful component library"
+          rows={2}
+          className="min-h-9 resize-y text-sm"
+        />
+      </Field>
+
+      <Field label="Logo">
+        <LogoPicker value={s.logo} onChange={v => set({ logo: v })} />
+      </Field>
+      {s.logo ? (
+        <Field label="Logo color">
+          <ColorInput value={s.logoColor} onChange={v => set({ logoColor: v })} />
+        </Field>
+      ) : null}
+
+      <Row>
+        <Field label="Size">
+          <Select value={s.size} onValueChange={v => set({ size: v as HeaderState["size"] })}>
+            <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {HEADER_SIZES.map(sz => <SelectItem key={sz} value={sz}>{HEADER_SIZE_LABELS[sz]}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </Field>
+        <Field label="Theme">
+          <Select value={s.theme || "_none"} onValueChange={v => set({ theme: v === "_none" ? "" : v })}>
+            <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="_none">Default</SelectItem>
+              {HEADER_THEMES.map(t => <SelectItem key={t} value={t}>{t}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </Field>
+      </Row>
+
+      <Row>
+        <Field label="Align">
+          <Select value={s.align} onValueChange={v => set({ align: v as HeaderState["align"] })}>
+            <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="center">Center</SelectItem>
+              <SelectItem value="left">Left</SelectItem>
+            </SelectContent>
+          </Select>
+        </Field>
+        <Field label="Font">
+          <Select value={s.font} onValueChange={v => set({ font: v })}>
+            <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {HEADER_FONTS.map(f => <SelectItem key={f} value={f}>{f}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </Field>
+      </Row>
+
+      <Separator />
+      <ToggleField label="Border" checked={s.border} onCheckedChange={v => set({ border: v })} />
+      <ToggleField label="Watermark" checked={s.watermark} onCheckedChange={v => set({ watermark: v })} />
+
+      <Separator />
+      <Field label="Alt text" htmlFor="hdr-alt">
+        <Input id="hdr-alt" value={block.alt} onChange={e => onChange({ ...block, alt: e.target.value })} placeholder="header" />
+      </Field>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Badge item editor (one badge inside a row)
+// ---------------------------------------------------------------------------
+
+function BadgeItemEditor({ item, onChange, onRemove, index }: {
+  item: BadgeItem
+  onChange: (b: BadgeItem) => void
+  onRemove: () => void
+  index: number
+}) {
+  const s = item.state
+  const set = useCallback((patch: Partial<BuilderState>) => onChange({ ...item, state: { ...item.state, ...patch } }), [item, onChange])
+
+  const [search, setSearch] = useState("")
+  const [filter, setFilter] = useState("all")
+
+  const matched = useMemo(() => findPresetForPath(s.path), [s.path])
+  const selectedValue = matched ? String(matched.idx) : ""
+  const paramValues = useMemo(() => matched?.values ?? {}, [matched])
+
+  const allowed = useMemo(() => allowedVariantsForPath(s.path), [s.path])
+
+  const sections = useMemo<SearchablePickerSection[]>(() => {
+    return PRESET_GROUP_NAMES.map(group => {
+      const presets = PRESET_GROUPS.get(group) ?? []
+      const items = presets
+        .filter(p => presetMatchesSearch(p, search, filter))
+        .map(p => ({ value: String(BADGE_PRESETS.indexOf(p)), label: presetDisplay(p), tag: getPresetService(p) }))
+      return { heading: group, items }
+    })
+  }, [search, filter])
+
+  const onPresetChange = useCallback((indexStr: string) => {
+    const idx = parseInt(indexStr, 10)
+    const preset = BADGE_PRESETS[idx]
+    if (!preset) return
+    const values: Record<string, string> = {}
+    preset.params.forEach(p => { values[p.key] = p.default })
+    const path = resolveTemplate(preset, values)
+    const linkUrl = resolveDefaultLinkUrl(preset, values)
+    onChange({ ...item, alt: preset.label, state: { ...item.state, path, linkUrl } })
+    setSearch("")
+  }, [item, onChange])
+
+  const onParamChange = useCallback((paramKey: string, value: string) => {
+    if (!matched) return
+    const values = { ...paramValues, [paramKey]: value }
+    const path = resolveTemplate(matched.preset, values)
+    const linkUrl = resolveDefaultLinkUrl(matched.preset, values)
+    set({ path, linkUrl })
+  }, [matched, paramValues, set])
+
+  return (
+    <div className="rounded-md border border-border bg-muted/30 p-3 space-y-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-semibold text-foreground">Badge {index + 1}</span>
+        <Tip label="Remove badge">
+          <Button variant="ghost" size="icon" className="size-6 text-muted-foreground hover:text-destructive" onClick={onRemove} aria-label={`Remove badge ${index + 1}`}>
+            <Trash2 className="size-3.5" />
+          </Button>
+        </Tip>
+      </div>
+
+      <Field label="Type">
+        <SearchablePicker
+          value={selectedValue}
+          triggerLabel={matched ? presetDisplay(matched.preset) : "Custom path"}
+          placeholder="Search badge types..."
+          emptyLabel="No badge type found."
+          search={search}
+          onSearchChange={setSearch}
+          filters={PRESET_FILTERS}
+          activeFilter={filter}
+          onFilterChange={setFilter}
+          sections={sections}
+          onValueChange={onPresetChange}
+          triggerClassName="w-full"
+          contentClassName="w-[min(420px,calc(100vw-2rem))]"
+          listClassName="max-h-[320px]"
+        />
+      </Field>
+
+      {matched && matched.preset.params.length > 0 ? (
+        <div className="space-y-2">
+          {matched.preset.params.map(param => (
+            <Field key={param.key} label={param.label}>
+              <Input
+                value={paramValues[param.key] ?? ""}
+                onChange={e => onParamChange(param.key, e.target.value)}
+                placeholder={param.placeholder}
+              />
+            </Field>
+          ))}
+        </div>
+      ) : (
+        <Field label="Path">
+          <Input value={s.path} onChange={e => set({ path: e.target.value })} placeholder="/badge/build-passing-22c55e.svg" className="font-mono text-xs" />
+        </Field>
+      )}
+
+      <Row>
+        <Field label="Variant">
+          <Select value={s.variant} onValueChange={v => set({ variant: v })}>
+            <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {VARIANTS.map(v => (
+                <SelectItem key={v} value={v} disabled={!allowed.includes(v)}>{VARIANT_LABELS[v] ?? v}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Field>
+        <Field label="Size">
+          <Select value={s.size} onValueChange={v => set({ size: v })}>
+            <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {SIZES.map(v => <SelectItem key={v} value={v}>{v}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </Field>
+      </Row>
+
+      <Row>
+        <Field label="Theme">
+          <Select value={s.theme || "_none"} onValueChange={v => set({ theme: v })}>
+            <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {THEMES.map(v => <SelectItem key={v} value={v}>{v === "_none" ? "Default" : v}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </Field>
+        <Field label="Font">
+          <Select value={s.font} onValueChange={v => set({ font: v })}>
+            <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {FONTS.map(v => <SelectItem key={v} value={v}>{v}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </Field>
+      </Row>
+
+      <Field label="Logo">
+        <LogoPicker value={s.logo} onChange={v => set({ logo: v })} />
+      </Field>
+
+      <Row>
+        <Field label="Label override">
+          <Input value={s.label} onChange={e => set({ label: e.target.value })} placeholder="auto" />
+        </Field>
+        <Field label="Color">
+          <ColorInput value={s.color} onChange={v => set({ color: v })} />
+        </Field>
+      </Row>
+
+      <ToggleField label="Split label / value" checked={s.split} onCheckedChange={v => set({ split: v })} />
+      {s.split ? (
+        <div className="space-y-3 rounded-md border border-dashed border-border bg-background/50 p-3">
+          <p className="text-xs text-muted-foreground">Split badges render the label and value as separate pills. Style each side:</p>
+          <Row>
+            <Field label="Label bg"><ColorInput value={s.labelColor} onChange={v => set({ labelColor: v })} /></Field>
+            <Field label="Value bg"><ColorInput value={s.valueColor} onChange={v => set({ valueColor: v })} /></Field>
+          </Row>
+          <Row>
+            <Field label="Label text"><ColorInput value={s.labelTextColor} onChange={v => set({ labelTextColor: v })} /></Field>
+            <Field label="Label opacity"><Input value={s.labelOpacity} onChange={e => set({ labelOpacity: e.target.value })} placeholder="0.7" /></Field>
+          </Row>
+        </div>
+      ) : null}
+
+      <Field label="Link URL">
+        <Input value={s.linkUrl} onChange={e => set({ linkUrl: e.target.value })} placeholder="https://…" className="text-xs" />
+      </Field>
+    </div>
+  )
+}
+
+export function BadgesInspector({ block, onChange }: { block: BadgesBlock; onChange: (b: BadgesBlock) => void }) {
+  const updateItem = useCallback((id: string, next: BadgeItem) => {
+    onChange({ ...block, badges: block.badges.map(b => (b.id === id ? next : b)) })
+  }, [block, onChange])
+
+  const removeItem = useCallback((id: string) => {
+    onChange({ ...block, badges: block.badges.filter(b => b.id !== id) })
+  }, [block, onChange])
+
+  const addItem = useCallback(() => {
+    onChange({ ...block, badges: [...block.badges, makeBadgeItem({ path: "/badge/label-value-22c55e.svg" })] })
+  }, [block, onChange])
+
+  return (
+    <div className="space-y-4">
+      <AlignControl value={block.align} onChange={v => onChange({ ...block, align: v })} />
+      <Separator />
+      <div className="space-y-3">
+        {block.badges.map((item, i) => (
+          <BadgeItemEditor
+            key={item.id}
+            item={item}
+            index={i}
+            onChange={next => updateItem(item.id, next)}
+            onRemove={() => removeItem(item.id)}
+          />
+        ))}
+      </div>
+      <Button variant="outline" size="sm" className="w-full" onClick={addItem}>
+        <Plus className="size-3.5" /> Add badge
+      </Button>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Chart inspector
+// ---------------------------------------------------------------------------
+
+export function ChartInspector({ block, onChange }: { block: ChartBlock; onChange: (b: ChartBlock) => void }) {
+  const s = block.state
+  const set = useCallback((patch: Partial<ChartState>) => onChange({ ...block, state: { ...block.state, ...patch } }), [block, onChange])
+
+  return (
+    <div className="space-y-4">
+      <Field label="Chart">
+        <Select value={s.kind} onValueChange={v => set({ kind: v as ChartState["kind"] })}>
+          <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="stars">GitHub stars</SelectItem>
+            <SelectItem value="issues">GitHub issues</SelectItem>
+            <SelectItem value="npm">npm downloads</SelectItem>
+            <SelectItem value="json">Inline JSON</SelectItem>
+          </SelectContent>
+        </Select>
+      </Field>
+
+      {(s.kind === "stars" || s.kind === "issues") ? (
+        <Row>
+          <Field label="Owner"><Input value={s.owner} onChange={e => set({ owner: e.target.value })} placeholder="vercel" /></Field>
+          <Field label="Repo"><Input value={s.repo} onChange={e => set({ repo: e.target.value })} placeholder="next.js" /></Field>
+        </Row>
+      ) : null}
+
+      {s.kind === "npm" ? (
+        <Row>
+          <Field label="Package"><Input value={s.package} onChange={e => set({ package: e.target.value })} placeholder="zod" /></Field>
+          <Field label="Days"><Input value={s.days} onChange={e => set({ days: e.target.value })} placeholder="365" /></Field>
+        </Row>
+      ) : null}
+
+      {s.kind === "json" ? (
+        <>
+          <Field label="Values (comma-separated)">
+            <Input value={s.values} onChange={e => set({ values: e.target.value })} placeholder="10,25,40,30,60" className="font-mono text-xs" />
+          </Field>
+          <Field label="Data label"><Input value={s.dataLabel} onChange={e => set({ dataLabel: e.target.value })} placeholder="optional" /></Field>
+        </>
+      ) : null}
+
+      <Field label="Title"><Input value={s.title} onChange={e => set({ title: e.target.value })} placeholder="optional" /></Field>
+
+      <Row>
+        <Field label="Theme">
+          <Select value={s.theme} onValueChange={v => set({ theme: v })}>
+            <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {CHART_THEMES.map(t => <SelectItem key={t} value={t}>{t === "_none" ? "Default" : t}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </Field>
+        <Field label="Font">
+          <Select value={s.font} onValueChange={v => set({ font: v })}>
+            <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {CHART_FONTS.map(f => <SelectItem key={f} value={f}>{f}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </Field>
+      </Row>
+
+      <Row>
+        <Field label="Line color"><ColorInput value={s.color} onChange={v => set({ color: v })} /></Field>
+        <Field label="Fill color"><ColorInput value={s.fill} onChange={v => set({ fill: v })} /></Field>
+      </Row>
+
+      <Row>
+        <Field label="Width"><Input value={s.width} onChange={e => set({ width: e.target.value })} placeholder="800" /></Field>
+        <Field label="Height"><Input value={s.height} onChange={e => set({ height: e.target.value })} placeholder="400" /></Field>
+      </Row>
+
+      <Field label="Icon (SimpleIcons slug)">
+        <LogoPicker value={s.icon} onChange={v => set({ icon: v })} />
+      </Field>
+
+      <Separator />
+      <ToggleField label="Area fill" checked={s.area} onCheckedChange={v => set({ area: v })} />
+      <ToggleField label="Border" checked={s.border} onCheckedChange={v => set({ border: v })} />
+      <ToggleField label="Logo watermark" checked={s.logo} onCheckedChange={v => set({ logo: v })} />
+      <ToggleField label="Transparent background" checked={s.transparent} onCheckedChange={v => set({ transparent: v })} />
+
+      <Separator />
+      <AlignControl value={block.align} onChange={v => onChange({ ...block, align: v })} />
+      <Field label="Alt text"><Input value={block.alt} onChange={e => onChange({ ...block, alt: e.target.value })} placeholder="chart" /></Field>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Table inspector — spreadsheet-style grid editor
+// ---------------------------------------------------------------------------
+
+const ALIGN_ICON: Record<Alignment, React.ComponentType<{ className?: string }>> = {
+  left: AlignLeft,
+  center: AlignCenter,
+  right: AlignRight,
+}
+
+function nextAlign(a: Alignment): Alignment {
+  return a === "left" ? "center" : a === "center" ? "right" : "left"
+}
+
+export function TableInspector({ block, onChange }: { block: TableBlock; onChange: (b: TableBlock) => void }) {
+  const cols = block.headers.length
+
+  const setHeader = (c: number, val: string) => {
+    const headers = block.headers.slice(); headers[c] = val
+    onChange({ ...block, headers })
+  }
+  const setAlign = (c: number) => {
+    const aligns = block.aligns.slice(); aligns[c] = nextAlign(aligns[c] ?? "left")
+    onChange({ ...block, aligns })
+  }
+  const setCell = (r: number, c: number, val: string) => {
+    const rows = block.rows.map(row => row.slice())
+    while (rows[r].length < cols) rows[r].push("")
+    rows[r][c] = val
+    onChange({ ...block, rows })
+  }
+  const addColumn = () => onChange({
+    ...block,
+    headers: [...block.headers, "Column"],
+    aligns: [...block.aligns, "left"],
+    rows: block.rows.map(row => [...row, ""]),
+  })
+  const removeColumn = (c: number) => onChange({
+    ...block,
+    headers: block.headers.filter((_, i) => i !== c),
+    aligns: block.aligns.filter((_, i) => i !== c),
+    rows: block.rows.map(row => row.filter((_, i) => i !== c)),
+  })
+  const addRow = () => onChange({ ...block, rows: [...block.rows, Array.from({ length: cols }, () => "")] })
+  const removeRow = (r: number) => onChange({ ...block, rows: block.rows.filter((_, i) => i !== r) })
+
+  const gridStyle = { gridTemplateColumns: `repeat(${cols}, minmax(92px, 1fr)) 1.75rem` }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2">
+        <Button variant="outline" size="sm" className="flex-1" onClick={addColumn}><Plus className="size-3.5" /> Column</Button>
+        <Button variant="outline" size="sm" className="flex-1" onClick={addRow}><Plus className="size-3.5" /> Row</Button>
+      </div>
+
+      <div className="overflow-x-auto pb-1">
+        <div className="grid min-w-full gap-1" style={gridStyle}>
+          {/* Delete-column buttons */}
+          {block.headers.map((_, c) => (
+            <Tip key={`del-${c}`} label="Delete column">
+              <button
+                className="flex h-5 items-center justify-center rounded text-muted-foreground/50 hover:text-destructive disabled:opacity-30"
+                onClick={() => removeColumn(c)}
+                disabled={cols <= 1}
+                aria-label={`Delete column ${c + 1}`}
+              >
+                <Trash2 className="size-3" />
+              </button>
+            </Tip>
+          ))}
+          <span />
+
+          {/* Header inputs */}
+          {block.headers.map((h, c) => (
+            <Input key={`h-${c}`} value={h} onChange={e => setHeader(c, e.target.value)} placeholder="Header" className="h-8 text-xs font-medium" />
+          ))}
+          <span />
+
+          {/* Per-column alignment */}
+          {block.headers.map((_, c) => {
+            const a = block.aligns[c] ?? "left"
+            const Icon = ALIGN_ICON[a]
+            return (
+              <Tip key={`a-${c}`} label={`Column alignment: ${a} — click to change`}>
+                <button
+                  className="flex h-6 items-center justify-center gap-1 rounded border border-border bg-muted/40 text-[10px] text-muted-foreground hover:text-foreground"
+                  onClick={() => setAlign(c)}
+                  aria-label={`Column ${c + 1} alignment: ${a}`}
+                >
+                  <Icon className="size-3" /> {a}
+                </button>
+              </Tip>
+            )
+          })}
+          <span />
+
+          {/* Body cells */}
+          {block.rows.map((row, r) => (
+            <Fragment key={`r-${r}`}>
+              {block.headers.map((_, c) => (
+                <Input key={`c-${r}-${c}`} value={row[c] ?? ""} onChange={e => setCell(r, c, e.target.value)} placeholder="—" className="h-8 text-xs" />
+              ))}
+              <Tip label="Delete row">
+                <button
+                  className="flex items-center justify-center rounded text-muted-foreground/50 hover:text-destructive disabled:opacity-30"
+                  onClick={() => removeRow(r)}
+                  disabled={block.rows.length <= 1}
+                  aria-label={`Delete row ${r + 1}`}
+                >
+                  <Trash2 className="size-3.5" />
+                </button>
+              </Tip>
+            </Fragment>
+          ))}
+        </div>
+      </div>
+
+      <Separator />
+      <AlignControl value={block.align ?? "left"} onChange={v => onChange({ ...block, align: v })} />
+      <p className="text-xs text-muted-foreground">Edit cells directly like a spreadsheet. Click a column’s alignment chip to cycle left / center / right. Exports as a GitHub-flavored Markdown table.</p>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Image inspector
+// ---------------------------------------------------------------------------
+
+export function ImageInspector({ block, onChange }: { block: ImageBlock; onChange: (b: ImageBlock) => void }) {
+  return (
+    <div className="space-y-4">
+      <Field label="Image URL or path" htmlFor="img-src">
+        <div className="flex gap-1.5">
+          <Input
+            id="img-src"
+            value={block.src}
+            onChange={e => onChange({ ...block, src: e.target.value })}
+            placeholder={PLACEHOLDER_IMAGE}
+            className="font-mono text-xs"
+          />
+          <Tip label="Random placeholder image">
+            <Button variant="outline" size="icon" className="size-9 shrink-0" aria-label="Random placeholder image" onClick={() => onChange({ ...block, src: randomPlaceholder(block.src) })}>
+              <Shuffle className="size-3.5" />
+            </Button>
+          </Tip>
+        </div>
+      </Field>
+      <p className="text-xs text-muted-foreground">Paste any image URL or a repo-relative path (e.g. <code className="text-foreground">./docs/hero.png</code>). The shuffle button drops in a placeholder photo.</p>
+
+      <Field label="Alt text" htmlFor="img-alt">
+        <Input id="img-alt" value={block.alt} onChange={e => onChange({ ...block, alt: e.target.value })} placeholder="image" />
+      </Field>
+
+      <Row>
+        <Field label="Width (px)"><Input value={block.width ?? ""} onChange={e => onChange({ ...block, width: e.target.value })} placeholder="auto" /></Field>
+        <Field label="Link URL"><Input value={block.link ?? ""} onChange={e => onChange({ ...block, link: e.target.value })} placeholder="https://…" className="text-xs" /></Field>
+      </Row>
+
+      <Separator />
+      <AlignControl value={block.align ?? "left"} onChange={v => onChange({ ...block, align: v })} />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Re-export grip icon for the layers panel convenience.
+// ---------------------------------------------------------------------------
+export { GripVertical }
+export { cn }

--- a/packages/web/components/studio/studio.tsx
+++ b/packages/web/components/studio/studio.tsx
@@ -19,7 +19,7 @@
 import { useCallback, useEffect, useState } from "react"
 import {
   Copy, Check, Download, RotateCcw, Plus, Trash2, Copy as Duplicate,
-  ChevronUp, ChevronDown, Type, Image as ImageIcon, Images, Tag, LineChart, Table as TableIcon, Code2, Eye, GripVertical, SunMoon,
+  ChevronUp, ChevronDown, Type, Image as ImageIcon, Images, Tag, LineChart, Table as TableIcon, Code2, Eye, GripVertical, SunMoon, X,
 } from "lucide-react"
 import { useSyncExternalStore } from "react"
 import { useBadgeMode } from "@/lib/use-badge-mode"
@@ -110,6 +110,7 @@ export function Studio() {
   const [copied, setCopied] = useState(false)
   const [view, setView] = useState<"design" | "code">("design")
   const [themeAware, setThemeAware] = useState(false)
+  const [mobileInspectorOpen, setMobileInspectorOpen] = useState(false)
   const [dragFrom, setDragFrom] = useState<number | null>(null)
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null)
 
@@ -147,6 +148,14 @@ export function Studio() {
   }, [themeAware, hydrated])
 
   const selected = blocks.find(b => b.id === selectedId) ?? null
+  const selectedIndex = blocks.findIndex(b => b.id === selectedId)
+
+  // Selecting a block opens the inspector. On mobile that inspector is a
+  // bottom sheet; on desktop the open flag is inert (sheet is md:hidden).
+  const selectBlock = useCallback((id: string) => {
+    setSelectedId(id)
+    setMobileInspectorOpen(true)
+  }, [])
 
   // --- mutations -----------------------------------------------------------
 
@@ -164,6 +173,7 @@ export function Studio() {
       return copy
     })
     setSelectedId(block.id)
+    setMobileInspectorOpen(true)
   }, [selectedId])
 
   const removeBlock = useCallback((id: string) => {
@@ -227,6 +237,22 @@ export function Studio() {
   if (!hydrated) {
     return <div className="flex h-[60vh] items-center justify-center text-sm text-muted-foreground">Loading studio…</div>
   }
+
+  const inspectorBody = !selected ? (
+    <p className="text-sm text-muted-foreground">Select a block to edit its properties.</p>
+  ) : selected.type === "markdown" ? (
+    <MarkdownInspector block={selected as MarkdownBlock} onChange={updateBlock} />
+  ) : selected.type === "header" ? (
+    <HeaderInspector block={selected as HeaderBlock} onChange={updateBlock} />
+  ) : selected.type === "badges" ? (
+    <BadgesInspector block={selected as BadgesBlock} onChange={updateBlock} />
+  ) : selected.type === "table" ? (
+    <TableInspector block={selected as TableBlock} onChange={updateBlock} />
+  ) : selected.type === "image" ? (
+    <ImageInspector block={selected as ImageBlock} onChange={updateBlock} />
+  ) : (
+    <ChartInspector block={selected as ChartBlock} onChange={updateBlock} />
+  )
 
   return (
     <TooltipProvider delayDuration={200}>
@@ -321,15 +347,15 @@ export function Studio() {
                     )}
                   >
                     <GripVertical className="size-3.5 shrink-0 cursor-grab text-muted-foreground/60 active:cursor-grabbing" aria-hidden />
-                    <button className="flex min-w-0 flex-1 items-center gap-2 text-left" onClick={() => setSelectedId(block.id)}>
+                    <button className="flex min-w-0 flex-1 items-center gap-2 rounded text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50" onClick={() => setSelectedId(block.id)}>
                       <Icon className="size-3.5 shrink-0" />
                       <span className="truncate text-xs">{blockSummary(block)}</span>
                     </button>
-                    <div className="flex shrink-0 items-center opacity-0 transition-opacity group-hover:opacity-100">
-                      <Tip label="Move up"><button className="rounded p-0.5 hover:text-foreground disabled:opacity-30" disabled={i === 0} onClick={() => moveBlock(i, i - 1)} aria-label="Move up"><ChevronUp className="size-3.5" /></button></Tip>
-                      <Tip label="Move down"><button className="rounded p-0.5 hover:text-foreground disabled:opacity-30" disabled={i === blocks.length - 1} onClick={() => moveBlock(i, i + 1)} aria-label="Move down"><ChevronDown className="size-3.5" /></button></Tip>
-                      <Tip label="Duplicate"><button className="rounded p-0.5 hover:text-foreground" onClick={() => duplicateBlock(block.id)} aria-label="Duplicate"><Duplicate className="size-3" /></button></Tip>
-                      <Tip label="Delete"><button className="rounded p-0.5 hover:text-destructive" onClick={() => removeBlock(block.id)} aria-label="Delete"><Trash2 className="size-3.5" /></button></Tip>
+                    <div className="flex shrink-0 items-center opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+                      <Tip label="Move up"><button className="rounded p-1 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-30" disabled={i === 0} onClick={() => moveBlock(i, i - 1)} aria-label="Move up"><ChevronUp className="size-3.5" /></button></Tip>
+                      <Tip label="Move down"><button className="rounded p-1 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-30" disabled={i === blocks.length - 1} onClick={() => moveBlock(i, i + 1)} aria-label="Move down"><ChevronDown className="size-3.5" /></button></Tip>
+                      <Tip label="Duplicate"><button className="rounded p-1 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50" onClick={() => duplicateBlock(block.id)} aria-label="Duplicate"><Duplicate className="size-3" /></button></Tip>
+                      <Tip label="Delete"><button className="rounded p-1 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50" onClick={() => removeBlock(block.id)} aria-label="Delete"><Trash2 className="size-3.5" /></button></Tip>
                     </div>
                   </li>
                 )
@@ -360,7 +386,25 @@ export function Studio() {
             <div className="mx-auto max-w-3xl p-4 sm:p-6">
               <div className="rounded-xl border border-border bg-background p-4 shadow-sm sm:p-6">
                 {blocks.length === 0 ? (
-                  <p className="py-12 text-center text-sm text-muted-foreground">No blocks yet. Add one from the toolbar.</p>
+                  <div className="flex flex-col items-center gap-4 px-6 py-16 text-center">
+                    <div className="flex size-12 items-center justify-center rounded-xl border border-border bg-muted/40 text-muted-foreground">
+                      <Type className="size-5" />
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-sm font-medium text-foreground">Start your README</p>
+                      <p className="mx-auto max-w-xs text-sm text-muted-foreground">Add a block to begin. Mix text, headers, badges, charts, tables, and images, then export clean Markdown.</p>
+                    </div>
+                    <div className="flex flex-wrap justify-center gap-1.5">
+                      {(["markdown", "header", "badges", "chart", "table", "image"] as BlockType[]).map(type => {
+                        const Icon = BLOCK_ICONS[type]
+                        return (
+                          <Button key={type} variant="outline" size="sm" className="gap-1.5" onClick={() => addBlock(type)}>
+                            <Icon className="size-3.5" /> {BLOCK_LABELS[type]}
+                          </Button>
+                        )
+                      })}
+                    </div>
+                  </div>
                 ) : (
                   <div className="space-y-1">
                     {blocks.map(block => (
@@ -370,7 +414,7 @@ export function Studio() {
                         siteMode={mode}
                         themeAware={themeAware}
                         selected={block.id === selectedId}
-                        onSelect={() => setSelectedId(block.id)}
+                        onSelect={() => selectBlock(block.id)}
                       />
                     ))}
                   </div>
@@ -395,24 +439,31 @@ export function Studio() {
             ) : null}
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto p-4">
-            {!selected ? (
-              <p className="text-sm text-muted-foreground">Select a block to edit its properties.</p>
-            ) : selected.type === "markdown" ? (
-              <MarkdownInspector block={selected as MarkdownBlock} onChange={updateBlock} />
-            ) : selected.type === "header" ? (
-              <HeaderInspector block={selected as HeaderBlock} onChange={updateBlock} />
-            ) : selected.type === "badges" ? (
-              <BadgesInspector block={selected as BadgesBlock} onChange={updateBlock} />
-            ) : selected.type === "table" ? (
-              <TableInspector block={selected as TableBlock} onChange={updateBlock} />
-            ) : selected.type === "image" ? (
-              <ImageInspector block={selected as ImageBlock} onChange={updateBlock} />
-            ) : (
-              <ChartInspector block={selected as ChartBlock} onChange={updateBlock} />
-            )}
+            {inspectorBody}
           </div>
         </aside>
       </div>
+
+      {/* Mobile inspector — bottom sheet (below md, where the side panel is hidden) */}
+      {mobileInspectorOpen && selected ? (
+        <div className="md:hidden" role="dialog" aria-modal="true" aria-label={`${BLOCK_LABELS[selected.type]} settings`}>
+          <div className="fixed inset-0 z-40 bg-black/50" onClick={() => setMobileInspectorOpen(false)} aria-hidden="true" />
+          <div className="fixed inset-x-0 bottom-0 z-50 flex max-h-[82vh] flex-col rounded-t-xl border-t border-border bg-background shadow-xl">
+            <div className="flex items-center justify-between gap-2 border-b border-border px-4 py-3">
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{BLOCK_LABELS[selected.type]} settings</p>
+              <div className="flex items-center gap-1">
+                <Button variant="ghost" size="icon" className="size-8" disabled={selectedIndex <= 0} onClick={() => moveBlock(selectedIndex, selectedIndex - 1)} aria-label="Move block up"><ChevronUp className="size-4" /></Button>
+                <Button variant="ghost" size="icon" className="size-8" disabled={selectedIndex >= blocks.length - 1} onClick={() => moveBlock(selectedIndex, selectedIndex + 1)} aria-label="Move block down"><ChevronDown className="size-4" /></Button>
+                <Button variant="ghost" size="icon" className="size-8 text-muted-foreground hover:text-destructive" onClick={() => { removeBlock(selected.id); setMobileInspectorOpen(false) }} aria-label="Delete block"><Trash2 className="size-4" /></Button>
+                <Button variant="ghost" size="icon" className="size-8" onClick={() => setMobileInspectorOpen(false)} aria-label="Close"><X className="size-4" /></Button>
+              </div>
+            </div>
+            <div className="min-h-0 flex-1 overflow-y-auto p-4">
+              {inspectorBody}
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
     </TooltipProvider>
   )

--- a/packages/web/components/studio/studio.tsx
+++ b/packages/web/components/studio/studio.tsx
@@ -1,0 +1,419 @@
+/**
+ * shieldcn
+ * components/studio/studio
+ *
+ * README Studio — a Figma-style editor for composing a complete README from
+ * Markdown text, header banners, badge rows, and charts.
+ *
+ * Layout (desktop):
+ *   ┌───────────── toolbar (title · export · reset) ─────────────┐
+ *   │ Layers   │            Canvas (live preview)      │ Inspector│
+ *   │ + blocks │   selectable, reorderable blocks      │  props   │
+ *   └──────────┴──────────────────────────────────────┴──────────┘
+ *
+ * State persists to localStorage so a work-in-progress README survives reloads.
+ */
+
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import {
+  Copy, Check, Download, RotateCcw, Plus, Trash2, Copy as Duplicate,
+  ChevronUp, ChevronDown, Type, Image as ImageIcon, Images, Tag, LineChart, Table as TableIcon, Code2, Eye, GripVertical, SunMoon,
+} from "lucide-react"
+import { useSyncExternalStore } from "react"
+import { useBadgeMode } from "@/lib/use-badge-mode"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Toggle } from "@/components/ui/toggle"
+import { Separator } from "@/components/ui/separator"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { cn } from "@/lib/utils"
+import { BlockFrame } from "@/components/studio/canvas"
+import {
+  MarkdownInspector,
+  HeaderInspector,
+  BadgesInspector,
+  ChartInspector,
+  TableInspector,
+  ImageInspector,
+  Tip,
+} from "@/components/studio/inspectors"
+import {
+  BLOCK_LABELS,
+  documentToMarkdown,
+  makeBlock,
+  makeStarterDocument,
+  newId,
+  type Block,
+  type BlockType,
+  type BadgesBlock,
+  type ChartBlock,
+  type HeaderBlock,
+  type MarkdownBlock,
+  type TableBlock,
+  type ImageBlock,
+} from "@/lib/studio-shared"
+
+const STORAGE_KEY = "shieldcn:studio:v1"
+const SETTINGS_KEY = "shieldcn:studio:settings:v1"
+
+const BLOCK_ICONS: Record<BlockType, React.ComponentType<{ className?: string }>> = {
+  markdown: Type,
+  header: ImageIcon,
+  badges: Tag,
+  chart: LineChart,
+  table: TableIcon,
+  image: Images,
+}
+
+// ---------------------------------------------------------------------------
+// Persistence helpers
+// ---------------------------------------------------------------------------
+
+function loadBlocks(): Block[] | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw)
+    if (Array.isArray(parsed) && parsed.length > 0) return parsed as Block[]
+    return null
+  } catch {
+    return null
+  }
+}
+
+function blockSummary(block: Block): string {
+  switch (block.type) {
+    case "markdown": {
+      const firstLine = block.content.split("\n").find(l => l.trim()) ?? ""
+      return firstLine.replace(/^#+\s*/, "").slice(0, 32) || "Empty text"
+    }
+    case "header": return block.state.title || "Header"
+    case "badges": return `${block.badges.length} badge${block.badges.length === 1 ? "" : "s"}`
+    case "chart": return `${block.state.kind} chart`
+    case "table": return `${block.rows.length}×${block.headers.length} table`
+    case "image": return block.alt || "image"
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Studio
+// ---------------------------------------------------------------------------
+
+export function Studio() {
+  const { mode } = useBadgeMode()
+  const [blocks, setBlocks] = useState<Block[]>([])
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [hydrated, setHydrated] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const [view, setView] = useState<"design" | "code">("design")
+  const [themeAware, setThemeAware] = useState(false)
+  const [dragFrom, setDragFrom] = useState<number | null>(null)
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null)
+
+  const baseUrl = useSyncExternalStore(
+    () => () => {},
+    () => window.location.origin,
+    () => "https://shieldcn.dev",
+  )
+
+  // Hydrate from localStorage or seed a starter document.
+  useEffect(() => {
+    const saved = loadBlocks()
+    const initial = saved ?? makeStarterDocument()
+    let savedThemeAware = false
+    try { savedThemeAware = JSON.parse(localStorage.getItem(SETTINGS_KEY) ?? "{}")?.themeAware === true } catch { /* ignore */ }
+    // One-time client hydration from localStorage; mismatch avoided by the
+    // `hydrated` gate below. (react-compiler set-state-in-effect debt.)
+    /* eslint-disable react-hooks/set-state-in-effect */
+    setBlocks(initial)
+    setSelectedId(initial[0]?.id ?? null)
+    setThemeAware(savedThemeAware)
+    setHydrated(true)
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, [])
+
+  // Persist on change.
+  useEffect(() => {
+    if (!hydrated) return
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(blocks)) } catch { /* ignore quota */ }
+  }, [blocks, hydrated])
+
+  useEffect(() => {
+    if (!hydrated) return
+    try { localStorage.setItem(SETTINGS_KEY, JSON.stringify({ themeAware })) } catch { /* ignore quota */ }
+  }, [themeAware, hydrated])
+
+  const selected = blocks.find(b => b.id === selectedId) ?? null
+
+  // --- mutations -----------------------------------------------------------
+
+  const updateBlock = useCallback((next: Block) => {
+    setBlocks(prev => prev.map(b => (b.id === next.id ? next : b)))
+  }, [])
+
+  const addBlock = useCallback((type: BlockType) => {
+    const block = makeBlock(type)
+    setBlocks(prev => {
+      const idx = prev.findIndex(b => b.id === selectedId)
+      if (idx === -1) return [...prev, block]
+      const copy = [...prev]
+      copy.splice(idx + 1, 0, block)
+      return copy
+    })
+    setSelectedId(block.id)
+  }, [selectedId])
+
+  const removeBlock = useCallback((id: string) => {
+    setBlocks(prev => {
+      const idx = prev.findIndex(b => b.id === id)
+      const next = prev.filter(b => b.id !== id)
+      setSelectedId(next[Math.max(0, idx - 1)]?.id ?? next[0]?.id ?? null)
+      return next
+    })
+  }, [])
+
+  const duplicateBlock = useCallback((id: string) => {
+    setBlocks(prev => {
+      const idx = prev.findIndex(b => b.id === id)
+      if (idx === -1) return prev
+      const clone = structuredClone(prev[idx])
+      clone.id = newId(clone.type)
+      const copy = [...prev]
+      copy.splice(idx + 1, 0, clone)
+      setSelectedId(clone.id)
+      return copy
+    })
+  }, [])
+
+  const moveBlock = useCallback((from: number, to: number) => {
+    setBlocks(prev => {
+      if (to < 0 || to >= prev.length || from === to) return prev
+      const copy = [...prev]
+      const [moved] = copy.splice(from, 1)
+      copy.splice(to, 0, moved)
+      return copy
+    })
+  }, [])
+
+  const reset = useCallback(() => {
+    const fresh = makeStarterDocument()
+    setBlocks(fresh)
+    setSelectedId(fresh[0]?.id ?? null)
+  }, [])
+
+  // --- export --------------------------------------------------------------
+
+  const markdown = hydrated ? documentToMarkdown(blocks, baseUrl, themeAware) : ""
+
+  const copyMarkdown = useCallback(() => {
+    navigator.clipboard.writeText(documentToMarkdown(blocks, baseUrl, themeAware))
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }, [blocks, baseUrl, themeAware])
+
+  const downloadMarkdown = useCallback(() => {
+    const blob = new Blob([documentToMarkdown(blocks, baseUrl, themeAware)], { type: "text/markdown" })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement("a")
+    a.href = url
+    a.download = "README.md"
+    a.click()
+    URL.revokeObjectURL(url)
+  }, [blocks, baseUrl, themeAware])
+
+  if (!hydrated) {
+    return <div className="flex h-[60vh] items-center justify-center text-sm text-muted-foreground">Loading studio…</div>
+  }
+
+  return (
+    <TooltipProvider delayDuration={200}>
+    <div className="flex h-full flex-col">
+      {/* Toolbar */}
+      <div className="flex items-center justify-between gap-2 border-b border-border bg-background px-4 py-2.5">
+        <div className="flex items-center gap-2 min-w-0">
+          <h1 className="text-sm font-semibold tracking-tight">README Studio</h1>
+          <Badge variant="secondary" className="h-5 rounded-full px-2 text-[10px] font-medium uppercase tracking-wide">Beta</Badge>
+          <span className="hidden truncate text-xs text-muted-foreground sm:inline">· {blocks.length} blocks</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="hidden md:flex">
+            <Tabs value={view} onValueChange={v => setView(v as "design" | "code")}>
+              <TabsList className="h-8">
+                <TabsTrigger value="design" className="gap-1.5 text-xs"><Eye className="size-3.5" /> Design</TabsTrigger>
+                <TabsTrigger value="code" className="gap-1.5 text-xs"><Code2 className="size-3.5" /> Markdown</TabsTrigger>
+              </TabsList>
+            </Tabs>
+          </div>
+          <Separator orientation="vertical" className="mx-1 hidden h-5 md:block" />
+          <Tip label={themeAware ? "Adaptive light/dark is ON — badges, headers & charts export as <picture> and follow the reader's GitHub theme" : "Make the whole README adaptive — export badges, headers & charts as <picture> that follow the reader's light/dark theme"}>
+            <span className="inline-flex">
+              <Toggle
+                size="sm"
+                variant="outline"
+                pressed={themeAware}
+                onPressedChange={setThemeAware}
+                aria-label="Adaptive light and dark mode for the whole README"
+                className="h-8 gap-1.5 data-[state=on]:border-primary data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:hover:bg-primary/90"
+              >
+                <SunMoon className="size-3.5" /> <span className="hidden lg:inline">Adaptive</span>
+              </Toggle>
+            </span>
+          </Tip>
+          <Tip label="Copy README Markdown">
+            <Button variant="outline" size="sm" className="h-8 gap-1.5" onClick={copyMarkdown}>
+              {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+              <span className="hidden sm:inline">{copied ? "Copied" : "Copy"}</span>
+            </Button>
+          </Tip>
+          <Tip label="Download README.md">
+            <Button variant="outline" size="sm" className="h-8 gap-1.5" onClick={downloadMarkdown}>
+              <Download className="size-3.5" /> <span className="hidden sm:inline">Download</span>
+            </Button>
+          </Tip>
+          <Tip label="Reset to the starter document">
+            <Button variant="ghost" size="sm" className="h-8 gap-1.5 text-muted-foreground" onClick={reset}>
+              <RotateCcw className="size-3.5" /> <span className="hidden lg:inline">Reset</span>
+            </Button>
+          </Tip>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Left — add + layers */}
+        <aside className="hidden w-60 shrink-0 flex-col border-r border-border bg-muted/20 lg:flex">
+          <div className="border-b border-border p-3">
+            <p className="mb-2 px-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">Add block</p>
+            <div className="grid grid-cols-2 gap-1.5">
+              {(["markdown", "header", "badges", "chart", "table", "image"] as BlockType[]).map(type => {
+                const Icon = BLOCK_ICONS[type]
+                return (
+                  <Button key={type} variant="outline" size="sm" className="h-auto flex-col gap-1 py-2.5 text-xs" onClick={() => addBlock(type)}>
+                    <Icon className="size-4" />
+                    {BLOCK_LABELS[type]}
+                  </Button>
+                )
+              })}
+            </div>
+          </div>
+          <div className="flex min-h-0 flex-1 flex-col">
+            <p className="px-4 pb-1 pt-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">Layers</p>
+            <ul className="min-h-0 flex-1 space-y-0.5 overflow-y-auto px-2 pb-3">
+              {blocks.map((block, i) => {
+                const Icon = BLOCK_ICONS[block.type]
+                const active = block.id === selectedId
+                return (
+                  <li
+                    key={block.id}
+                    draggable
+                    onDragStart={e => { setDragFrom(i); e.dataTransfer.effectAllowed = "move" }}
+                    onDragOver={e => { e.preventDefault(); e.dataTransfer.dropEffect = "move"; if (dragOverIndex !== i) setDragOverIndex(i) }}
+                    onDragLeave={() => setDragOverIndex(prev => (prev === i ? null : prev))}
+                    onDrop={() => { if (dragFrom !== null) moveBlock(dragFrom, i); setDragFrom(null); setDragOverIndex(null) }}
+                    onDragEnd={() => { setDragFrom(null); setDragOverIndex(null) }}
+                    className={cn(
+                      "group flex items-center gap-1 rounded-md px-1.5 py-1.5 text-sm transition-colors",
+                      active ? "bg-accent text-accent-foreground" : "hover:bg-accent/50 text-muted-foreground",
+                      dragOverIndex === i && dragFrom !== null && dragFrom !== i && "opacity-60 ring-2 ring-primary ring-inset",
+                    )}
+                  >
+                    <GripVertical className="size-3.5 shrink-0 cursor-grab text-muted-foreground/60 active:cursor-grabbing" aria-hidden />
+                    <button className="flex min-w-0 flex-1 items-center gap-2 text-left" onClick={() => setSelectedId(block.id)}>
+                      <Icon className="size-3.5 shrink-0" />
+                      <span className="truncate text-xs">{blockSummary(block)}</span>
+                    </button>
+                    <div className="flex shrink-0 items-center opacity-0 transition-opacity group-hover:opacity-100">
+                      <Tip label="Move up"><button className="rounded p-0.5 hover:text-foreground disabled:opacity-30" disabled={i === 0} onClick={() => moveBlock(i, i - 1)} aria-label="Move up"><ChevronUp className="size-3.5" /></button></Tip>
+                      <Tip label="Move down"><button className="rounded p-0.5 hover:text-foreground disabled:opacity-30" disabled={i === blocks.length - 1} onClick={() => moveBlock(i, i + 1)} aria-label="Move down"><ChevronDown className="size-3.5" /></button></Tip>
+                      <Tip label="Duplicate"><button className="rounded p-0.5 hover:text-foreground" onClick={() => duplicateBlock(block.id)} aria-label="Duplicate"><Duplicate className="size-3" /></button></Tip>
+                      <Tip label="Delete"><button className="rounded p-0.5 hover:text-destructive" onClick={() => removeBlock(block.id)} aria-label="Delete"><Trash2 className="size-3.5" /></button></Tip>
+                    </div>
+                  </li>
+                )
+              })}
+            </ul>
+          </div>
+        </aside>
+
+        {/* Center — canvas / markdown */}
+        <main className="min-w-0 flex-1 overflow-y-auto bg-muted/40">
+          {/* Mobile add bar */}
+          <div className="flex items-center gap-1.5 overflow-x-auto border-b border-border bg-background px-3 py-2 lg:hidden">
+            {(["markdown", "header", "badges", "chart", "table", "image"] as BlockType[]).map(type => {
+              const Icon = BLOCK_ICONS[type]
+              return (
+                <Button key={type} variant="outline" size="sm" className="h-8 shrink-0 gap-1.5 text-xs" onClick={() => addBlock(type)}>
+                  <Plus className="size-3" /> <Icon className="size-3.5" /> {BLOCK_LABELS[type]}
+                </Button>
+              )
+            })}
+          </div>
+
+          {view === "code" ? (
+            <pre className="m-4 overflow-x-auto rounded-lg border border-border bg-background p-4 text-xs leading-relaxed">
+              <code className="font-mono">{markdown}</code>
+            </pre>
+          ) : (
+            <div className="mx-auto max-w-3xl p-4 sm:p-6">
+              <div className="rounded-xl border border-border bg-background p-4 shadow-sm sm:p-6">
+                {blocks.length === 0 ? (
+                  <p className="py-12 text-center text-sm text-muted-foreground">No blocks yet. Add one from the toolbar.</p>
+                ) : (
+                  <div className="space-y-1">
+                    {blocks.map(block => (
+                      <BlockFrame
+                        key={block.id}
+                        block={block}
+                        siteMode={mode}
+                        themeAware={themeAware}
+                        selected={block.id === selectedId}
+                        onSelect={() => setSelectedId(block.id)}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </main>
+
+        {/* Right — inspector */}
+        <aside className="hidden w-80 shrink-0 flex-col border-l border-border bg-background md:flex">
+          <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              {selected ? `${BLOCK_LABELS[selected.type]} settings` : "Inspector"}
+            </p>
+            {selected ? (
+              <Tip label="Delete block">
+                <Button variant="ghost" size="icon" className="size-7 text-muted-foreground hover:text-destructive" onClick={() => removeBlock(selected.id)} aria-label="Delete block">
+                  <Trash2 className="size-3.5" />
+                </Button>
+              </Tip>
+            ) : null}
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto p-4">
+            {!selected ? (
+              <p className="text-sm text-muted-foreground">Select a block to edit its properties.</p>
+            ) : selected.type === "markdown" ? (
+              <MarkdownInspector block={selected as MarkdownBlock} onChange={updateBlock} />
+            ) : selected.type === "header" ? (
+              <HeaderInspector block={selected as HeaderBlock} onChange={updateBlock} />
+            ) : selected.type === "badges" ? (
+              <BadgesInspector block={selected as BadgesBlock} onChange={updateBlock} />
+            ) : selected.type === "table" ? (
+              <TableInspector block={selected as TableBlock} onChange={updateBlock} />
+            ) : selected.type === "image" ? (
+              <ImageInspector block={selected as ImageBlock} onChange={updateBlock} />
+            ) : (
+              <ChartInspector block={selected as ChartBlock} onChange={updateBlock} />
+            )}
+          </div>
+        </aside>
+      </div>
+    </div>
+    </TooltipProvider>
+  )
+}

--- a/packages/web/components/ui/tooltip.tsx
+++ b/packages/web/components/ui/tooltip.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import * as React from "react"
+import { Tooltip as TooltipPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delayDuration = 200,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+    </TooltipProvider>
+  )
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 4,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md bg-primary px-2.5 py-1 text-xs text-balance text-primary-foreground shadow-md",
+          "animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-primary fill-primary" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/packages/web/lib/studio-shared.ts
+++ b/packages/web/lib/studio-shared.ts
@@ -357,7 +357,11 @@ function alignWrap(align: Alignment, inner: string): string {
 }
 
 function escapeAttr(s: string): string {
-  return s.replace(/"/g, "&quot;")
+  return s
+    .replace(/&/g, "&amp;") // must run first
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
 }
 
 /**
@@ -366,13 +370,12 @@ function escapeAttr(s: string): string {
  * renderer that ignores <picture> (npm, PyPI, plain Markdown previews).
  */
 function picture(darkUrl: string, lightUrl: string, alt: string, link?: string): string {
-  const a = escapeAttr(alt)
   const pic =
     `<picture>` +
-    `<source media="(prefers-color-scheme: dark)" srcset="${darkUrl}" />` +
-    `<img alt="${a}" src="${lightUrl}" />` +
+    `<source media="(prefers-color-scheme: dark)" srcset="${escapeAttr(darkUrl)}" />` +
+    `<img alt="${escapeAttr(alt)}" src="${escapeAttr(lightUrl)}" />` +
     `</picture>`
-  return link ? `<a href="${link}">${pic}</a>` : pic
+  return link ? `<a href="${escapeAttr(link)}">${pic}</a>` : pic
 }
 
 /**
@@ -401,7 +404,7 @@ export function blockToMarkdown(block: Block, baseUrl: string, themeAware = fals
         return `<p align="center">\n  ${picture(dark, light, block.alt)}\n</p>`
       }
       const url = buildHeaderUrl(block.state, baseUrl)
-      const img = `<img alt="${block.alt}" src="${url}" />`
+      const img = `<img alt="${escapeAttr(block.alt)}" src="${escapeAttr(url)}" />`
       // Headers are full-width banners — center them.
       return `<p align="center">\n  ${img}\n</p>`
     }
@@ -426,8 +429,8 @@ export function blockToMarkdown(block: Block, baseUrl: string, themeAware = fals
       if (block.align === "left") return imgs.join("\n")
       const inner = block.badges.map(b => {
         const url = buildBadgeUrl(b.state, baseUrl)
-        const img = `<img alt="${b.alt}" src="${url}" />`
-        return b.state.linkUrl ? `<a href="${b.state.linkUrl}">${img}</a>` : img
+        const img = `<img alt="${escapeAttr(b.alt)}" src="${escapeAttr(url)}" />`
+        return b.state.linkUrl ? `<a href="${escapeAttr(b.state.linkUrl)}">${img}</a>` : img
       }).join("\n  ")
       return `<p align="${block.align}">\n  ${inner}\n</p>`
     }
@@ -443,7 +446,7 @@ export function blockToMarkdown(block: Block, baseUrl: string, themeAware = fals
       const url = buildChartUrl(block.state, baseUrl)
       if (!url) return ""
       if (block.align === "left") return `![${block.alt}](${url})`
-      return alignWrap(block.align, `<img alt="${block.alt}" src="${url}" />`)
+      return alignWrap(block.align, `<img alt="${escapeAttr(block.alt)}" src="${escapeAttr(url)}" />`)
     }
 
     case "table": {
@@ -457,14 +460,14 @@ export function blockToMarkdown(block: Block, baseUrl: string, themeAware = fals
 
     case "image": {
       if (!block.src) return ""
-      const widthAttr = block.width ? ` width="${block.width}"` : ""
+      const widthAttr = block.width ? ` width="${escapeAttr(block.width)}"` : ""
       // Plain left-aligned images with no width export as clean Markdown.
       if ((!block.align || block.align === "left") && !block.width) {
         const img = `![${block.alt}](${block.src})`
         return block.link ? `[${img}](${block.link})` : img
       }
-      const img = `<img alt="${block.alt}" src="${block.src}"${widthAttr} />`
-      const wrapped = block.link ? `<a href="${block.link}">${img}</a>` : img
+      const img = `<img alt="${escapeAttr(block.alt)}" src="${escapeAttr(block.src)}"${widthAttr} />`
+      const wrapped = block.link ? `<a href="${escapeAttr(block.link)}">${img}</a>` : img
       return block.align && block.align !== "left" ? `<p align="${block.align}">\n  ${wrapped}\n</p>` : wrapped
     }
   }

--- a/packages/web/lib/studio-shared.ts
+++ b/packages/web/lib/studio-shared.ts
@@ -1,0 +1,500 @@
+/**
+ * shieldcn
+ * lib/studio-shared
+ *
+ * Block model, defaults, URL builders, and Markdown serialization for the
+ * README Studio. A README is modeled as an ordered list of blocks. Each block
+ * is one of: rich markdown text, a header banner, a row of badges, or a chart.
+ *
+ * The Studio renders these blocks live (selectable, Figma-style) and serializes
+ * the whole document to clean GitHub-flavored Markdown for export.
+ */
+
+import {
+  BUILDER_DEFAULTS,
+  buildBadgeUrl,
+  type BuilderState,
+} from "@/lib/badge-builder-shared"
+import {
+  HEADER_DEFAULTS,
+  buildHeaderUrl,
+  type HeaderState,
+} from "@/lib/header-builder-shared"
+
+// ---------------------------------------------------------------------------
+// Chart state (the chart sandbox keeps state inline; the Studio needs it as a
+// serializable object, so we model it here and mirror the sandbox URL builder).
+// ---------------------------------------------------------------------------
+
+export type ChartKind = "stars" | "issues" | "npm" | "json"
+
+export interface ChartState {
+  kind: ChartKind
+  owner: string
+  repo: string
+  package: string
+  values: string
+  dataLabel: string
+  format: "svg" | "png"
+  mode: "dark" | "light"
+  theme: string
+  font: string
+  color: string
+  fill: string
+  area: boolean
+  transparent: boolean
+  border: boolean
+  logo: boolean
+  width: string
+  height: string
+  title: string
+  icon: string
+  days: string
+}
+
+export const CHART_DEFAULTS: ChartState = {
+  kind: "stars",
+  owner: "vercel",
+  repo: "next.js",
+  package: "zod",
+  values: "10,25,40,30,60,55,80",
+  dataLabel: "",
+  format: "svg",
+  mode: "dark",
+  theme: "_none",
+  font: "inter",
+  color: "",
+  fill: "",
+  area: true,
+  transparent: false,
+  border: true,
+  logo: true,
+  width: "800",
+  height: "400",
+  title: "",
+  icon: "",
+  days: "365",
+}
+
+export const CHART_THEMES = [
+  "_none", "zinc", "blue", "green", "rose", "orange", "amber",
+  "violet", "purple", "cyan", "emerald",
+] as const
+
+export const CHART_FONTS = [
+  "inter", "geist", "geist-mono", "jetbrains-mono", "fira-code", "roboto", "space-grotesk",
+] as const
+
+/** Build the `/chart/...` URL for a chart block. Mirrors chart-sandbox.tsx. */
+export function buildChartUrl(s: ChartState, baseUrl: string): string | null {
+  const ext = s.format === "svg" ? ".svg" : ".png"
+  let path: string
+  if (s.kind === "stars" || s.kind === "issues") {
+    if (!s.owner || !s.repo) return null
+    path = `/chart/github/${s.kind}/${encodeURIComponent(s.owner)}/${encodeURIComponent(s.repo)}${ext}`
+  } else if (s.kind === "npm") {
+    if (!s.package) return null
+    const encoded = s.package.split("/").map(encodeURIComponent).join("/")
+    path = `/chart/npm/${encoded}${ext}`
+  } else {
+    path = `/chart/json${ext}`
+  }
+
+  const qp = new URLSearchParams()
+  if (s.kind === "json") {
+    const cleaned = s.values.split(",").map(v => v.trim()).filter(Boolean).join(",")
+    if (!cleaned) return null
+    qp.set("values", cleaned)
+    if (s.dataLabel) qp.set("label", s.dataLabel)
+  }
+  if (s.kind === "npm" && s.days && s.days !== "365") qp.set("days", s.days)
+  if (s.mode !== "dark") qp.set("mode", s.mode)
+  if (s.theme && s.theme !== "_none") qp.set("theme", s.theme)
+  if (s.font && s.font !== "inter") qp.set("font", s.font)
+  if (s.color) qp.set("color", s.color)
+  if (s.fill) qp.set("fill", s.fill)
+  if (!s.area) qp.set("area", "false")
+  if (s.transparent) qp.set("bg", "transparent")
+  if (!s.border) qp.set("border", "false")
+  if (!s.logo) qp.set("logo", "false")
+  if (s.width && s.width !== "800") qp.set("width", s.width)
+  if (s.height && s.height !== "400") qp.set("height", s.height)
+  if (s.title) qp.set("title", s.title)
+  if (s.icon) qp.set("icon", s.icon)
+
+  const qs = qp.toString()
+  return `${baseUrl}${path}${qs ? `?${qs}` : ""}`
+}
+
+// ---------------------------------------------------------------------------
+// Block model
+// ---------------------------------------------------------------------------
+
+export type BlockType = "markdown" | "header" | "badges" | "chart" | "table" | "image"
+
+/** Default placeholder image source. */
+export const PLACEHOLDER_IMAGE = "https://placeholdpicsum.dev/photo/600/400"
+
+// placeholdpicsum.dev is deterministic per size, so vary the dimensions (at a
+// fixed 3:2 aspect) to get a different placeholder photo on each shuffle.
+const PLACEHOLDER_WIDTHS = [600, 660, 720, 780, 840, 900, 960]
+
+/** A fresh random placeholder image URL, guaranteed different from `current`. */
+export function randomPlaceholder(current?: string): string {
+  const currentW = current?.match(/photo\/(\d+)\//)?.[1]
+  const pool = PLACEHOLDER_WIDTHS.filter(w => String(w) !== currentW)
+  const widths = pool.length ? pool : PLACEHOLDER_WIDTHS
+  const w = widths[Math.floor(Math.random() * widths.length)]
+  const h = Math.round((w * 2) / 3)
+  return `https://placeholdpicsum.dev/photo/${w}/${h}`
+}
+
+export type Alignment = "left" | "center" | "right"
+
+interface BaseBlock {
+  id: string
+  type: BlockType
+}
+
+export interface MarkdownBlock extends BaseBlock {
+  type: "markdown"
+  content: string
+  /** Horizontal alignment for the whole text block. */
+  align?: Alignment
+}
+
+export interface HeaderBlock extends BaseBlock {
+  type: "header"
+  alt: string
+  /** Emit a GitHub <picture> that swaps dark/light with the reader's theme. */
+  themeAware?: boolean
+  state: HeaderState
+}
+
+/** A single badge inside a badge row. */
+export interface BadgeItem {
+  id: string
+  alt: string
+  state: BuilderState
+}
+
+export interface BadgesBlock extends BaseBlock {
+  type: "badges"
+  align: Alignment
+  /** Emit GitHub <picture> markup so each badge swaps with the reader's theme. */
+  themeAware?: boolean
+  badges: BadgeItem[]
+}
+
+export interface ChartBlock extends BaseBlock {
+  type: "chart"
+  alt: string
+  align: Alignment
+  /** Emit a GitHub <picture> that swaps dark/light with the reader's theme. */
+  themeAware?: boolean
+  state: ChartState
+}
+
+export interface ImageBlock extends BaseBlock {
+  type: "image"
+  /** Image URL or absolute/relative path. */
+  src: string
+  alt: string
+  align?: Alignment
+  /** Optional pixel width. */
+  width?: string
+  /** Optional link wrapping the image. */
+  link?: string
+}
+
+export interface TableBlock extends BaseBlock {
+  type: "table"
+  /** Column header labels. Column count is derived from this array. */
+  headers: string[]
+  /** Per-column horizontal alignment. */
+  aligns: Alignment[]
+  /** Body rows; each row holds one cell per column. */
+  rows: string[][]
+  /** Alignment of the whole table within the page. */
+  align?: Alignment
+}
+
+export type Block = MarkdownBlock | HeaderBlock | BadgesBlock | ChartBlock | TableBlock | ImageBlock
+
+export const BLOCK_LABELS: Record<BlockType, string> = {
+  markdown: "Text",
+  header: "Header",
+  badges: "Badges",
+  chart: "Chart",
+  table: "Table",
+  image: "Image",
+}
+
+// ---------------------------------------------------------------------------
+// ID generation
+// ---------------------------------------------------------------------------
+
+let idCounter = 0
+export function newId(prefix = "blk"): string {
+  idCounter += 1
+  const rand = Math.random().toString(36).slice(2, 8)
+  return `${prefix}_${Date.now().toString(36)}${idCounter}${rand}`
+}
+
+// ---------------------------------------------------------------------------
+// Block factories
+// ---------------------------------------------------------------------------
+
+export function makeMarkdownBlock(content?: string): MarkdownBlock {
+  return {
+    id: newId("md"),
+    type: "markdown",
+    content:
+      content ??
+      "## Getting started\n\nWrite anything here using **Markdown**. Add headings, lists, code blocks, links, and tables.\n\n```bash\nnpm install your-package\n```",
+  }
+}
+
+export function makeHeaderBlock(): HeaderBlock {
+  return {
+    id: newId("hdr"),
+    type: "header",
+    alt: "header",
+    state: { ...HEADER_DEFAULTS },
+  }
+}
+
+export function makeBadgeItem(state?: Partial<BuilderState>): BadgeItem {
+  return {
+    id: newId("badge"),
+    alt: "badge",
+    state: { ...BUILDER_DEFAULTS, ...state },
+  }
+}
+
+export function makeBadgesBlock(): BadgesBlock {
+  return {
+    id: newId("badges"),
+    type: "badges",
+    align: "left",
+    badges: [
+      makeBadgeItem({ path: "/npm/react.svg" }),
+      makeBadgeItem({ path: "/github/vercel/next.js/stars.svg" }),
+    ],
+  }
+}
+
+export function makeChartBlock(): ChartBlock {
+  return {
+    id: newId("chart"),
+    type: "chart",
+    alt: "chart",
+    align: "center",
+    state: { ...CHART_DEFAULTS },
+  }
+}
+
+export function makeTableBlock(): TableBlock {
+  return {
+    id: newId("table"),
+    type: "table",
+    headers: ["Feature", "Status"],
+    aligns: ["left", "left"],
+    rows: [
+      ["Fast", "✅"],
+      ["Accessible", "✅"],
+    ],
+  }
+}
+
+/** Escape a value so it is safe inside a single GFM table cell. */
+function escapeCell(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\n/g, " ").trim()
+}
+
+/** Serialize a table block to a GitHub-flavored Markdown table. */
+export function tableToGfm(block: TableBlock): string {
+  const cols = block.headers.length
+  if (cols === 0) return ""
+  const sepFor = (a: Alignment) =>
+    a === "center" ? ":---:" : a === "right" ? "---:" : "---"
+  const header = `| ${block.headers.map(escapeCell).join(" | ")} |`
+  const sep = `| ${Array.from({ length: cols }, (_, i) => sepFor(block.aligns[i] ?? "left")).join(" | ")} |`
+  const body = block.rows.map(row =>
+    `| ${Array.from({ length: cols }, (_, i) => escapeCell(row[i] ?? "")).join(" | ")} |`,
+  )
+  return [header, sep, ...body].join("\n")
+}
+
+export function makeImageBlock(): ImageBlock {
+  return {
+    id: newId("img"),
+    type: "image",
+    src: randomPlaceholder(),
+    alt: "image",
+    align: "center",
+  }
+}
+
+export function makeBlock(type: BlockType): Block {
+  switch (type) {
+    case "markdown": return makeMarkdownBlock()
+    case "header": return makeHeaderBlock()
+    case "badges": return makeBadgesBlock()
+    case "chart": return makeChartBlock()
+    case "table": return makeTableBlock()
+    case "image": return makeImageBlock()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Markdown serialization
+// ---------------------------------------------------------------------------
+
+function alignWrap(align: Alignment, inner: string): string {
+  if (align === "left") return inner
+  return `<p align="${align}">\n  ${inner}\n</p>`
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/"/g, "&quot;")
+}
+
+/**
+ * Build a GitHub theme-aware <picture>. The <source> targets dark-theme
+ * viewers; the <img> fallback (light) covers light-theme viewers and any
+ * renderer that ignores <picture> (npm, PyPI, plain Markdown previews).
+ */
+function picture(darkUrl: string, lightUrl: string, alt: string, link?: string): string {
+  const a = escapeAttr(alt)
+  const pic =
+    `<picture>` +
+    `<source media="(prefers-color-scheme: dark)" srcset="${darkUrl}" />` +
+    `<img alt="${a}" src="${lightUrl}" />` +
+    `</picture>`
+  return link ? `<a href="${link}">${pic}</a>` : pic
+}
+
+/**
+ * Serialize a single block to Markdown. baseUrl is prepended to image URLs.
+ * When `themeAware` is true, image blocks export as GitHub <picture> elements
+ * that swap with the reader's light/dark theme.
+ */
+export function blockToMarkdown(block: Block, baseUrl: string, themeAware = false): string {
+  const adaptive = themeAware || ("themeAware" in block && !!block.themeAware)
+  switch (block.type) {
+    case "markdown": {
+      const content = block.content.trim()
+      if (!content) return ""
+      if (block.align && block.align !== "left") {
+        // GitHub renders Markdown inside an aligned <div> when blank lines
+        // separate the HTML wrapper from the Markdown content.
+        return `<div align="${block.align}">\n\n${content}\n\n</div>`
+      }
+      return content
+    }
+
+    case "header": {
+      if (adaptive) {
+        const dark = buildHeaderUrl({ ...block.state, mode: "dark" }, baseUrl)
+        const light = buildHeaderUrl({ ...block.state, mode: "light" }, baseUrl)
+        return `<p align="center">\n  ${picture(dark, light, block.alt)}\n</p>`
+      }
+      const url = buildHeaderUrl(block.state, baseUrl)
+      const img = `<img alt="${block.alt}" src="${url}" />`
+      // Headers are full-width banners — center them.
+      return `<p align="center">\n  ${img}\n</p>`
+    }
+
+    case "badges": {
+      if (block.badges.length === 0) return ""
+      // Theme-aware rows emit <picture> per badge (HTML); wrap for alignment.
+      if (adaptive) {
+        const pics = block.badges.map(b => {
+          const dark = buildBadgeUrl({ ...b.state, mode: "dark" }, baseUrl)
+          const light = buildBadgeUrl({ ...b.state, mode: "light" }, baseUrl)
+          return picture(dark, light, b.alt, b.state.linkUrl || undefined)
+        })
+        if (block.align === "left") return pics.join("\n")
+        return `<p align="${block.align}">\n  ${pics.join("\n  ")}\n</p>`
+      }
+      const imgs = block.badges.map(b => {
+        const url = buildBadgeUrl(b.state, baseUrl)
+        const img = `![${b.alt}](${url})`
+        return b.state.linkUrl ? `[${img}](${b.state.linkUrl})` : img
+      })
+      if (block.align === "left") return imgs.join("\n")
+      const inner = block.badges.map(b => {
+        const url = buildBadgeUrl(b.state, baseUrl)
+        const img = `<img alt="${b.alt}" src="${url}" />`
+        return b.state.linkUrl ? `<a href="${b.state.linkUrl}">${img}</a>` : img
+      }).join("\n  ")
+      return `<p align="${block.align}">\n  ${inner}\n</p>`
+    }
+
+    case "chart": {
+      if (adaptive) {
+        const dark = buildChartUrl({ ...block.state, mode: "dark" }, baseUrl)
+        const light = buildChartUrl({ ...block.state, mode: "light" }, baseUrl)
+        if (!dark || !light) return ""
+        const pic = picture(dark, light, block.alt)
+        return block.align === "left" ? pic : `<p align="${block.align}">\n  ${pic}\n</p>`
+      }
+      const url = buildChartUrl(block.state, baseUrl)
+      if (!url) return ""
+      if (block.align === "left") return `![${block.alt}](${url})`
+      return alignWrap(block.align, `<img alt="${block.alt}" src="${url}" />`)
+    }
+
+    case "table": {
+      const gfm = tableToGfm(block)
+      if (!gfm) return ""
+      if (block.align && block.align !== "left") {
+        return `<div align="${block.align}">\n\n${gfm}\n\n</div>`
+      }
+      return gfm
+    }
+
+    case "image": {
+      if (!block.src) return ""
+      const widthAttr = block.width ? ` width="${block.width}"` : ""
+      // Plain left-aligned images with no width export as clean Markdown.
+      if ((!block.align || block.align === "left") && !block.width) {
+        const img = `![${block.alt}](${block.src})`
+        return block.link ? `[${img}](${block.link})` : img
+      }
+      const img = `<img alt="${block.alt}" src="${block.src}"${widthAttr} />`
+      const wrapped = block.link ? `<a href="${block.link}">${img}</a>` : img
+      return block.align && block.align !== "left" ? `<p align="${block.align}">\n  ${wrapped}\n</p>` : wrapped
+    }
+  }
+}
+
+/** Serialize an entire README document to Markdown. */
+export function documentToMarkdown(blocks: Block[], baseUrl: string, themeAware = false): string {
+  return blocks
+    .map(b => blockToMarkdown(b, baseUrl, themeAware))
+    .filter(Boolean)
+    .join("\n\n") + "\n"
+}
+
+// ---------------------------------------------------------------------------
+// Starter document
+// ---------------------------------------------------------------------------
+
+export function makeStarterDocument(): Block[] {
+  const header = makeHeaderBlock()
+  header.state = {
+    ...HEADER_DEFAULTS,
+    title: "Acme Toolkit",
+    subtitle: "A delightful component library",
+    preset: "gradient",
+  }
+  const badges = makeBadgesBlock()
+  badges.align = "center"
+  const intro = makeMarkdownBlock(
+    "## Overview\n\nAcme Toolkit is a fast, accessible set of building blocks. Use the toolbar on the right to edit any block, drag the list to reorder, and export clean Markdown for your README.\n\n- 🎨 Themeable\n- ⚡ Fast\n- ♿ Accessible",
+  )
+  const chart = makeChartBlock()
+  return [header, badges, intro, chart]
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -34,6 +34,8 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "shiki": "^4.0.2",
     "svgo": "^4.0.1",
     "tailwind-merge": "^3.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,12 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.14)(react@19.2.4)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       shiki:
         specifier: ^4.0.2
         version: 4.0.2
@@ -2621,6 +2627,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -4169,6 +4176,9 @@ packages:
   html-to-image@1.11.13:
     resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
@@ -5431,6 +5441,12 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -9807,8 +9823,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.4
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
@@ -9830,7 +9846,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -9841,22 +9857,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9867,7 +9883,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -10565,6 +10581,8 @@ snapshots:
   hono@4.12.23: {}
 
   html-to-image@1.11.13: {}
+
+  html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
 
@@ -12074,6 +12092,24 @@ snapshots:
       react: 19.2.4
 
   react-is@16.13.1: {}
+
+  react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.14
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.4
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
     dependencies:


### PR DESCRIPTION
## What

Adds **README Studio** (`/studio`), a Figma-style visual builder for composing an entire GitHub README from reorderable blocks with a live preview and a property inspector, then exporting clean GitHub-flavored Markdown.

Block types: **Text** (Markdown editor with a formatting toolbar, alignment, and table insert), **Header**, **Badges** (searchable type picker, split styling, per-row alignment), **Chart**, **Table** (spreadsheet-style grid with per-column alignment), and **Image** (URL/path input with a `placeholdpicsum.dev` placeholder + shuffle).

Key features:
- Drag-and-drop layer reordering with grip handles and a drop indicator
- Global **Adaptive** toggle: exports badges/headers/charts as GitHub `<picture>` elements that follow the reader's light/dark theme (mirrors `lib/gen/shieldcn`)
- Preview pins each block to its own mode; it only follows the site theme when Adaptive is on
- Copy / Download `README.md`, Design and Markdown views, `localStorage` persistence
- Mobile bottom-sheet inspector so blocks are editable on phones
- Keyboard-accessible controls with visible focus rings; accessible tooltips on icon controls

## Why

Building a README by hand-writing badge/header/chart URLs is tedious and error-prone. The Studio lets maintainers compose visually and export Markdown that renders identically on GitHub.

Closes #

## Type

- [x] `feat` — New feature

## Checklist

- [x] Branch follows conventional naming (`feat/`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tested locally with `pnpm dev`
- [x] Badge renders correctly in SVG and PNG (existing endpoints reused; verified 200 SVG)
- [ ] Docs updated (follow-up: add a Studio docs page)

## How

- New: `app/studio/page.tsx`, `components/studio/{studio,canvas,inspectors}.tsx`, `lib/studio-shared.ts` (block model + Markdown serializer), and a shadcn `components/ui/tooltip.tsx` primitive.
- Rendering uses `react-markdown` + `remark-gfm` (new deps). Nav link added in `animated-header.tsx`.
- Also adds `PRODUCT.md` (impeccable project context).

## Testing

- `tsc --noEmit` and `eslint` clean; pre-commit hook (lint-staged) passed.
- Verified in-browser: all six block types render; searchable badge picker; split props; theme-aware `<picture>` export; Markdown export; Copy/Download; and the mobile inspector sheet at 500px width.

## Screenshots

Desktop and mobile (bottom-sheet inspector) captured locally during the build. Can attach in the web UI on request.
