### PR TITLE
feat(header): add photo/Unsplash background support

### DIFF
--- a/packages/core/src/badges/header-backgrounds.ts
+++ b/packages/core/src/badges/header-backgrounds.ts
@@ -134,6 +134,15 @@ function clamp(n: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, n))
 }
 
+/** Escape a value for safe embedding inside a double-quoted SVG/XML attribute. */
+function escAttr(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+}
+
 /** Parse a "c1,c2[,c3][,angle]" gradient param into stops + angle. */
 function parseGradientSpec(raw: string): { stops: string[]; angle: number } | null {
   const parts = raw.split(",").map((s) => s.trim()).filter(Boolean)
@@ -213,7 +222,7 @@ export function resolveHeaderBackground(input: HeaderBgInput): ResolvedHeaderBg 
     const tintHex = normHex(input.tint) ?? "#000000"
     const scrimId = `${uid}scrim`
     layers.push(
-      `<image href="${image}" x="0" y="0" width="${width}" height="${height}" preserveAspectRatio="xMidYMid slice" />`,
+      `<image href="${escAttr(image)}" x="0" y="0" width="${width}" height="${height}" preserveAspectRatio="xMidYMid slice" />`,
     )
     // Flat tint for overall contrast.
     layers.push(`<rect x="0" y="0" width="${width}" height="${height}" fill="${rgba(tintHex, r2(overlay * 0.5))}" />`)

--- a/packages/core/src/badges/header-backgrounds.ts
+++ b/packages/core/src/badges/header-backgrounds.ts
@@ -71,6 +71,16 @@ export interface HeaderBgInput {
   glow?: string | null
   /** Accent color hex (no `#`). */
   accent?: string | null
+  /**
+   * Inlined background photo as a data URI (already fetched + base64 by the
+   * route). Renders edge-to-edge under an auto scrim so text stays legible.
+   * Wins over bg / gradient / preset patterns.
+   */
+  imageDataUri?: string | null
+  /** Scrim strength over the photo, 0 (none) – 1 (opaque). Default 0.45. */
+  overlay?: number | null
+  /** Scrim tint color hex (no `#`). Default black. */
+  tint?: string | null
 }
 
 export interface ResolvedHeaderBg {
@@ -84,6 +94,8 @@ export interface ResolvedHeaderBg {
   accent: string
   /** Hairline border color (#rrggbb) matching the surface. */
   border: string
+  /** True when a photo background is in use (text renders light + legible). */
+  hasImage: boolean
 }
 
 const HEX_RE = /^[0-9a-fA-F]{3,8}$/
@@ -116,6 +128,10 @@ function rgba(hex: string, alpha: number): string {
 
 function r2(n: number): number {
   return Math.round(n * 100) / 100
+}
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, n))
 }
 
 /** Parse a "c1,c2[,c3][,angle]" gradient param into stops + angle. */
@@ -187,9 +203,30 @@ export function resolveHeaderBackground(input: HeaderBgInput): ResolvedHeaderBg 
   const transparent = !!input.transparent || style === "transparent"
   const bgOverride = normHex(input.bg)
   const gradOverride = input.gradient ? parseGradientSpec(input.gradient) : null
+  const image = input.imageDataUri || null
 
   // --- Base fill ---
-  if (transparent && !bgOverride && !gradOverride) {
+  if (image) {
+    // Photo background — edge-to-edge cover, then an auto scrim so the title and
+    // subtitle stay legible on any image. Text is forced light.
+    const overlay = clamp(input.overlay ?? 0.45, 0, 1)
+    const tintHex = normHex(input.tint) ?? "#000000"
+    const scrimId = `${uid}scrim`
+    layers.push(
+      `<image href="${image}" x="0" y="0" width="${width}" height="${height}" preserveAspectRatio="xMidYMid slice" />`,
+    )
+    // Flat tint for overall contrast.
+    layers.push(`<rect x="0" y="0" width="${width}" height="${height}" fill="${rgba(tintHex, r2(overlay * 0.5))}" />`)
+    // Bottom-weighted vertical gradient so the subtitle reads on busy photos.
+    defs.push(
+      `<linearGradient id="${scrimId}" x1="0" y1="0" x2="0" y2="1">` +
+        `<stop offset="0%" stop-color="${rgba(tintHex, r2(overlay * 0.25))}" />` +
+        `<stop offset="100%" stop-color="${rgba(tintHex, r2(Math.min(1, overlay * 1.1)))}" />` +
+        `</linearGradient>`,
+    )
+    layers.push(`<rect x="0" y="0" width="${width}" height="${height}" fill="url(#${scrimId})" />`)
+    isLight = false
+  } else if (transparent && !bgOverride && !gradOverride) {
     // No surface fill — blend into the host page. Text contrast follows mode.
   } else if (gradOverride) {
     const { x1, y1, x2, y2 } = angleToCoords(gradOverride.angle)
@@ -226,7 +263,7 @@ export function resolveHeaderBackground(input: HeaderBgInput): ResolvedHeaderBg 
   } else if (patParam === "dots" || patParam === "grid" || patParam === "graph") {
     pattern = patParam
   }
-  if (pattern) {
+  if (pattern && !image) {
     const lineColor = rgba(isLight ? "#000000" : "#ffffff", isLight ? 0.06 : 0.06)
     const dotColor = rgba(isLight ? "#000000" : "#ffffff", isLight ? 0.1 : 0.09)
     if (pattern === "dots") {
@@ -261,7 +298,7 @@ export function resolveHeaderBackground(input: HeaderBgInput): ResolvedHeaderBg 
   // --- Spotlight glow (style "glow" default, or ?glow=). Skipped on a fully
   // transparent background unless explicitly requested. ---
   const glowColor = normHex(input.glow) ?? (style === "glow" && !transparent ? tint.glow : undefined)
-  if (glowColor) {
+  if (glowColor && !image) {
     const id = `${uid}glow`
     const cx = r2(width / 2)
     const cy = 0
@@ -282,5 +319,6 @@ export function resolveHeaderBackground(input: HeaderBgInput): ResolvedHeaderBg 
     isLight,
     accent,
     border: surf.border,
+    hasImage: !!image,
   }
 }

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -2061,6 +2061,65 @@ async function resolveHeaderLogo(
   return { icon: si.icon, color }
 }
 
+/** Max bytes for a fetched/inlined header background photo (~4 MB). */
+const MAX_HEADER_IMAGE_BYTES = 4_000_000
+/** Raster image types allowed as a header background (no SVG — photos only). */
+const HEADER_IMAGE_TYPES = new Set(["image/jpeg", "image/png", "image/webp", "image/gif", "image/avif"])
+
+/**
+ * Resolve a `?image=` value into an inlined data URI for a header background.
+ * Supports a `data:image/*` URI (used as-is) or an `http(s)` URL that is fetched
+ * and base64-embedded (never hot-linked from a sandboxed `<img>` SVG). For
+ * `images.unsplash.com` URLs we request a sized JPEG via Unsplash's imgix
+ * params so the inlined payload stays small. Returns undefined on any failure.
+ */
+async function resolveHeaderImage(imageParam: string | null): Promise<string | undefined> {
+  if (!imageParam || imageParam === "false" || imageParam === "none" || imageParam === "0") {
+    return undefined
+  }
+
+  // Pre-inlined data URI — accept raster only, with a rough size cap.
+  if (imageParam.startsWith("data:image/")) {
+    if (imageParam.startsWith("data:image/svg+xml")) return undefined
+    if (imageParam.length > MAX_HEADER_IMAGE_BYTES * 1.4) return undefined
+    return imageParam
+  }
+
+  if (!/^https?:\/\//.test(imageParam)) return undefined
+
+  // Build the fetch URL; ask Unsplash for a banner-sized JPEG.
+  let fetchUrl = imageParam
+  try {
+    const u = new URL(imageParam)
+    if (u.hostname === "images.unsplash.com") {
+      if (!u.searchParams.has("w")) u.searchParams.set("w", "1600")
+      if (!u.searchParams.has("q")) u.searchParams.set("q", "70")
+      if (!u.searchParams.has("fit")) u.searchParams.set("fit", "crop")
+      u.searchParams.set("fm", "jpg")
+      fetchUrl = u.toString()
+    }
+  } catch {
+    return undefined
+  }
+
+  try {
+    const res = await raceTimeout(
+      fetch(fetchUrl, {
+        next: { revalidate: 86400 },
+        headers: { Accept: "image/*", "User-Agent": "shieldcn/1.0" },
+      }),
+    )
+    if (!res?.ok) return undefined
+    const ct = res.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase() || ""
+    if (!HEADER_IMAGE_TYPES.has(ct)) return undefined
+    const bytes = Buffer.from(await res.arrayBuffer())
+    if (bytes.byteLength === 0 || bytes.byteLength > MAX_HEADER_IMAGE_BYTES) return undefined
+    return `data:${ct};base64,${bytes.toString("base64")}`
+  } catch {
+    return undefined
+  }
+}
+
 async function handleHeader(
   cleanSegments: string[],
   searchParams: URLSearchParams,
@@ -2097,6 +2156,12 @@ async function handleHeader(
   const bgRaw = searchParams.get("bg") ?? searchParams.get("background")
   const transparent = bgRaw === "transparent" || bgRaw === "none"
 
+  // Photo background (Unsplash or any image URL / data URI), fetched + inlined.
+  const imageDataUri = await resolveHeaderImage(searchParams.get("image") ?? searchParams.get("bgImage"))
+  const overlay = searchParams.has("overlay")
+    ? clampNum(searchParams.get("overlay"), 0, 1, 0.45)
+    : undefined
+
   const background = resolveHeaderBackground({
     preset,
     mode,
@@ -2110,6 +2175,9 @@ async function handleHeader(
     pattern: searchParams.get("pattern"),
     glow: resolveColor(searchParams.get("glow")),
     accent: resolveColor(searchParams.get("accent")),
+    imageDataUri,
+    overlay,
+    tint: resolveColor(searchParams.get("tint")),
   })
 
   const logo = await resolveHeaderLogo(searchParams.get("logo"), searchParams.get("logoColor"))

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -2065,6 +2065,12 @@ async function resolveHeaderLogo(
 const MAX_HEADER_IMAGE_BYTES = 4_000_000
 /** Raster image types allowed as a header background (no SVG — photos only). */
 const HEADER_IMAGE_TYPES = new Set(["image/jpeg", "image/png", "image/webp", "image/gif", "image/avif"])
+/**
+ * Strict raster `data:` image URI. The value is embedded into an SVG attribute,
+ * so it must match exactly — `data:image/<type>;base64,<base64>` with nothing
+ * else — to rule out attribute-breakout payloads (e.g. an embedded `"`).
+ */
+const DATA_IMAGE_RE = /^data:image\/(?:png|jpe?g|webp|gif|avif);base64,[A-Za-z0-9+/]+={0,2}$/
 
 /**
  * Resolve a `?image=` value into an inlined data URI for a header background.
@@ -2078,11 +2084,12 @@ async function resolveHeaderImage(imageParam: string | null): Promise<string | u
     return undefined
   }
 
-  // Pre-inlined data URI — accept raster only, with a rough size cap.
-  if (imageParam.startsWith("data:image/")) {
-    if (imageParam.startsWith("data:image/svg+xml")) return undefined
+  // Pre-inlined data URI — accept only a well-formed base64 raster URI. The
+  // strict regex (not a `startsWith` check) ensures the value cannot contain
+  // characters that would break out of the SVG `href` attribute it's placed in.
+  if (imageParam.startsWith("data:")) {
     if (imageParam.length > MAX_HEADER_IMAGE_BYTES * 1.4) return undefined
-    return imageParam
+    return DATA_IMAGE_RE.test(imageParam) ? imageParam : undefined
   }
 
   if (!/^https?:\/\//.test(imageParam)) return undefined

--- a/packages/web/components/header-builder.tsx
+++ b/packages/web/components/header-builder.tsx
@@ -11,7 +11,7 @@
 "use client"
 
 import { useState, useCallback, useMemo, useSyncExternalStore } from "react"
-import { Copy, Check } from "lucide-react"
+import { Copy, Check, Shuffle } from "lucide-react"
 import { useTheme } from "next-themes"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -37,6 +37,7 @@ import {
   HEADER_FONTS,
   HEADER_THEMES,
   buildHeaderUrl,
+  randomUnsplashHeader,
   type HeaderState,
 } from "@/lib/header-builder-shared"
 
@@ -220,6 +221,36 @@ export function HeaderBuilder() {
             </div>
             <ColorSwatch label="Logo color" value={s.logoColor} onChange={(v) => set("logoColor", v)} />
           </div>
+        </div>
+
+        {/* Background image */}
+        <div className="space-y-2">
+          <FieldLabel>Background image</FieldLabel>
+          <div className="flex gap-2">
+            <Input
+              value={s.image}
+              onChange={(e) => set("image", e.target.value)}
+              placeholder="Unsplash or image URL"
+              className="text-xs"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className="size-9 shrink-0"
+              aria-label="Random Unsplash photo"
+              title="Random Unsplash photo"
+              onClick={() => set("image", randomUnsplashHeader(s.image))}
+            >
+              <Shuffle className="size-3.5" />
+            </Button>
+          </div>
+          {s.image ? (
+            <div className="space-y-1.5">
+              <FieldLabel>Overlay (0–1)</FieldLabel>
+              <Input value={s.overlay} onChange={(e) => set("overlay", e.target.value)} placeholder="0.45" className="h-9" />
+            </div>
+          ) : null}
         </div>
 
         {/* Selects */}

--- a/packages/web/components/studio/inspectors.tsx
+++ b/packages/web/components/studio/inspectors.tsx
@@ -51,6 +51,7 @@ import {
   HEADER_SIZE_LABELS,
   HEADER_FONTS,
   HEADER_THEMES,
+  randomUnsplashHeader,
   type HeaderState,
 } from "@/lib/header-builder-shared"
 import {
@@ -377,6 +378,22 @@ export function HeaderInspector({ block, onChange }: { block: HeaderBlock; onCha
       {s.logo ? (
         <Field label="Logo color">
           <ColorInput value={s.logoColor} onChange={v => set({ logoColor: v })} />
+        </Field>
+      ) : null}
+
+      <Field label="Background image">
+        <div className="flex gap-1.5">
+          <Input value={s.image} onChange={e => set({ image: e.target.value })} placeholder="Unsplash or image URL" className="text-xs" />
+          <Tip label="Random Unsplash photo">
+            <Button variant="outline" size="icon" className="size-9 shrink-0" aria-label="Random Unsplash photo" onClick={() => set({ image: randomUnsplashHeader(s.image) })}>
+              <Shuffle className="size-3.5" />
+            </Button>
+          </Tip>
+        </div>
+      </Field>
+      {s.image ? (
+        <Field label="Overlay (0–1)">
+          <Input value={s.overlay} onChange={e => set({ overlay: e.target.value })} placeholder="0.45" />
         </Field>
       ) : null}
 

--- a/packages/web/lib/header-builder-shared.ts
+++ b/packages/web/lib/header-builder-shared.ts
@@ -73,6 +73,35 @@ export interface HeaderState {
   font: string
   border: boolean
   watermark: boolean
+  /** Background photo URL (Unsplash or any image). Fetched + inlined server-side. */
+  image: string
+  /** Scrim strength over the photo, "0"–"1". Blank = default (0.45). */
+  overlay: string
+}
+
+// Curated Unsplash photos that read well as wide banners (sized via imgix).
+const UNSPLASH_SAMPLES = [
+  "photo-1517336714731-489689fd1ca8", // laptop / code
+  "photo-1451187580459-43490279c0fa", // earth / network
+  "photo-1462331940025-496dfbfc7564", // galaxy
+  "photo-1550745165-9bc0b252726f", // retro tech
+  "photo-1499951360447-b19be8fe80f5", // workspace
+  "photo-1480506132288-68f7705954bd", // mountains
+  "photo-1509822929063-6b6cfc9b42f2", // gradient paper
+  "photo-1614850523459-c2f4c699c52e", // abstract gradient
+]
+
+/** Build an Unsplash image URL (banner-sized) for a given photo id. */
+export function unsplashUrl(id: string): string {
+  return `https://images.unsplash.com/${id}?w=1600&q=70&fit=crop&fm=jpg`
+}
+
+/** A random curated Unsplash banner URL, different from `current` when possible. */
+export function randomUnsplashHeader(current?: string): string {
+  const currentId = current?.match(/photo-[\w-]+/)?.[0]
+  const pool = UNSPLASH_SAMPLES.filter(id => id !== currentId)
+  const list = pool.length ? pool : UNSPLASH_SAMPLES
+  return unsplashUrl(list[Math.floor(Math.random() * list.length)])
 }
 
 export const HEADER_DEFAULTS: HeaderState = {
@@ -88,6 +117,8 @@ export const HEADER_DEFAULTS: HeaderState = {
   font: "inter",
   border: true,
   watermark: false,
+  image: "",
+  overlay: "",
 }
 
 /** Build the `/header/{preset}.svg?...` URL from builder state. */
@@ -105,6 +136,8 @@ export function buildHeaderUrl(s: HeaderState, baseUrl: string): string {
   if (s.font && s.font !== "inter") params.set("font", s.font)
   if (s.watermark) params.set("watermark", "true")
   if (!s.border) params.set("border", "false")
+  if (s.image) params.set("image", s.image)
+  if (s.image && s.overlay) params.set("overlay", s.overlay)
 
   const preset = s.preset || "surface"
   const qs = params.toString()


### PR DESCRIPTION
## What

Adds **photo background support to headers** (Unsplash or any image URL), in both the standalone `/header` builder and the README Studio header inspector.

- New header param `image=<url>`. Because the header SVG is sandboxed (served as `<img>`, no external resources load), the server **fetches the photo and inlines it as a base64 data URI**.
- For `images.unsplash.com` URLs it requests a banner-sized JPEG via Unsplash's imgix params (`w/q/fit/fm`) so the inlined payload stays small.
- **Auto scrim** for legibility: a flat tint plus a bottom-weighted gradient, tunable via `overlay` (0–1) and `tint`. Title/subtitle are forced light over photos.
- Raster-only (jpeg/png/webp/gif/avif), 4 MB cap, and a graceful fallback to the normal preset background on any fetch failure.
- UI: a "Background image" field + a one-click **random Unsplash** shuffle in both the `/header` builder and the Studio header inspector.

## Why

Repo headers were limited to generated backgrounds (surface, gradient, dots, grid, graph, glow). Photo banners are a common README style and a frequent ask.

Closes #

## Type

- [x] `feat` — New feature

## Checklist

- [x] Branch follows conventional naming (`feat/`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tested locally with `pnpm dev`
- [x] Renders correctly in SVG and PNG (verified 200 + inlined JPEG + scrim; PNG via resvg)
- [ ] Docs updated (follow-up: document `image`/`overlay`/`tint` on the headers docs page)

## How

- `packages/core/src/badges/header-backgrounds.ts` — `imageDataUri`/`overlay`/`tint` inputs; renders the photo edge-to-edge with `preserveAspectRatio="xMidYMid slice"` + auto scrim; skips patterns/glow over a photo; forces light text.
- `packages/core/src/route-handler.ts` — `resolveHeaderImage()` (data-URI passthrough or fetch+inline, Unsplash imgix sizing, type/size guards); wires `image`/`overlay`/`tint` into `handleHeader`.
- `packages/web/lib/header-builder-shared.ts` — `image`/`overlay` on `HeaderState`, `buildHeaderUrl`, plus `unsplashUrl()` / `randomUnsplashHeader()` (curated banner photos).
- `packages/web/components/header-builder.tsx` + `components/studio/inspectors.tsx` — the "Background image" field + shuffle.

## Testing

- 110/110 core tests pass (`vitest`); `tsc` + `eslint` clean; pre-commit hook passed.
- Verified live: `/header/*.svg?image=<unsplash>` returns 200 with an inlined JPEG + scrim and light title; PNG renders via resvg; a bad image URL falls back to the preset; the Studio preview and export URL carry `image=`.

## Stacking

This branches off `feat/readme-studio` (PR #143) because it also wires the Studio header inspector. Merge **after #143**; once #143 lands in `main`, this PR's diff reduces to just the Unsplash changes.

## Screenshots

Header with an Unsplash photo background + auto scrim (white title legible over the image), verified locally.
