### PR TITLE
feat(sponsors): add sponsors grid image, generator, and Studio block

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,20 @@ Premade backgrounds: `surface`, `gradient`, `dots`, `grid`, `graph`, `glow`,
 [header generator](https://shieldcn.dev/header) or see the
 [Headers docs](https://shieldcn.dev/docs/headers).
 
+### Sponsors
+
+A grid of your account's active public GitHub Sponsors — every sponsor's
+avatar, name, and link — as one portable image:
+
+```md
+![Sponsors](https://shieldcn.dev/sponsors/shadcn.svg)
+```
+
+Pin logins into larger `special` and smaller `backers` rows; everyone else
+lands in the default `Sponsors` row. Available as `.svg`, `.png`, and `.json`.
+Customize with `special`, `backers`, `title`, `size`, `limit`, `names`, `bg`,
+and more. See the [Sponsors docs](https://shieldcn.dev/docs/sponsors).
+
 ## Supported providers
 
 See the [docs](https://shieldcn.dev/docs) for full endpoint details, interactive sandboxes, and copy-paste examples.

--- a/packages/core/src/badges/render-sponsors.ts
+++ b/packages/core/src/badges/render-sponsors.ts
@@ -1,0 +1,316 @@
+/**
+ * shieldcn
+ * src/badges/render-sponsors
+ *
+ * Sponsors grid image renderer. Hand-built SVG (like the header / chart
+ * renderers) so the result is safe inside a sandboxed `<img>` SVG — no
+ * external CSS, no CSS variables, no remote image refs (every avatar is
+ * inlined by the route handler as a base64 data URI before it reaches here).
+ *
+ * A sponsors image is: an optional title, then one or more tiers, each a
+ * centered grid of circular sponsor avatars with an optional name caption.
+ * Tiers let the repo owner pin "special sponsors" larger at the top and
+ * "backers" smaller at the bottom. Layout and sizing are driven by the URL.
+ */
+
+import { resolveFontFamily } from "./render-chart"
+import { resolveHeaderBackground } from "./header-backgrounds"
+
+export interface SponsorAvatar {
+  login: string
+  /** Display name (falls back to login when absent). */
+  name: string | null
+  /** Inlined avatar image (`data:image/...;base64,...`) or undefined. */
+  imageDataUri?: string
+  url: string
+}
+
+export interface SponsorTier {
+  /** Optional centered heading above the row (e.g. "Special Sponsors"). */
+  title?: string
+  /** Avatar diameter in px. */
+  size: number
+  avatars: SponsorAvatar[]
+}
+
+export interface SponsorsConfig {
+  /** Overall heading (e.g. "Sponsors"). Omit/empty to hide. */
+  title?: string
+  tiers: SponsorTier[]
+  width: number
+  mode: "dark" | "light"
+  /** Corner radius in px. */
+  radius: number
+  /** font-family stack (resolved from the `font` keyword). */
+  fontFamily?: string
+  /** Draw a 1px hairline border around the card. */
+  border: boolean
+  /** Show a subtle shieldcn.dev watermark. */
+  watermark: boolean
+  /** Render a name caption under each avatar. */
+  showNames: boolean
+  /** Message shown when there are no public sponsors. */
+  emptyText?: string
+
+  // --- Background (same premade system as headers) ---
+  /** Named preset: surface | gradient | dots | grid | graph | glow | transparent. */
+  preset?: string | null
+  /** shadcn theme name — tints the accent / glow. */
+  theme?: string | null
+  /** Solid background color hex (no #). Replaces the preset base. */
+  bg?: string | null
+  /** Custom gradient "c1,c2[,c3][,angle]" (hex without #). */
+  gradient?: string | null
+  /** Overlay pattern: dots | grid | graph | none. */
+  pattern?: string | null
+  /** Spotlight glow color hex (no #). */
+  glow?: string | null
+  /** Accent color hex (no #) — also colors the title rule. */
+  accent?: string | null
+  /** Render with no background fill (blend into the host page). */
+  transparent?: boolean
+  /** Inlined background photo data URI (already fetched + base64 by the route). */
+  imageDataUri?: string | null
+  /** Scrim strength over a photo, 0–1. */
+  overlay?: number | null
+  /** Scrim tint color hex (no #). */
+  tint?: string | null
+}
+
+/** shieldcn logo glyph (viewBox 0 0 512 512). */
+const SHIELDCN_LOGO =
+  '<path d="M148.02,363.76c-4.48,0-8.64-2.42-10.86-6.32l-54.29-95.68c-2.15-3.8-2.15-8.52,0-12.32l54.29-95.68c2.21-3.9,6.37-6.32,10.86-6.32h18.51c4.44,0,8.45,2.28,10.73,6.09,2.27,3.82,2.37,8.43.25,12.33l-42.23,77.99c-3.98,7.36-3.98,16.14,0,23.49l22.22,41.02c4.25,7.85,12.43,12.8,21.36,12.92,0,0,45.08.61,45.11.61,8.68,0,16.83-4.64,21.26-12.12l24.87-41.99c2.23-3.77,6.34-6.11,10.72-6.12l19.47-.04c4.48,0,8.49,2.29,10.76,6.12,2.27,3.83,2.35,8.45.21,12.35l-42.2,77.17c-2.19,4-6.39,6.49-10.95,6.49h-110.08Z"/><path d="M346.7,363.69c-4.44,0-8.45-2.28-10.73-6.09-2.27-3.82-2.37-8.43-.25-12.33l42.23-77.99c3.98-7.35,3.98-16.14,0-23.49l-22.22-41.02c-4.25-7.85-12.44-12.8-21.36-12.92,0,0-46.51-.63-46.53-.63-8.88,0-17.12,4.81-21.48,12.54l-23.35,41.36c-2.2,3.9-6.36,6.34-10.84,6.35l-19.21.04c-4.48,0-8.49-2.29-10.76-6.12-2.27-3.83-2.35-8.45-.22-12.36l42.2-77.17c2.19-4.01,6.39-6.5,10.95-6.5h110.08c4.48,0,8.64,2.42,10.86,6.32l54.29,95.68c2.16,3.8,2.16,8.52,0,12.32l-54.29,95.68c-2.21,3.9-6.37,6.32-10.86,6.32h-18.51Z"/>'
+
+const AVATAR_CLIP_ID = "scAvatarClip"
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+}
+
+function r2(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, n))
+}
+
+/** Truncate `text` to roughly `maxWidth` px at `fontSize` (no font metrics). */
+function truncate(text: string, maxWidth: number, fontSize: number, charFactor = 0.58): string {
+  const maxChars = Math.max(3, Math.floor(maxWidth / (fontSize * charFactor)))
+  if (text.length <= maxChars) return text
+  return text.slice(0, Math.max(1, maxChars - 1)).replace(/\s+$/, "") + "…"
+}
+
+/**
+ * Initials placeholder when an avatar image couldn't be inlined — keeps the
+ * grid intact instead of leaving a hole or hot-linking a remote image.
+ */
+function placeholderAvatar(login: string, x: number, y: number, size: number, isLight: boolean): string {
+  const bg = isLight ? "#e4e4e7" : "#27272a"
+  const fg = isLight ? "#52525b" : "#a1a1aa"
+  const r = size / 2
+  const initial = esc((login[0] || "?").toUpperCase())
+  return (
+    `<circle cx="${r2(x + r)}" cy="${r2(y + r)}" r="${r2(r)}" fill="${bg}" />` +
+    `<text x="${r2(x + r)}" y="${r2(y + r + size * 0.16)}" text-anchor="middle" font-size="${r2(size * 0.42)}" font-weight="600" fill="${fg}">${initial}</text>`
+  )
+}
+
+/** Render one avatar (circular image + hairline ring), optionally linked. */
+function renderAvatar(
+  a: SponsorAvatar,
+  x: number,
+  y: number,
+  size: number,
+  ringColor: string,
+  isLight: boolean,
+): string {
+  const img = a.imageDataUri
+    ? `<image href="${a.imageDataUri}" x="${r2(x)}" y="${r2(y)}" width="${r2(size)}" height="${r2(size)}" preserveAspectRatio="xMidYMid slice" clip-path="url(#${AVATAR_CLIP_ID})" />`
+    : placeholderAvatar(a.login, x, y, size, isLight)
+  const ring = `<circle cx="${r2(x + size / 2)}" cy="${r2(y + size / 2)}" r="${r2(size / 2 - 0.5)}" fill="none" stroke="${ringColor}" stroke-width="1" />`
+  const inner = img + ring
+  // Wrap in a link so the avatar is clickable when the SVG is opened directly.
+  return `<a href="${esc(a.url)}" target="_blank" rel="noopener">${inner}</a>`
+}
+
+interface TierLayout {
+  svg: string
+  height: number
+}
+
+/** Lay a single tier (heading + centered avatar grid) starting at `top`. */
+function layoutTier(
+  tier: SponsorTier,
+  top: number,
+  width: number,
+  padX: number,
+  cfg: SponsorsConfig,
+  colors: { fg: string; muted: string; ring: string; isLight: boolean },
+): TierLayout {
+  const parts: string[] = []
+  let y = top
+
+  const titleSize = 15
+  if (tier.title) {
+    parts.push(
+      `<text x="${r2(width / 2)}" y="${r2(y + titleSize)}" text-anchor="middle" font-size="${titleSize}" font-weight="600" fill="${colors.muted}" font-family="${cfg.fontFamily}" letter-spacing="0.04em">${esc(tier.title)}</text>`,
+    )
+    y += titleSize + 18
+  }
+
+  const size = tier.size
+  const gap = clamp(Math.round(size * 0.34), 12, 40)
+  const nameSize = clamp(Math.round(size * 0.18), 11, 14)
+  const nameH = cfg.showNames ? nameSize + 8 : 0
+  const cellW = size + gap
+  const cellH = size + nameH + gap
+
+  const availW = width - padX * 2
+  const perRow = Math.max(1, Math.min(tier.avatars.length, Math.floor((availW + gap) / cellW)))
+
+  let i = 0
+  while (i < tier.avatars.length) {
+    const rowItems = tier.avatars.slice(i, i + perRow)
+    const rowW = rowItems.length * cellW - gap
+    let x = r2((width - rowW) / 2)
+    const rowTop = y
+    for (const a of rowItems) {
+      parts.push(renderAvatar(a, x, rowTop, size, colors.ring, colors.isLight))
+      if (cfg.showNames) {
+        const label = a.name ?? a.login
+        parts.push(
+          `<text x="${r2(x + size / 2)}" y="${r2(rowTop + size + nameSize + 2)}" text-anchor="middle" font-size="${nameSize}" font-weight="500" fill="${colors.fg}" font-family="${cfg.fontFamily}">${esc(truncate(label, size + gap, nameSize))}</text>`,
+        )
+      }
+      x = r2(x + cellW)
+    }
+    y += cellH
+    i += perRow
+  }
+  // Trailing gap belongs between tiers, not inside the measured block.
+  y -= gap
+
+  return { svg: parts.join("\n    "), height: y - top }
+}
+
+/**
+ * Render a sponsors grid to an SVG string. Height is computed from the tiers.
+ */
+export function renderSponsors(cfg: SponsorsConfig): { svg: string; height: number } {
+  const { width } = cfg
+  const fontStack = cfg.fontFamily ?? resolveFontFamily("inter")
+  cfg.fontFamily = fontStack
+  const radius = clamp(cfg.radius, 0, 80)
+
+  // Resolve the background using the shared header system. width/height only
+  // affect the paint geometry — not `isLight`/`accent`/`border` — so a probe
+  // pass with a provisional height yields the contrast info we need to lay out
+  // text before the real height is known.
+  const bgInput = {
+    preset: cfg.preset,
+    mode: cfg.mode,
+    width,
+    radius,
+    theme: cfg.theme,
+    transparent: cfg.transparent,
+    bg: cfg.bg,
+    gradient: cfg.gradient,
+    pattern: cfg.pattern,
+    glow: cfg.glow,
+    accent: cfg.accent,
+    imageDataUri: cfg.imageDataUri,
+    overlay: cfg.overlay,
+    tint: cfg.tint,
+  }
+  const probe = resolveHeaderBackground({ ...bgInput, height: 200 })
+  const isLight = probe.isLight
+
+  const fg = isLight ? "#18181b" : "#fafafa"
+  const muted = isLight ? "rgba(24,24,27,0.6)" : "rgba(250,250,250,0.55)"
+  const ring = isLight ? "rgba(24,24,27,0.12)" : "rgba(250,250,250,0.14)"
+  const colors = { fg, muted, ring, isLight }
+
+  const padX = clamp(Math.round(width * 0.05), 28, 80)
+  const padY = 32
+
+  const body: string[] = []
+  let y = padY
+
+  // --- Title + hairline rule ---
+  if (cfg.title) {
+    const titleSize = 26
+    body.push(
+      `<text x="${padX}" y="${r2(y + titleSize)}" font-size="${titleSize}" font-weight="700" fill="${fg}" font-family="${fontStack}" letter-spacing="-0.02em">${esc(cfg.title)}</text>`,
+    )
+    y += titleSize + 14
+    const ruleColor = cfg.accent ? `#${cfg.accent.replace(/^#/, "")}` : probe.border
+    body.push(
+      `<rect x="${padX}" y="${r2(y)}" width="${r2(width - padX * 2)}" height="1" fill="${ruleColor}" />`,
+    )
+    y += 28
+  }
+
+  const hasAny = cfg.tiers.some((t) => t.avatars.length > 0)
+  if (!hasAny) {
+    const msg = cfg.emptyText ?? "No public sponsors yet"
+    body.push(
+      `<text x="${r2(width / 2)}" y="${r2(y + 40)}" text-anchor="middle" font-size="16" font-weight="500" fill="${muted}" font-family="${fontStack}">${esc(msg)}</text>`,
+    )
+    y += 80
+  } else {
+    for (const tier of cfg.tiers) {
+      if (tier.avatars.length === 0) continue
+      const laid = layoutTier(tier, y, width, padX, cfg, colors)
+      body.push(laid.svg)
+      y += laid.height + 34
+    }
+    y -= 34
+  }
+
+  const height = Math.round(y + padY)
+
+  // --- Background (resolved at the real height) / border / watermark ---
+  const bg = resolveHeaderBackground({ ...bgInput, height })
+
+  const border = cfg.border
+    ? `<rect x="0.5" y="0.5" width="${width - 1}" height="${height - 1}" rx="${Math.max(0, radius - 0.5)}" fill="none" stroke="${bg.border}" stroke-width="1" />`
+    : ""
+
+  let watermark = ""
+  if (cfg.watermark) {
+    const wmColor = isLight ? "rgba(24,24,27,0.45)" : "rgba(250,250,250,0.45)"
+    const wmSize = 13
+    const lx = width - 18 - wmSize
+    const ly = height - 16 - wmSize
+    watermark =
+      `<g>` +
+      `<text x="${lx - 6}" y="${r2(ly + wmSize / 2 + 4)}" text-anchor="end" font-size="${wmSize}" font-weight="500" fill="${wmColor}" font-family="${fontStack}">shieldcn.dev</text>` +
+      `<g transform="translate(${lx}, ${ly}) scale(${r2(wmSize / 512)})" fill="${wmColor}">${SHIELDCN_LOGO}</g>` +
+      `</g>`
+  }
+
+  const ariaLabel = esc(cfg.title ? `${cfg.title} — GitHub sponsors` : "GitHub sponsors")
+  const cardClipId = "scCardClip"
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-label="${ariaLabel}">
+  <defs>
+    <clipPath id="${cardClipId}"><rect x="0" y="0" width="${width}" height="${height}" rx="${radius}" /></clipPath>
+    <clipPath id="${AVATAR_CLIP_ID}" clipPathUnits="objectBoundingBox"><circle cx="0.5" cy="0.5" r="0.5" /></clipPath>
+    ${bg.defs}
+  </defs>
+  <g clip-path="url(#${cardClipId})">
+    ${bg.layers}
+    ${body.join("\n    ")}
+  </g>
+  ${border}
+  ${watermark}
+</svg>`
+
+  return { svg, height }
+}

--- a/packages/core/src/badges/sponsors-route.test.ts
+++ b/packages/core/src/badges/sponsors-route.test.ts
@@ -94,6 +94,16 @@ describe("handleBadgeGET /sponsors", () => {
     expect(body.sponsors.map((s) => s.login)).toEqual(["sponsor1", "sponsor2", "sponsor3"])
   })
 
+  it("strips a leading @ from the login (intuitive hand-written URLs)", async () => {
+    // /sponsors/@jal-co.svg should resolve the same account as /sponsors/jal-co.
+    const req = new Request("https://x.dev/sponsors/@jal-co.json")
+    const res = await handleBadgeGET(req, ["sponsors", "@jal-co.json"])
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { login: string; publicCount: number }
+    expect(body.login).toBe("jal-co")
+    expect(body.publicCount).toBe(3)
+  })
+
   it("renders an SVG grid with inlined avatar images", async () => {
     const req = new Request("https://x.dev/sponsors/jal-co.svg")
     const res = await handleBadgeGET(req, ["sponsors", "jal-co.svg"])

--- a/packages/core/src/badges/sponsors-route.test.ts
+++ b/packages/core/src/badges/sponsors-route.test.ts
@@ -1,0 +1,141 @@
+/**
+ * shieldcn
+ * src/badges/sponsors-route.test
+ *
+ * End-to-end: handleBadgeGET routes /sponsors/{login} through the GitHub
+ * Sponsors-list provider (GraphQL, mocked) and renders the avatar-grid SVG.
+ * Avatar images are fetched and inlined as base64 data URIs (mocked, no
+ * network).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { handleBadgeGET } from "../route-handler"
+
+// A 1x1 transparent PNG (smallest valid raster the inliner will accept).
+const PNG_1x1 = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+  "base64",
+)
+
+function sponsorNode(i: number) {
+  return {
+    __typename: "User",
+    login: `sponsor${i}`,
+    name: `Sponsor ${i}`,
+    avatarUrl: `https://avatars.githubusercontent.com/u/${i}?s=160`,
+    url: `https://github.com/sponsor${i}`,
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string, init?: RequestInit) => {
+      // GitHub Sponsors-list GraphQL (the list query asks for `nodes`).
+      if (url === "https://api.github.com/graphql" && init?.method === "POST") {
+        const body = JSON.parse(String(init.body)) as { query: string; variables?: { login?: string } }
+        const login = body.variables?.login ?? ""
+        if (!body.query.includes("nodes")) {
+          return new Response(JSON.stringify({ data: { repositoryOwner: null } }), { status: 200 })
+        }
+        const repositoryOwner =
+          login === "jal-co"
+            ? {
+                __typename: "User",
+                sponsors: {
+                  totalCount: 5,
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                  nodes: [sponsorNode(1), sponsorNode(2), sponsorNode(3)],
+                },
+              }
+            : login === "empty"
+              ? {
+                  __typename: "User",
+                  sponsors: { totalCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+                }
+              : null
+        return new Response(JSON.stringify({ data: { repositoryOwner } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      }
+
+      // Avatar image fetches → small PNG.
+      if (url.startsWith("https://avatars.githubusercontent.com/")) {
+        return new Response(PNG_1x1, { status: 200, headers: { "content-type": "image/png" } })
+      }
+
+      return new Response("not found", { status: 404 })
+    }),
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe("handleBadgeGET /sponsors", () => {
+  it("returns sponsor data as JSON", async () => {
+    const req = new Request("https://x.dev/sponsors/jal-co.json")
+    const res = await handleBadgeGET(req, ["sponsors", "jal-co.json"])
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      type: string
+      login: string
+      totalCount: number
+      publicCount: number
+      sponsors: { login: string }[]
+    }
+    expect(body.type).toBe("sponsors")
+    expect(body.login).toBe("jal-co")
+    expect(body.totalCount).toBe(5)
+    expect(body.publicCount).toBe(3)
+    expect(body.sponsors.map((s) => s.login)).toEqual(["sponsor1", "sponsor2", "sponsor3"])
+  })
+
+  it("renders an SVG grid with inlined avatar images", async () => {
+    const req = new Request("https://x.dev/sponsors/jal-co.svg")
+    const res = await handleBadgeGET(req, ["sponsors", "jal-co.svg"])
+    expect(res.status).toBe(200)
+    expect(res.headers.get("Content-Type")).toBe("image/svg+xml")
+    const svg = await res.text()
+    expect(svg.startsWith("<svg")).toBe(true)
+    // Avatars inlined as base64 data URIs, not hot-linked.
+    expect(svg).toContain("data:image/png;base64,")
+    expect(svg).not.toContain("https://avatars.githubusercontent.com/")
+    // Default title shown.
+    expect(svg).toContain("Sponsors")
+    // One <a> wrapper per rendered avatar.
+    expect((svg.match(/<a href=/g) || []).length).toBe(3)
+  })
+
+  it("pins logins into a Special Sponsors tier via ?special=", async () => {
+    const req = new Request("https://x.dev/sponsors/jal-co.svg?special=sponsor1")
+    const res = await handleBadgeGET(req, ["sponsors", "jal-co.svg"])
+    const svg = await res.text()
+    expect(svg).toContain("Special Sponsors")
+  })
+
+  it("renders an empty-state message when there are no public sponsors", async () => {
+    const req = new Request("https://x.dev/sponsors/empty.svg")
+    const res = await handleBadgeGET(req, ["sponsors", "empty.svg"])
+    expect(res.status).toBe(200)
+    const svg = await res.text()
+    expect(svg).toContain("No public sponsors")
+    expect(svg).not.toContain("<a href=")
+  })
+
+  it("renders a card-shaped fallback (not a red badge pill) for an unknown account", async () => {
+    const req = new Request("https://x.dev/sponsors/does-not-exist.svg")
+    const res = await handleBadgeGET(req, ["sponsors", "does-not-exist.svg"])
+    expect(res.headers.get("Content-Type")).toBe("image/svg+xml")
+    const svg = await res.text()
+    // A large image element must degrade to the full sponsors card, never the
+    // tiny destructive-red badge pill scaled up huge.
+    expect(svg.startsWith("<svg")).toBe(true)
+    expect(svg.toLowerCase()).not.toContain("#dc2626")
+    expect(svg).toContain("No public sponsors to show")
+    expect(svg).not.toContain("data:image/png")
+  })
+})

--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -756,3 +756,105 @@ export async function getGitHubSponsors(login: string): Promise<BadgeData | null
     link: `https://github.com/sponsors/${login}`,
   }
 }
+
+// ---------------------------------------------------------------------------
+// Sponsors list (public active sponsors — avatars, names, logins)
+// ---------------------------------------------------------------------------
+
+/** A single public sponsor of an account. */
+export interface SponsorEntry {
+  login: string
+  name: string | null
+  /** GitHub-hosted avatar URL (sized via the GraphQL `size:` argument). */
+  avatarUrl: string
+  url: string
+  type: "User" | "Organization"
+}
+
+/** Resolved public-sponsor list for an account. */
+export interface SponsorsList {
+  /** Total active sponsors (includes private ones in the number only). */
+  totalCount: number
+  /** The publicly-visible sponsors, in GitHub's returned order. */
+  sponsors: SponsorEntry[]
+}
+
+// `sponsors` is the set of accounts *currently* sponsoring this one. Only the
+// public sponsors expose identity (login/name/avatar); private sponsors are
+// counted in `totalCount` but never enumerated to a pooled token. `avatarUrl`
+// takes a pixel `size` so GitHub returns an already-downscaled image, keeping
+// the inlined data URI small. Both User and Organization owners expose the same
+// `sponsors` connection, so the concrete-type spreads cover either account.
+const SPONSORS_LIST_NODE = `__typename
+  ... on User { login name avatarUrl(size: 160) url }
+  ... on Organization { login name avatarUrl(size: 160) url }`
+const SPONSORS_LIST_QUERY = `query($login: String!, $after: String) {
+  repositoryOwner(login: $login) {
+    ... on User { sponsors(first: 100, after: $after) { totalCount pageInfo { hasNextPage endCursor } nodes { ${SPONSORS_LIST_NODE} } } }
+    ... on Organization { sponsors(first: 100, after: $after) { totalCount pageInfo { hasNextPage endCursor } nodes { ${SPONSORS_LIST_NODE} } } }
+  }
+}`
+
+interface RawSponsorNode {
+  __typename?: string
+  login?: unknown
+  name?: unknown
+  avatarUrl?: unknown
+  url?: unknown
+}
+
+interface RawSponsorsConnection {
+  totalCount?: unknown
+  pageInfo?: { hasNextPage?: unknown; endCursor?: unknown }
+  nodes?: unknown
+}
+
+/**
+ * Fetch the public active-sponsor list for a user or organization. Paginates
+ * up to {@link SPONSORS_PAGE_CAP} pages (100 each) so very large sponsor lists
+ * stay bounded. Returns null on any failure (so the route serves
+ * last-known-good instead of an error image).
+ */
+const SPONSORS_PAGE_CAP = 3
+
+export async function getGitHubSponsorsList(login: string): Promise<SponsorsList | null> {
+  const sponsors: SponsorEntry[] = []
+  let totalCount = 0
+  let after: string | null = null
+  let resolvedAny = false
+
+  for (let page = 0; page < SPONSORS_PAGE_CAP; page++) {
+    const data: Record<string, unknown> | null = await githubGraphQL(SPONSORS_LIST_QUERY, { login, after })
+    const owner = data?.repositoryOwner as { sponsors?: RawSponsorsConnection } | null | undefined
+    const conn = owner?.sponsors
+    if (!conn) {
+      // A null owner on the very first page means the account couldn't be
+      // resolved (or the call failed) — surface that as a miss. After at least
+      // one good page, stop and return what we have.
+      if (!resolvedAny) return null
+      break
+    }
+    resolvedAny = true
+    if (typeof conn.totalCount === "number") totalCount = conn.totalCount
+
+    const nodes = Array.isArray(conn.nodes) ? (conn.nodes as RawSponsorNode[]) : []
+    for (const n of nodes) {
+      if (typeof n?.login !== "string" || typeof n?.avatarUrl !== "string") continue
+      sponsors.push({
+        login: n.login,
+        name: typeof n.name === "string" && n.name.trim() ? n.name : null,
+        avatarUrl: n.avatarUrl,
+        url: typeof n.url === "string" ? n.url : `https://github.com/${n.login}`,
+        type: n.__typename === "Organization" ? "Organization" : "User",
+      })
+    }
+
+    const hasNext = conn.pageInfo?.hasNextPage === true
+    const endCursor = conn.pageInfo?.endCursor
+    if (!hasNext || typeof endCursor !== "string") break
+    after = endCursor
+  }
+
+  if (!resolvedAny) return null
+  return { totalCount, sponsors }
+}

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -2257,7 +2257,12 @@ async function handleSponsors(
   options?: BadgeRequestOptions,
 ): Promise<Response> {
   const rest = cleanSegments.slice(1) // after "sponsors"
-  const login = rest[0]
+  // Normalize the login the same way the tier params (parseLoginList) and the
+  // URL generator (buildSponsorsUrl) do: a leading `@` is intuitive in a
+  // hand-written URL (/sponsors/@vercel.svg) but GitHub logins never contain
+  // one, so passing it to the GraphQL `repositoryOwner(login:)` lookup would
+  // miss and fall back to the empty card.
+  const login = (rest[0] ?? "").trim().replace(/^@/, "")
 
   const mode = (searchParams.get("mode") === "light" ? "light" : "dark") as "light" | "dark"
   const width = clampNum(searchParams.get("width"), 320, 2000, 800)

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -9,6 +9,7 @@
 import { renderBadge, renderBadgeBase, renderErrorBadge } from "./badges/render"
 import { renderChart, resolveAccent, resolveFontFamily, type ChartSeries, type ChartPoint } from "./badges/render-chart"
 import { renderHeader, type HeaderLogoInput } from "./badges/render-header"
+import { renderSponsors, type SponsorAvatar, type SponsorTier } from "./badges/render-sponsors"
 import { resolveHeaderBackground } from "./badges/header-backgrounds"
 import { getStarHistory, getIssueHistory } from "./providers/starhistory"
 import { getNpmDownloadSeries } from "./providers/npm"
@@ -114,6 +115,8 @@ import {
   getGitHubFollowers,
   getGitHubUserStars,
   getGitHubSponsors,
+  getGitHubSponsorsList,
+  type SponsorEntry,
   githubRepoExists,
 } from "./providers/github"
 import { getDiscordOnline, getDiscordByInvite } from "./providers/discord"
@@ -2130,6 +2133,312 @@ async function resolveHeaderImage(imageParam: string | null): Promise<string | u
   }
 }
 
+// ---------------------------------------------------------------------------
+// Sponsors image (/sponsors/{login}.svg) — public active-sponsor avatar grid.
+// ---------------------------------------------------------------------------
+
+/** Max bytes for a single inlined avatar (~200 KB). */
+const MAX_AVATAR_BYTES = 200_000
+/** Avatar image types we inline (GitHub serves png/jpeg/webp/gif). */
+const AVATAR_IMAGE_TYPES = new Set(["image/jpeg", "image/png", "image/webp", "image/gif", "image/avif"])
+/** Hard cap on how many avatars a single sponsors image will inline. */
+const SPONSORS_RENDER_CAP = 80
+/** Sponsors-image cache tuning (sponsor lists change slowly). */
+const SPONSORS_FRESH_TTL = 60 * 30 // 30 min fresh copy
+const SPONSORS_STALE_TTL = 60 * 60 * 24 * 7 // 7 day last-known-good fallback
+
+/**
+ * Rasterize an SVG string to PNG bytes via resvg-wasm, with the bundled fonts
+ * supplied so text (sponsor names, titles) renders in the wasm sandbox (which
+ * has no system fonts). Mirrors the header PNG path.
+ */
+async function rasterizeToPng(svg: string): Promise<Uint8Array> {
+  const { Resvg, initWasm } = await import("@resvg/resvg-wasm")
+  try {
+    let wasmLoaded = false
+    if (typeof process !== "undefined" && process.env.NODE_ENV === "production") {
+      try {
+        const fs = await import("node:fs")
+        const path = await import("node:path")
+        const candidates = [
+          path.join(process.cwd(), "node_modules", "@resvg", "resvg-wasm", "index_bg.wasm"),
+        ]
+        for (const p of candidates) {
+          if (fs.existsSync(p)) {
+            await initWasm(fs.readFileSync(p))
+            wasmLoaded = true
+            break
+          }
+        }
+      } catch { /* fs not available */ }
+    }
+    if (!wasmLoaded) {
+      await initWasm(fetch("https://unpkg.com/@resvg/resvg-wasm/index_bg.wasm"))
+    }
+  } catch { /* already initialized */ }
+  const { getFontBuffers, DEFAULT_FONT_FAMILY } = await import("./badges/fonts")
+  const resvg = new Resvg(svg, {
+    font: {
+      fontBuffers: getFontBuffers(),
+      defaultFontFamily: DEFAULT_FONT_FAMILY,
+      loadSystemFonts: false,
+    },
+  })
+  return resvg.render().asPng()
+}
+
+/** Default avatar diameters (px) per tier, scaled from the base `size`. */
+function tierSizes(base: number): { special: number; sponsors: number; backers: number } {
+  return {
+    special: Math.round(base * 1.35),
+    sponsors: base,
+    backers: Math.round(base * 0.72),
+  }
+}
+
+/**
+ * Fetch a GitHub avatar URL and return it as a base64 `data:` URI, or undefined
+ * on any failure. Never hot-links — a sandboxed `<img>` SVG cannot load remote
+ * images, so every avatar must be inlined.
+ */
+async function inlineAvatar(rawUrl: string): Promise<string | undefined> {
+  if (!/^https?:\/\//.test(rawUrl)) return undefined
+  try {
+    const res = await raceTimeout(
+      fetch(rawUrl, {
+        next: { revalidate: 86400 },
+        headers: { Accept: "image/*", "User-Agent": "shieldcn/1.0" },
+      }),
+    )
+    if (!res?.ok) return undefined
+    const ct = res.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase() || ""
+    if (!AVATAR_IMAGE_TYPES.has(ct)) return undefined
+    const bytes = Buffer.from(await res.arrayBuffer())
+    if (bytes.byteLength === 0 || bytes.byteLength > MAX_AVATAR_BYTES) return undefined
+    return `data:${ct};base64,${bytes.toString("base64")}`
+  } catch {
+    return undefined
+  }
+}
+
+/** Inline a batch of avatars with bounded concurrency. */
+async function inlineAvatars(entries: SponsorEntry[]): Promise<Map<string, string>> {
+  const out = new Map<string, string>()
+  const CONCURRENCY = 8
+  for (let i = 0; i < entries.length; i += CONCURRENCY) {
+    const batch = entries.slice(i, i + CONCURRENCY)
+    const results = await Promise.all(batch.map((e) => inlineAvatar(e.avatarUrl)))
+    results.forEach((uri, j) => {
+      if (uri) out.set(batch[j].login, uri)
+    })
+  }
+  return out
+}
+
+/** Parse a comma-separated login list into a lowercased, de-duped array. */
+function parseLoginList(raw: string | null): string[] {
+  if (!raw) return []
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const part of raw.split(",")) {
+    const login = part.trim().toLowerCase().replace(/^@/, "")
+    if (login && !seen.has(login)) {
+      seen.add(login)
+      out.push(login)
+    }
+  }
+  return out
+}
+
+async function handleSponsors(
+  cleanSegments: string[],
+  searchParams: URLSearchParams,
+  format: Format,
+  options?: BadgeRequestOptions,
+): Promise<Response> {
+  const rest = cleanSegments.slice(1) // after "sponsors"
+  const login = rest[0]
+
+  const mode = (searchParams.get("mode") === "light" ? "light" : "dark") as "light" | "dark"
+  const width = clampNum(searchParams.get("width"), 320, 2000, 800)
+  const radius = clampNum(searchParams.get("radius"), 0, 80, 12)
+  const baseSize = clampNum(searchParams.get("size"), 32, 140, 64)
+  const limit = clampNum(searchParams.get("limit"), 1, SPONSORS_RENDER_CAP, 60)
+  const fontFamily = resolveFontFamily(searchParams.get("font"))
+  const falsy = (v: string | null) => v === "false" || v === "0" || v === "none"
+  const border = !falsy(searchParams.get("border"))
+  const watermark = searchParams.get("watermark") === "true" || searchParams.get("watermark") === "1"
+  const showNames = !falsy(searchParams.get("names"))
+
+  // Title: defaults to "Sponsors"; `title=false`/empty hides it.
+  const titleRaw = searchParams.get("title")
+  const title = titleRaw === null ? "Sponsors" : falsy(titleRaw) ? undefined : titleRaw
+
+  // Background: the same premade system as headers — presets, gradients,
+  // patterns, glow, themes, and photo backgrounds — so the sponsors card is as
+  // customizable as a header banner. `transparent`/`none` blends into the page.
+  const bgRaw = searchParams.get("bg") ?? searchParams.get("background")
+  const transparent = bgRaw === "transparent" || bgRaw === "none"
+  const imageDataUri = await resolveHeaderImage(searchParams.get("image") ?? searchParams.get("bgImage"))
+  const bgParams = {
+    preset: searchParams.get("preset"),
+    theme: searchParams.get("theme"),
+    bg: transparent ? null : resolveColor(bgRaw),
+    transparent,
+    gradient: searchParams.get("gradient"),
+    pattern: searchParams.get("pattern"),
+    glow: resolveColor(searchParams.get("glow")),
+    accent: resolveColor(searchParams.get("accent")),
+    imageDataUri,
+    overlay: searchParams.has("overlay") ? clampNum(searchParams.get("overlay"), 0, 1, 0.45) : undefined,
+    tint: resolveColor(searchParams.get("tint")),
+  }
+
+  // Manual tiers: owner pins logins into a larger "special" row and/or a
+  // smaller "backers" row; everyone else falls into the default "Sponsors" row.
+  const specialLogins = parseLoginList(searchParams.get("special"))
+  const backerLogins = parseLoginList(searchParams.get("backers"))
+  const specialTitle = searchParams.get("specialTitle") ?? "Special Sponsors"
+  const sponsorsTitle = searchParams.get("sponsorsTitle") ?? "Sponsors"
+  const backersTitle = searchParams.get("backersTitle") ?? "Backers"
+
+  // Image response helper (svg or png), shared by the success + fallback paths.
+  const imageResponse = async (svg: string, headers: Record<string, string>): Promise<Response> => {
+    if (format === "png") {
+      const png = await rasterizeToPng(svg)
+      return new Response(Buffer.from(png), { headers: { "Content-Type": "image/png", ...headers } })
+    }
+    return new Response(svg, { headers: { "Content-Type": "image/svg+xml", ...headers } })
+  }
+
+  // A sponsors image is a large element — a failure must degrade to a full,
+  // card-shaped empty state (same chrome as the grid), never a tiny badge
+  // pill scaled up huge. Short-cached so it self-heals when data appears.
+  const fallbackCard = (message: string): Promise<Response> => {
+    const { svg } = renderSponsors({
+      title,
+      tiers: [{ size: tierSizes(baseSize).sponsors, avatars: [] }],
+      width,
+      mode,
+      radius,
+      fontFamily,
+      border,
+      watermark,
+      showNames,
+      ...bgParams,
+      emptyText: message,
+    })
+    return imageResponse(svg, ERROR_CACHE_HEADERS)
+  }
+
+  if (!login) {
+    if (format === "json") {
+      return Response.json({ error: "missing login" }, { status: 400, headers: ERROR_CACHE_HEADERS })
+    }
+    return fallbackCard("Provide a GitHub username or org")
+  }
+
+  // Fetch the public sponsor list (last-known-good on transient failure).
+  let servedStale = false
+  const list = await cachedFetchStale(
+    "github",
+    `sponsors-list/${login.toLowerCase()}`,
+    () => getGitHubSponsorsList(login),
+    SPONSORS_FRESH_TTL,
+    SPONSORS_STALE_TTL,
+    { onStale: () => { servedStale = true } },
+  )
+
+  if (!list) {
+    if (format === "json") {
+      return Response.json({ error: "not found" }, { status: 404, headers: ERROR_CACHE_HEADERS })
+    }
+    // No list: the account has no GitHub Sponsors program, doesn't exist, or
+    // the upstream is transiently unavailable. All three read better as a
+    // calm card than a red error — and the short cache lets it self-heal.
+    return fallbackCard(`No public sponsors to show for @${login}`)
+  }
+
+  const cacheHeaders = servedStale ? ERROR_CACHE_HEADERS : CACHE_HEADERS
+
+  // Partition the public sponsors into tiers.
+  const specialSet = new Set(specialLogins)
+  const backerSet = new Set(backerLogins)
+  const byLogin = new Map(list.sponsors.map((s) => [s.login.toLowerCase(), s]))
+
+  const special: SponsorEntry[] = specialLogins.map((l) => byLogin.get(l)).filter((s): s is SponsorEntry => !!s)
+  const backers: SponsorEntry[] = backerLogins.map((l) => byLogin.get(l)).filter((s): s is SponsorEntry => !!s)
+  const middle: SponsorEntry[] = list.sponsors.filter(
+    (s) => !specialSet.has(s.login.toLowerCase()) && !backerSet.has(s.login.toLowerCase()),
+  )
+
+  // Cap the middle tier so the whole image stays bounded; pinned tiers are
+  // always shown (the owner chose them explicitly).
+  const middleBudget = Math.max(0, limit - special.length - backers.length)
+  const middleShown = middle.slice(0, middleBudget)
+
+  if (format === "json") {
+    return Response.json(
+      {
+        type: "sponsors",
+        login,
+        totalCount: list.totalCount,
+        publicCount: list.sponsors.length,
+        shown: special.length + middleShown.length + backers.length,
+        sponsors: list.sponsors.map((s) => ({ login: s.login, name: s.name, url: s.url, type: s.type })),
+      },
+      { headers: cacheHeaders },
+    )
+  }
+
+  // Inline avatars for everyone we'll actually render.
+  const toRender = [...special, ...middleShown, ...backers]
+  const avatarMap = await inlineAvatars(toRender)
+  const toAvatar = (s: SponsorEntry): SponsorAvatar => ({
+    login: s.login,
+    name: s.name,
+    url: s.url,
+    imageDataUri: avatarMap.get(s.login),
+  })
+
+  const sizes = tierSizes(baseSize)
+  const tiers: SponsorTier[] = []
+  const hasPinned = special.length > 0 || backers.length > 0
+  if (special.length) tiers.push({ title: specialTitle, size: sizes.special, avatars: special.map(toAvatar) })
+  if (middleShown.length) {
+    tiers.push({
+      title: hasPinned ? sponsorsTitle : undefined,
+      size: sizes.sponsors,
+      avatars: middleShown.map(toAvatar),
+    })
+  }
+  if (backers.length) tiers.push({ title: backersTitle, size: sizes.backers, avatars: backers.map(toAvatar) })
+  if (tiers.length === 0) tiers.push({ size: sizes.sponsors, avatars: [] })
+
+  const { svg } = renderSponsors({
+    title,
+    tiers,
+    width,
+    mode,
+    radius,
+    fontFamily,
+    border,
+    watermark,
+    showNames,
+    ...bgParams,
+    emptyText: `No public sponsors yet — sponsor @${login}`,
+  })
+
+  if (options?.onTrack) {
+    void options.onTrack({
+      name: "sponsors_rendered",
+      data: { login, format, mode, shown: toRender.length, total: list.totalCount },
+    })
+  }
+
+  return imageResponse(svg, cacheHeaders)
+}
+
 async function handleHeader(
   cleanSegments: string[],
   searchParams: URLSearchParams,
@@ -2539,6 +2848,14 @@ async function handleBadgeGETInner(
   // ---------------------------------------------------------------------------
   if (cleanSegments[0] === "header") {
     return handleHeader(cleanSegments, searchParams, format, options)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Sponsors grid: /sponsors/{login}.svg?special=...&backers=...
+  // Renders a grid of an account's public active GitHub sponsors' avatars.
+  // ---------------------------------------------------------------------------
+  if (cleanSegments[0] === "sponsors") {
+    return handleSponsors(cleanSegments, searchParams, format, options)
   }
 
   // Fetch badge data from provider

--- a/packages/web/app/showcase/showcase-client.tsx
+++ b/packages/web/app/showcase/showcase-client.tsx
@@ -235,6 +235,7 @@ export default function ShowcasePage() {
 
       <ChartShowcase />
       <HeaderShowcase />
+      <SponsorsShowcase />
     </main>
   )
 }
@@ -302,6 +303,65 @@ function HeaderShowcase() {
             <div className="px-1 pt-3">
               <p className="text-sm font-medium">{h.title}</p>
               <p className="mt-1 text-xs text-muted-foreground">{h.description}</p>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+const SPONSOR_EXAMPLES: { title: string; description: string; src: string; href: string }[] = [
+  {
+    title: "Sponsors grid",
+    description: "Every active public GitHub Sponsor's avatar, names and all.",
+    src: "/sponsors/shadcn.svg",
+    href: "/docs/sponsors",
+  },
+  {
+    title: "Pinned tiers",
+    description: "Pin logins into a larger Special Sponsors row up top.",
+    src: "/sponsors/shadcn.svg?special=vercel,clerk",
+    href: "/docs/sponsors",
+  },
+]
+
+function SponsorsShowcase() {
+  const hydrated = useHydrated()
+  const { adaptUrl } = useBadgeMode()
+  return (
+    <section
+      id="sponsors-showcase"
+      aria-labelledby="sponsors-showcase-title"
+      className="mx-auto w-full max-w-7xl space-y-6 px-4 pb-16 md:px-8"
+    >
+      <div>
+        <h2 id="sponsors-showcase-title" className="font-heading text-2xl font-semibold tracking-tight md:text-3xl">
+          Sponsors
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          A grid of your account&apos;s active public GitHub Sponsors — avatars,
+          names, and links, with optional pinned tiers.
+        </p>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        {SPONSOR_EXAMPLES.map((s) => (
+          <Link
+            key={s.src}
+            href={s.href}
+            className="group rounded-2xl border border-border bg-card p-3 transition-colors hover:border-foreground/20"
+          >
+            <div className="overflow-hidden rounded-lg border border-border/60 bg-muted/30">
+              {hydrated ? (
+                /* eslint-disable-next-line @next/next/no-img-element */
+                <img src={adaptUrl(s.src)} alt={s.title} className="w-full" />
+              ) : (
+                <div className="aspect-[2/1] w-full" />
+              )}
+            </div>
+            <div className="px-1 pt-3">
+              <p className="text-sm font-medium">{s.title}</p>
+              <p className="mt-1 text-xs text-muted-foreground">{s.description}</p>
             </div>
           </Link>
         ))}

--- a/packages/web/app/sponsors/page.tsx
+++ b/packages/web/app/sponsors/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { SiteShell } from "@/components/site-shell"
+import { SponsorsBuilder } from "@/components/sponsors-builder"
+import { pageMetadata } from "@/lib/metadata"
+
+export const metadata: Metadata = pageMetadata({
+  title: "GitHub Sponsors Image Generator",
+  description:
+    "Free tool to generate a GitHub Sponsors grid image for your README: every active public sponsor's avatar, with pinned tiers, shadcn-styled or photo backgrounds, all from one image URL. SVG and PNG, dark and light.",
+  path: "/sponsors",
+})
+
+export default function SponsorsPage() {
+  return (
+    <SiteShell>
+      <main className="min-w-0 flex-1">
+        <div className="px-6 py-8 md:px-10 md:py-10">
+          <div className="mb-6 flex flex-wrap items-end justify-between gap-3">
+            <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">Sponsors image</h1>
+            <Link
+              href="/docs/sponsors"
+              className="text-sm font-medium text-muted-foreground underline underline-offset-4 hover:text-foreground"
+            >
+              Docs &amp; parameters
+            </Link>
+          </div>
+
+          <SponsorsBuilder />
+        </div>
+      </main>
+    </SiteShell>
+  )
+}

--- a/packages/web/components/animated-header.tsx
+++ b/packages/web/components/animated-header.tsx
@@ -35,8 +35,9 @@
 "use client"
 
 import type { ReactNode } from "react"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import Link from "next/link"
+import { ChevronDown } from "lucide-react"
 import { motion, useScroll, useMotionValueEvent, type Transition } from "motion/react"
 import { Button } from "@/components/ui/button"
 import { SponsorButton } from "@/components/sponsor-button"
@@ -87,6 +88,9 @@ const LOGO = {
 // NAV — primary links, staggered in. Items rendered with .map().
 // ---------------------------------------------------------------------------
 
+type NavLink = { href: string; label: string }
+type NavItem = NavLink | { label: string; children: NavLink[] }
+
 const NAV = {
   offsetY: -8, //    px each link drops in from
   stagger: 0.06, //  seconds between each link
@@ -95,10 +99,82 @@ const NAV = {
     { href: "/docs", label: "Docs" },
     { href: "/studio", label: "Studio" },
     { href: "/showcase", label: "Showcase" },
-    { href: "/header", label: "Headers" },
-    { href: "/gen", label: "Generator" },
+    {
+      label: "Generator",
+      children: [
+        { href: "/gen", label: "All badges" },
+        { href: "/header", label: "Headers" },
+        { href: "/sponsors", label: "Sponsors" },
+      ],
+    },
     { href: "/migrate", label: "Migrate" },
-  ],
+  ] as NavItem[],
+}
+
+// ---------------------------------------------------------------------------
+// NavDropdown — a hover/click menu for a nav item with children. Lightweight
+// (no Radix dependency) so it slots cleanly into the staggered motion items.
+// ---------------------------------------------------------------------------
+
+function NavDropdown({ label, items }: { label: string; items: NavLink[] }) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onDoc = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener("mousedown", onDoc)
+    return () => document.removeEventListener("mousedown", onDoc)
+  }, [open])
+
+  return (
+    <div
+      ref={ref}
+      className="relative"
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+    >
+      <Button
+        variant="ghost"
+        size="sm"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+      >
+        {label}
+        <ChevronDown
+          className={`ml-0.5 size-3.5 transition-transform ${open ? "rotate-180" : ""}`}
+          aria-hidden="true"
+        />
+      </Button>
+      {open && (
+        // Positioned wrapper sits flush against the trigger (top-full) and uses
+        // top *padding* — not margin — as a hover-safe bridge: the visual gap is
+        // still part of the hoverable element, so the cursor can travel from the
+        // button to the menu without leaving the dropdown and closing it.
+        <div className="absolute left-0 top-full z-40 min-w-[180px] pt-1.5">
+          <div
+            role="menu"
+            className="rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-md"
+          >
+            {items.map((it) => (
+              <Link
+                key={it.href}
+                href={it.href}
+                role="menuitem"
+                onClick={() => setOpen(false)}
+                className="flex items-center rounded-md px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground focus-visible:outline-none"
+              >
+                {it.label}
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
 }
 
 // ---------------------------------------------------------------------------
@@ -180,14 +256,18 @@ export function AnimatedHeader({ githubButton }: { githubButton: ReactNode }) {
       <nav className="ml-4 hidden items-center gap-1 text-sm md:flex">
         {NAV.items.map((item, i) => (
           <motion.div
-            key={item.href}
+            key={"children" in item ? item.label : item.href}
             initial={{ opacity: 0, y: NAV.offsetY }}
             animate={{ opacity: stage >= 3 ? 1 : 0, y: stage >= 3 ? 0 : NAV.offsetY }}
             transition={{ ...(NAV.spring as Transition), delay: stage >= 3 ? i * NAV.stagger : 0 }}
           >
-            <Button variant="ghost" size="sm" asChild>
-              <Link href={item.href}>{item.label}</Link>
-            </Button>
+            {"children" in item ? (
+              <NavDropdown label={item.label} items={item.children} />
+            ) : (
+              <Button variant="ghost" size="sm" asChild>
+                <Link href={item.href}>{item.label}</Link>
+              </Button>
+            )}
           </motion.div>
         ))}
       </nav>

--- a/packages/web/components/sidebar.tsx
+++ b/packages/web/components/sidebar.tsx
@@ -181,6 +181,14 @@ const docsNav: NavGroup[] = [
     ],
   },
   {
+    title: "Sponsors",
+    alwaysOpen: true,
+    items: [
+      { title: "Overview", href: "/docs/sponsors" },
+      { title: "Generator", href: "/sponsors" },
+    ],
+  },
+  {
     title: "Registry",
     items: [
       { title: "Overview", href: "/docs/registry" },

--- a/packages/web/components/sponsors-builder.tsx
+++ b/packages/web/components/sponsors-builder.tsx
@@ -1,0 +1,343 @@
+/**
+ * shieldcn
+ * components/sponsors-builder
+ *
+ * Interactive sponsors-image generator. Pick a GitHub login, arrange tiers
+ * (special / backers), choose a background preset, theme, avatar size, and
+ * toggles; preview live; copy the URL as Markdown / HTML / plain URL.
+ * Everything resolves to a /sponsors/{login}.svg image served from the server.
+ */
+
+"use client"
+
+import { useState, useCallback, useMemo, useSyncExternalStore } from "react"
+import { Copy, Check, Shuffle } from "lucide-react"
+import { useTheme } from "next-themes"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Checkbox as ShadcnCheckbox } from "@/components/ui/checkbox"
+import { cn } from "@/lib/utils"
+import {
+  SPONSORS_DEFAULTS,
+  SPONSORS_PRESETS,
+  SPONSORS_PRESET_LABELS,
+  SPONSORS_SIZES,
+  SPONSORS_SIZE_LABELS,
+  SPONSORS_FONTS,
+  SPONSORS_THEMES,
+  buildSponsorsUrl,
+  randomUnsplashHeader,
+  type SponsorsState,
+} from "@/lib/sponsors-builder-shared"
+
+type CopyFormat = "markdown" | "html" | "url"
+
+function formatOutput(url: string, format: CopyFormat, alt: string): string {
+  switch (format) {
+    case "markdown":
+      return `![${alt}](${url})`
+    case "html":
+      return `<img alt="${alt}" src="${url}">`
+    case "url":
+      return url
+  }
+}
+
+const COPY_FORMATS: { value: CopyFormat; label: string }[] = [
+  { value: "markdown", label: "Markdown" },
+  { value: "html", label: "HTML" },
+  { value: "url", label: "URL" },
+]
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+  return <Label className="text-xs text-muted-foreground">{children}</Label>
+}
+
+export function SponsorsBuilder() {
+  const [s, setS] = useState<SponsorsState>(SPONSORS_DEFAULTS)
+  const [copied, setCopied] = useState(false)
+  const [copyError, setCopyError] = useState(false)
+  const [copyFormat, setCopyFormat] = useState<CopyFormat>("markdown")
+  const { resolvedTheme } = useTheme()
+
+  // Read the origin on the client without a setState-in-effect (hydration-safe).
+  const baseUrl = useSyncExternalStore(
+    () => () => {},
+    () => window.location.origin,
+    () => "https://shieldcn.dev",
+  )
+  // Sponsors card mode follows the site theme — derived during render.
+  const mode: "dark" | "light" = resolvedTheme === "light" ? "light" : "dark"
+
+  const set = useCallback(<K extends keyof SponsorsState>(key: K, value: SponsorsState[K]) => {
+    setS((prev) => ({ ...prev, [key]: value }))
+  }, [])
+
+  const url = useMemo(() => buildSponsorsUrl({ ...s, mode }, baseUrl), [s, mode, baseUrl])
+  const altText = `${s.login || "shadcn"} sponsors`
+  const output = useMemo(() => formatOutput(url, copyFormat, altText), [url, copyFormat, altText])
+
+  const handleCopy = useCallback(() => {
+    if (!output) return
+    navigator.clipboard.writeText(output).then(
+      () => {
+        setCopied(true)
+        setTimeout(() => setCopied(false), 2000)
+      },
+      () => {
+        setCopyError(true)
+        setTimeout(() => setCopyError(false), 2000)
+      },
+    )
+  }, [output])
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[340px_minmax(0,1fr)]">
+      {/* ─── Preview + output (right on desktop, first on mobile) ─── */}
+      <div className="order-1 flex flex-col gap-4 lg:order-2">
+        <div
+          className="flex min-h-[300px] flex-1 items-center justify-center rounded-xl border border-border p-6 transition-colors md:p-10"
+          style={{
+            backgroundColor: mode === "light" ? "#f4f4f5" : "#0c0c0e",
+            backgroundImage:
+              mode === "light"
+                ? "radial-gradient(circle, #d4d4d8 1px, transparent 1px)"
+                : "radial-gradient(circle, #27272a 1px, transparent 1px)",
+            backgroundSize: "20px 20px",
+          }}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            key={url}
+            src={url}
+            alt="sponsors preview"
+            className="w-full max-w-[760px] select-none"
+            draggable={false}
+          />
+        </div>
+
+        {/* Copy output */}
+        <div className="space-y-3">
+          <ToggleGroup
+            type="single"
+            value={copyFormat}
+            onValueChange={(v) => v && setCopyFormat(v as CopyFormat)}
+            variant="outline"
+            size="sm"
+            className="w-full max-w-md"
+          >
+            {COPY_FORMATS.map((f) => (
+              <ToggleGroupItem key={f.value} value={f.value} className="flex-1 text-xs">
+                {f.label}
+              </ToggleGroupItem>
+            ))}
+          </ToggleGroup>
+          <div className="flex items-start gap-2">
+            <code className="flex-1 rounded-lg border border-border bg-muted/30 px-3 py-2.5 text-[11px] font-mono break-all text-muted-foreground leading-relaxed min-h-[2.5rem]">
+              {output}
+            </code>
+            <Button variant="outline" size="sm" onClick={handleCopy} className="shrink-0 h-9">
+              {copied ? (
+                <>
+                  <Check className="size-3.5 text-success" /> Copied
+                </>
+              ) : copyError ? (
+                <>
+                  <Copy className="size-3.5 text-destructive" /> Failed
+                </>
+              ) : (
+                <>
+                  <Copy className="size-3.5" /> Copy
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* ─── Controls sidebar (left on desktop) ─── */}
+      <div className="order-2 lg:order-1 space-y-5 rounded-xl border border-border bg-card p-5">
+        {/* Login + title */}
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <FieldLabel>GitHub login (user or org)</FieldLabel>
+            <Input
+              value={s.login}
+              onChange={(e) => set("login", e.target.value)}
+              placeholder="shadcn"
+              className="h-9 text-sm"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <FieldLabel>Title (empty to hide)</FieldLabel>
+            <Input
+              value={s.title}
+              onChange={(e) => set("title", e.target.value)}
+              placeholder="Sponsors"
+              className="h-9 text-sm"
+            />
+          </div>
+        </div>
+
+        {/* Tiers */}
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <FieldLabel>Special sponsors (comma-separated logins)</FieldLabel>
+            <Input
+              value={s.special}
+              onChange={(e) => set("special", e.target.value)}
+              placeholder="vercel, clerk"
+              className="h-9 text-sm"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <FieldLabel>Backers (comma-separated logins)</FieldLabel>
+            <Input
+              value={s.backers}
+              onChange={(e) => set("backers", e.target.value)}
+              placeholder="octocat"
+              className="h-9 text-sm"
+            />
+          </div>
+        </div>
+
+        {/* Background preset */}
+        <div className="space-y-2">
+          <FieldLabel>Background</FieldLabel>
+          <div className="grid grid-cols-2 gap-1.5">
+            {SPONSORS_PRESETS.map((p) => (
+              <button
+                key={p}
+                onClick={() => set("preset", p)}
+                aria-pressed={s.preset === p}
+                className={cn(
+                  "rounded-lg px-1 py-2 text-xs transition-colors",
+                  s.preset === p
+                    ? "bg-primary/10 ring-1 ring-primary text-foreground"
+                    : "hover:bg-muted/60 text-muted-foreground",
+                )}
+              >
+                {SPONSORS_PRESET_LABELS[p]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Background image */}
+        <div className="space-y-2">
+          <FieldLabel>Background image</FieldLabel>
+          <div className="flex gap-2">
+            <Input
+              value={s.image}
+              onChange={(e) => set("image", e.target.value)}
+              placeholder="Unsplash or image URL"
+              className="text-xs"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className="size-9 shrink-0"
+              aria-label="Random Unsplash photo"
+              title="Random Unsplash photo"
+              onClick={() => set("image", randomUnsplashHeader(s.image))}
+            >
+              <Shuffle className="size-3.5" />
+            </Button>
+          </div>
+          {s.image ? (
+            <div className="space-y-1.5">
+              <FieldLabel>Overlay (0–1)</FieldLabel>
+              <Input value={s.overlay} onChange={(e) => set("overlay", e.target.value)} placeholder="0.45" className="h-9" />
+            </div>
+          ) : null}
+        </div>
+
+        {/* Selects */}
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1.5">
+            <FieldLabel>Avatar size</FieldLabel>
+            <Select value={s.size} onValueChange={(v) => set("size", v as SponsorsState["size"])}>
+              <SelectTrigger className="h-9 w-full text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {SPONSORS_SIZES.map((v) => (
+                  <SelectItem key={v} value={v}>
+                    {SPONSORS_SIZE_LABELS[v]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5">
+            <FieldLabel>Theme</FieldLabel>
+            <Select value={s.theme || "_none"} onValueChange={(v) => set("theme", v === "_none" ? "" : v)}>
+              <SelectTrigger className="h-9 w-full text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="_none">None</SelectItem>
+                {SPONSORS_THEMES.map((v) => (
+                  <SelectItem key={v} value={v}>
+                    {v}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5">
+            <FieldLabel>Limit</FieldLabel>
+            <Input
+              value={s.limit}
+              onChange={(e) => set("limit", e.target.value)}
+              placeholder="60"
+              inputMode="numeric"
+              className="h-9 text-sm"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <FieldLabel>Font</FieldLabel>
+            <Select value={s.font} onValueChange={(v) => set("font", v)}>
+              <SelectTrigger className="h-9 w-full text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {SPONSORS_FONTS.map((v) => (
+                  <SelectItem key={v} value={v}>
+                    {v}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        {/* Toggles */}
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <ShadcnCheckbox checked={s.names} onCheckedChange={(v) => set("names", v === true)} />
+            <span className="text-xs">Names</span>
+          </label>
+          <label className="flex items-center gap-2 cursor-pointer">
+            <ShadcnCheckbox checked={s.border} onCheckedChange={(v) => set("border", v === true)} />
+            <span className="text-xs">Border</span>
+          </label>
+          <label className="flex items-center gap-2 cursor-pointer">
+            <ShadcnCheckbox checked={s.watermark} onCheckedChange={(v) => set("watermark", v === true)} />
+            <span className="text-xs">Watermark</span>
+          </label>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/web/components/studio/canvas.tsx
+++ b/packages/web/components/studio/canvas.tsx
@@ -33,6 +33,7 @@ import { IconBooleanGroupSubstract } from "@central-icons-react/round-filled-rad
 import { IconTrending5 } from "@central-icons-react/round-filled-radius-3-stroke-1.5/IconTrending5"
 import { IconLayoutGrid2 } from "@central-icons-react/round-filled-radius-3-stroke-1.5/IconLayoutGrid2"
 import { IconAddImage } from "@central-icons-react/round-filled-radius-3-stroke-1.5/IconAddImage"
+import { IconPeople } from "@central-icons-react/round-filled-radius-3-stroke-1.5/IconPeople"
 import { IconAlignmentLeft } from "@central-icons-react/round-filled-radius-1-stroke-1.5/IconAlignmentLeft"
 import { IconAlignmentCenter } from "@central-icons-react/round-filled-radius-1-stroke-1.5/IconAlignmentCenter"
 import { IconAlignmentRight } from "@central-icons-react/round-filled-radius-1-stroke-1.5/IconAlignmentRight"
@@ -50,6 +51,7 @@ import {
 } from "@/components/ui/context-menu"
 import { buildBadgeUrl } from "@/lib/badge-builder-shared"
 import { buildHeaderUrl } from "@/lib/header-builder-shared"
+import { buildSponsorsUrl } from "@/lib/sponsors-builder-shared"
 import {
   buildChartUrl,
   buildGroupUrl,
@@ -62,7 +64,7 @@ import {
   type MarkdownBlock,
 } from "@/lib/studio-shared"
 
-const BLOCK_TYPES: BlockType[] = ["markdown", "header", "badges", "group", "chart", "table", "image"]
+const BLOCK_TYPES: BlockType[] = ["markdown", "header", "badges", "group", "chart", "table", "image", "sponsors"]
 
 const BLOCK_ICONS: Record<BlockType, React.ComponentType<{ className?: string }>> = {
   markdown: IconText1,
@@ -72,6 +74,7 @@ const BLOCK_ICONS: Record<BlockType, React.ComponentType<{ className?: string }>
   chart: IconTrending5,
   table: IconLayoutGrid2,
   image: IconAddImage,
+  sponsors: IconPeople,
 }
 
 // Tiptap is heavy — keep it out of the initial Studio bundle until a text
@@ -287,6 +290,18 @@ function BlockContent({
       const built = buildChartUrl({ ...block.state, mode }, "")
       if (!built) return <p className="text-sm text-muted-foreground italic">Fill in the chart inputs in the inspector.</p>
       const url = ensureMode(built, mode)
+      return (
+        <div className={cn("flex", ALIGN_CLASS[block.align])}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={url} alt={block.alt} className="max-w-full rounded-md" />
+        </div>
+      )
+    }
+
+    case "sponsors": {
+      const mode = themeAware ? siteMode : block.state.mode
+      if (!block.state.login.trim()) return <p className="text-sm text-muted-foreground italic">Enter a GitHub login in the inspector.</p>
+      const url = buildSponsorsUrl({ ...block.state, mode }, "")
       return (
         <div className={cn("flex", ALIGN_CLASS[block.align])}>
           {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/packages/web/components/studio/inspectors.tsx
+++ b/packages/web/components/studio/inspectors.tsx
@@ -58,6 +58,15 @@ import {
   type HeaderState,
 } from "@/lib/header-builder-shared"
 import {
+  SPONSORS_PRESETS,
+  SPONSORS_PRESET_LABELS,
+  SPONSORS_SIZES,
+  SPONSORS_SIZE_LABELS,
+  SPONSORS_FONTS,
+  SPONSORS_THEMES,
+  type SponsorsState,
+} from "@/lib/sponsors-builder-shared"
+import {
   CHART_THEMES,
   CHART_FONTS,
   makeBadgeItem,
@@ -72,6 +81,7 @@ import {
   type HeaderBlock,
   type ImageBlock,
   type MarkdownBlock,
+  type SponsorsBlock,
   type TableBlock,
 } from "@/lib/studio-shared"
 
@@ -433,6 +443,90 @@ export function HeaderInspector({ block, onChange }: { block: HeaderBlock; onCha
       <Separator />
       <Field label="Alt text" htmlFor="hdr-alt">
         <Input id="hdr-alt" value={block.alt} onChange={e => onChange({ ...block, alt: e.target.value })} placeholder="header" />
+      </Field>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Sponsors inspector
+// ---------------------------------------------------------------------------
+
+export function SponsorsInspector({ block, onChange }: { block: SponsorsBlock; onChange: (b: SponsorsBlock) => void }) {
+  const s = block.state
+  const set = useCallback((patch: Partial<SponsorsState>) => onChange({ ...block, state: { ...block.state, ...patch } }), [block, onChange])
+
+  return (
+    <div className="space-y-4">
+      <Field label="GitHub login (user or org)" htmlFor="sp-login">
+        <Input id="sp-login" value={s.login} onChange={e => set({ login: e.target.value })} placeholder="shadcn" />
+      </Field>
+      <Field label="Title (empty to hide)" htmlFor="sp-title">
+        <Input id="sp-title" value={s.title} onChange={e => set({ title: e.target.value })} placeholder="Sponsors" />
+      </Field>
+
+      <Separator />
+      <Field label="Special sponsors (logins)" htmlFor="sp-special">
+        <Input id="sp-special" value={s.special} onChange={e => set({ special: e.target.value })} placeholder="vercel, clerk" />
+      </Field>
+      <Field label="Backers (logins)" htmlFor="sp-backers">
+        <Input id="sp-backers" value={s.backers} onChange={e => set({ backers: e.target.value })} placeholder="octocat" />
+      </Field>
+
+      <Separator />
+      <Field label="Background">
+        <Select value={s.preset} onValueChange={v => set({ preset: v as SponsorsState["preset"] })}>
+          <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+          <SelectContent>
+            {SPONSORS_PRESETS.map(p => (
+              <SelectItem key={p} value={p}>{SPONSORS_PRESET_LABELS[p]}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </Field>
+
+      <Row>
+        <Field label="Avatar size">
+          <Select value={s.size} onValueChange={v => set({ size: v as SponsorsState["size"] })}>
+            <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {SPONSORS_SIZES.map(sz => <SelectItem key={sz} value={sz}>{SPONSORS_SIZE_LABELS[sz]}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </Field>
+        <Field label="Theme">
+          <Select value={s.theme || "_none"} onValueChange={v => set({ theme: v === "_none" ? "" : v })}>
+            <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="_none">Default</SelectItem>
+              {SPONSORS_THEMES.map(t => <SelectItem key={t} value={t}>{t}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </Field>
+      </Row>
+
+      <Row>
+        <Field label="Limit" htmlFor="sp-limit">
+          <Input id="sp-limit" value={s.limit} onChange={e => set({ limit: e.target.value })} placeholder="60" inputMode="numeric" />
+        </Field>
+        <Field label="Font">
+          <Select value={s.font} onValueChange={v => set({ font: v })}>
+            <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {SPONSORS_FONTS.map(f => <SelectItem key={f} value={f}>{f}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </Field>
+      </Row>
+
+      <Separator />
+      <ToggleField label="Names" checked={s.names} onCheckedChange={v => set({ names: v })} />
+      <ToggleField label="Border" checked={s.border} onCheckedChange={v => set({ border: v })} />
+      <ToggleField label="Watermark" checked={s.watermark} onCheckedChange={v => set({ watermark: v })} />
+
+      <Separator />
+      <Field label="Alt text" htmlFor="sp-alt">
+        <Input id="sp-alt" value={block.alt} onChange={e => onChange({ ...block, alt: e.target.value })} placeholder="sponsors" />
       </Field>
     </div>
   )

--- a/packages/web/components/studio/studio.tsx
+++ b/packages/web/components/studio/studio.tsx
@@ -33,6 +33,7 @@ import { IconBooleanGroupSubstract } from "@central-icons-react/round-filled-rad
 import { IconTrending5 } from "@central-icons-react/round-filled-radius-3-stroke-1.5/IconTrending5"
 import { IconLayoutGrid2 } from "@central-icons-react/round-filled-radius-3-stroke-1.5/IconLayoutGrid2"
 import { IconAddImage } from "@central-icons-react/round-filled-radius-3-stroke-1.5/IconAddImage"
+import { IconPeople } from "@central-icons-react/round-filled-radius-3-stroke-1.5/IconPeople"
 import { useSyncExternalStore } from "react"
 import { useBadgeMode } from "@/lib/use-badge-mode"
 import { Button } from "@/components/ui/button"
@@ -51,6 +52,7 @@ import {
   ChartInspector,
   TableInspector,
   ImageInspector,
+  SponsorsInspector,
   Tip,
 } from "@/components/studio/inspectors"
 import {
@@ -68,6 +70,7 @@ import {
   type MarkdownBlock,
   type TableBlock,
   type ImageBlock,
+  type SponsorsBlock,
 } from "@/lib/studio-shared"
 import { markdownToDocument } from "@/lib/studio-import"
 
@@ -82,6 +85,7 @@ const BLOCK_ICONS: Record<BlockType, React.ComponentType<{ className?: string }>
   chart: IconTrending5,
   table: IconLayoutGrid2,
   image: IconAddImage,
+  sponsors: IconPeople,
 }
 
 // ---------------------------------------------------------------------------
@@ -112,6 +116,7 @@ function blockSummary(block: Block): string {
     case "chart": return `${block.state.kind} chart`
     case "table": return `${block.rows.length}×${block.headers.length} table`
     case "image": return block.alt || "image"
+    case "sponsors": return block.state.login ? `@${block.state.login} sponsors` : "sponsors"
   }
 }
 
@@ -308,6 +313,8 @@ export function Studio() {
     <TableInspector block={selected as TableBlock} onChange={updateBlock} />
   ) : selected.type === "image" ? (
     <ImageInspector block={selected as ImageBlock} onChange={updateBlock} />
+  ) : selected.type === "sponsors" ? (
+    <SponsorsInspector block={selected as SponsorsBlock} onChange={updateBlock} />
   ) : (
     <ChartInspector block={selected as ChartBlock} onChange={updateBlock} />
   )
@@ -377,7 +384,7 @@ export function Studio() {
           <div className="border-b border-border p-3">
             <p className="mb-2 px-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">Add block</p>
             <div className="grid grid-cols-2 gap-1.5">
-              {(["markdown", "header", "badges", "group", "chart", "table", "image"] as BlockType[]).map(type => {
+              {(["markdown", "header", "badges", "group", "chart", "table", "image", "sponsors"] as BlockType[]).map(type => {
                 const Icon = BLOCK_ICONS[type]
                 return (
                   <Button key={type} variant="outline" size="sm" className="h-auto flex-col gap-1 py-2.5 text-xs" onClick={() => addBlock(type)}>
@@ -431,7 +438,7 @@ export function Studio() {
         <main className="min-w-0 flex-1 overflow-y-auto bg-muted/40">
           {/* Mobile add bar */}
           <div className="flex items-center gap-1.5 overflow-x-auto border-b border-border bg-background px-3 py-2 lg:hidden">
-            {(["markdown", "header", "badges", "group", "chart", "table", "image"] as BlockType[]).map(type => {
+            {(["markdown", "header", "badges", "group", "chart", "table", "image", "sponsors"] as BlockType[]).map(type => {
               const Icon = BLOCK_ICONS[type]
               return (
                 <Button key={type} variant="outline" size="sm" className="h-8 shrink-0 gap-1.5 text-xs" onClick={() => addBlock(type)}>
@@ -466,7 +473,7 @@ export function Studio() {
                       <p className="mx-auto max-w-xs text-sm text-muted-foreground">Add a block to begin. Mix text, headers, badges, charts, tables, and images, then export clean Markdown.</p>
                     </div>
                     <div className="flex flex-wrap justify-center gap-1.5">
-                      {(["markdown", "header", "badges", "group", "chart", "table", "image"] as BlockType[]).map(type => {
+                      {(["markdown", "header", "badges", "group", "chart", "table", "image", "sponsors"] as BlockType[]).map(type => {
                         const Icon = BLOCK_ICONS[type]
                         return (
                           <Button key={type} variant="outline" size="sm" className="gap-1.5" onClick={() => addBlock(type)}>

--- a/packages/web/content/docs/api-reference.mdx
+++ b/packages/web/content/docs/api-reference.mdx
@@ -153,6 +153,20 @@ Premade backgrounds: `surface`, `gradient`, `dots`, `grid`, `graph`, `glow`,
 `watermark`, `pattern`, plus `mode`, `theme`, and `font`. See
 [Headers docs](/docs/headers).
 
+### Sponsors
+
+| Endpoint | Description |
+|----------|-------------|
+| `/sponsors/{login}.svg` | Active public GitHub Sponsors grid |
+| `/sponsors/{login}.png` | PNG grid |
+| `/sponsors/{login}.json` | Resolved sponsor list |
+
+A grid of an account's active public GitHub Sponsors. Arrange tiers by pinning
+logins with `special` and `backers` (comma-separated). Support `specialTitle`,
+`sponsorsTitle`, `backersTitle`, `title`, `size`, `width`, `limit`, `names`,
+`bg`, `accent`, `radius`, `border`, `watermark`, plus `mode` and `font`. See
+[Sponsors docs](/docs/sponsors).
+
 ## Query parameters
 
 <ApiRefTable

--- a/packages/web/content/docs/meta.json
+++ b/packages/web/content/docs/meta.json
@@ -15,6 +15,8 @@
     "...charts",
     "---Headers---",
     "...headers",
+    "---Sponsors---",
+    "...sponsors",
     "---Registry---",
     "...registry",
     "---Reference---",

--- a/packages/web/content/docs/sponsors/index.mdx
+++ b/packages/web/content/docs/sponsors/index.mdx
@@ -1,0 +1,194 @@
+---
+title: Sponsors
+description: A grid of your account's active GitHub Sponsors — every public sponsor's avatar, rendered as one portable image for your README.
+---
+
+The sponsors image renders a grid of an account's **active public GitHub
+Sponsors** — their avatars, names, and links — as a single portable SVG (or
+PNG) served from shieldcn. Like [headers](headers) and [charts](charts),
+everything is encoded in the image URL, so it works anywhere a Markdown image
+does and never needs a build step or a CI job.
+
+<SponsorsPreview
+  src="/sponsors/shadcn.svg"
+  alt="shadcn's GitHub sponsors"
+/>
+
+## Builder
+
+The fastest way to make a sponsors image is the interactive generator. Enter a
+login, pin tiers, pick a background and theme, then copy the Markdown.
+
+[Open the sponsors generator](/sponsors)
+
+## URL format
+
+```
+/sponsors/{login}.svg     SVG grid
+/sponsors/{login}.png     PNG grid
+/sponsors/{login}.json    resolved sponsor list (JSON)
+```
+
+`{login}` is any GitHub user or organization that has GitHub Sponsors enabled.
+Drop it into your README with a Markdown image:
+
+```md
+![Sponsors](https://shieldcn.dev/sponsors/shadcn.svg)
+```
+
+Or center it with an HTML block:
+
+```html
+<p align="center">
+  <a href="https://github.com/sponsors/shadcn">
+    <img src="https://shieldcn.dev/sponsors/shadcn.svg" alt="Sponsors" />
+  </a>
+</p>
+```
+
+## Tiers
+
+GitHub only exposes sponsor **dollar amounts** to the sponsored account's own
+token. shieldcn fetches through a shared pool of community tokens, so it can
+read the **public sponsor list** but not each sponsor's tier. Instead, you
+arrange tiers yourself by pinning logins:
+
+- `special` — a comma-separated list of logins shown **larger**, at the top, in
+  a "Special Sponsors" row.
+- `backers` — a comma-separated list of logins shown **smaller**, at the
+  bottom, in a "Backers" row.
+- Everyone else falls into the default "Sponsors" row.
+
+```md
+![Sponsors](https://shieldcn.dev/sponsors/shadcn.svg?special=vercel,clerk&backers=octocat)
+```
+
+<SponsorsPreview
+  src="/sponsors/shadcn.svg?special=vercel,clerk"
+  alt="sponsors with a pinned special tier"
+  description="vercel and clerk pinned into the Special Sponsors row"
+/>
+
+Rename the rows with `specialTitle`, `sponsorsTitle`, and `backersTitle`. A
+`@login` prefix is accepted and ignored, so `special=@vercel` also works.
+
+## Sizing and layout
+
+The `size` parameter sets the base avatar diameter; the special and backers
+rows scale from it automatically. Use `width` to set the canvas width — avatars
+wrap into as many rows as needed.
+
+| Parameter | Values | Default |
+| --- | --- | --- |
+| `size` | 32–140 (px) | 64 |
+| `width` | 320–2000 (px) | 800 |
+| `limit` | 1–80 | 60 |
+| `names` | `true`, `false` | `true` |
+| `radius` | 0–80 (px) | 12 |
+| `border` | `true`, `false` | `true` |
+| `watermark` | `true`, `false` | `false` |
+
+`limit` caps how many avatars are shown — pinned `special` and `backers`
+sponsors are always rendered, and the cap applies to the default row. Pass
+`names=false` for a tighter, avatar-only grid.
+
+```md
+![Sponsors](https://shieldcn.dev/sponsors/shadcn.svg?names=false&size=48&limit=40)
+```
+
+## Title and colors
+
+The grid has a "Sponsors" heading by default. Override it with `title=...`, or
+hide it with `title=false`. Color controls:
+
+- `bg` — a solid background color (hex without `#`), or `transparent` to blend
+  into the page.
+- `accent` — the color of the hairline rule under the title (hex without `#`).
+
+```md
+![Sponsors](https://shieldcn.dev/sponsors/shadcn.svg?title=Our+Backers&bg=transparent)
+```
+
+## Backgrounds
+
+The card uses the **same premade background system as [headers](headers)** —
+so it's just as customizable. Set a preset with `?preset=`:
+
+| Preset | Description |
+| --- | --- |
+| `surface` | Clean flat zinc surface. The default. |
+| `gradient` | Subtle neutral vertical gradient. |
+| `dots` | Dot grid over the surface. |
+| `grid` | Line grid over the surface. |
+| `graph` | Fine and coarse graph paper. |
+| `glow` | Soft themed spotlight from the top. |
+| `transparent` | No surface fill — blends into the page. |
+
+<SponsorsPreview
+  src="/sponsors/shadcn.svg?preset=glow&theme=blue"
+  alt="sponsors with the glow preset and blue theme"
+  description="glow preset, blue theme"
+/>
+
+For full control, override the background directly:
+
+- `theme` — tints the glow/accent: `zinc`, `slate`, `blue`, `green`, `rose`,
+  `orange`, `violet`, `purple`, `cyan`, `emerald`.
+- `gradient` — comma-separated hex stops with an optional trailing angle, e.g.
+  `gradient=7c2d12,9f1239,86198f,135`.
+- `pattern` — `dots`, `grid`, `graph`, or `none`.
+- `glow` — the spotlight color (hex without `#`).
+- `bg` — a solid color (hex without `#`), or `transparent`.
+- `image` — a background photo (Unsplash or any image URL), inlined behind an
+  auto scrim; tune it with `overlay` (0–1) and `tint`.
+
+```md
+![Sponsors](https://shieldcn.dev/sponsors/shadcn.svg?gradient=7c2d12,9f1239,86198f,135)
+```
+
+## Light and dark mode
+
+The grid reads correctly in both modes. Pass `mode=light` or `mode=dark`, or
+pair two images in a `<picture>` element so it follows the reader's GitHub
+theme. See [Light & Dark Mode](customization/light-dark-mode).
+
+## Parameters
+
+In addition to the shared `mode` and `font` parameters from the
+[API reference](api-reference):
+
+| Parameter | Values | Default |
+| --- | --- | --- |
+| `special` | comma-separated logins | — |
+| `backers` | comma-separated logins | — |
+| `specialTitle` | string | `Special Sponsors` |
+| `sponsorsTitle` | string | `Sponsors` |
+| `backersTitle` | string | `Backers` |
+| `title` | string, or `false` | `Sponsors` |
+| `size` | 32–140 (px) | 64 |
+| `width` | 320–2000 (px) | 800 |
+| `limit` | 1–80 | 60 |
+| `names` | `true`, `false` | `true` |
+| `preset` | `surface`, `gradient`, `dots`, `grid`, `graph`, `glow`, `transparent` | `surface` |
+| `theme` | `zinc`, `slate`, `blue`, `green`, `rose`, `orange`, `violet`, `purple`, `cyan`, `emerald` | — |
+| `bg` | hex without `#`, or `transparent` | card surface |
+| `gradient` | comma-separated hex stops, optional trailing angle | — |
+| `pattern` | `dots`, `grid`, `graph`, `none` | preset |
+| `glow` | hex without `#` | per preset |
+| `image` | Unsplash / image URL, or `data:` URI | — |
+| `overlay` | 0–1 | 0.45 |
+| `tint` | hex without `#` | `000000` |
+| `accent` | hex without `#` | — |
+| `radius` | 0–80 (px) | 12 |
+| `border` | `true`, `false` | `true` |
+| `watermark` | `true`, `false` | `false` |
+| `mode` | `dark`, `light` | `dark` |
+
+## Data source
+
+Sponsor data comes from the [GitHub Sponsors GraphQL API](https://docs.github.com/en/graphql/reference/objects#sponsorconnection),
+fetched through shieldcn's community token pool. Only **public** sponsors are
+listed; private sponsors are counted in the total but never shown. Avatars are
+fetched once and inlined into the image, and the list is cached for 30 minutes
+(serving the last-known-good list during any GitHub outage). Accounts without
+GitHub Sponsors enabled render an empty-state message.

--- a/packages/web/content/docs/sponsors/meta.json
+++ b/packages/web/content/docs/sponsors/meta.json
@@ -1,0 +1,6 @@
+{
+  "title": "Sponsors",
+  "pages": [
+    "index"
+  ]
+}

--- a/packages/web/lib/sponsors-builder-shared.ts
+++ b/packages/web/lib/sponsors-builder-shared.ts
@@ -1,0 +1,105 @@
+/**
+ * shieldcn
+ * lib/sponsors-builder-shared
+ *
+ * Shared state + URL builder for the sponsors-image generator UI.
+ * Mirrors header-builder-shared but for /sponsors/{login}.svg images.
+ */
+
+import {
+  HEADER_PRESETS,
+  HEADER_PRESET_LABELS,
+  HEADER_FONTS,
+  HEADER_THEMES,
+  randomUnsplashHeader,
+  type HeaderPreset,
+} from "./header-builder-shared"
+
+// The sponsors card reuses the exact background system as headers.
+export const SPONSORS_PRESETS = HEADER_PRESETS
+export const SPONSORS_PRESET_LABELS = HEADER_PRESET_LABELS
+export const SPONSORS_FONTS = HEADER_FONTS
+export const SPONSORS_THEMES = HEADER_THEMES
+export { randomUnsplashHeader }
+export type SponsorsPreset = HeaderPreset
+
+export const SPONSORS_SIZES = ["48", "64", "80"] as const
+export type SponsorsSize = (typeof SPONSORS_SIZES)[number]
+export const SPONSORS_SIZE_LABELS: Record<SponsorsSize, string> = {
+  "48": "Small",
+  "64": "Medium",
+  "80": "Large",
+}
+
+export interface SponsorsState {
+  /** GitHub user or org login. */
+  login: string
+  /** Card heading. Empty hides it (title=false). */
+  title: string
+  preset: SponsorsPreset
+  theme: string
+  /** Base avatar diameter (px) as a string. */
+  size: SponsorsSize
+  /** Show a name caption under each avatar. */
+  names: boolean
+  /** Comma-separated logins pinned into the larger "Special Sponsors" row. */
+  special: string
+  /** Comma-separated logins pinned into the smaller "Backers" row. */
+  backers: string
+  /** Max avatars in the default row (string for the input). */
+  limit: string
+  mode: "dark" | "light"
+  font: string
+  border: boolean
+  watermark: boolean
+  /** Background photo URL (Unsplash or any image). Fetched + inlined server-side. */
+  image: string
+  /** Scrim strength over the photo, "0"–"1". Blank = default (0.45). */
+  overlay: string
+}
+
+export const SPONSORS_DEFAULTS: SponsorsState = {
+  login: "shadcn",
+  title: "Sponsors",
+  preset: "surface",
+  theme: "",
+  size: "64",
+  names: true,
+  special: "",
+  backers: "",
+  limit: "",
+  mode: "dark",
+  font: "inter",
+  border: true,
+  watermark: false,
+  image: "",
+  overlay: "",
+}
+
+/** Build the `/sponsors/{login}.svg?...` URL from builder state. */
+export function buildSponsorsUrl(s: SponsorsState, baseUrl: string): string {
+  const login = s.login.trim().replace(/^@/, "") || "shadcn"
+  const params = new URLSearchParams()
+
+  // Title: default is "Sponsors". An empty title hides the heading entirely.
+  if (s.title.trim() === "") params.set("title", "false")
+  else if (s.title !== "Sponsors") params.set("title", s.title)
+
+  if (s.preset && s.preset !== "surface") params.set("preset", s.preset)
+  if (s.theme) params.set("theme", s.theme)
+  if (s.size && s.size !== "64") params.set("size", s.size)
+  if (!s.names) params.set("names", "false")
+  if (s.special.trim()) params.set("special", s.special.trim())
+  if (s.backers.trim()) params.set("backers", s.backers.trim())
+  if (s.limit.trim()) params.set("limit", s.limit.trim())
+  // Always include mode so the URL changes with the site theme (cache-safe).
+  params.set("mode", s.mode)
+  if (s.font && s.font !== "inter") params.set("font", s.font)
+  if (s.watermark) params.set("watermark", "true")
+  if (!s.border) params.set("border", "false")
+  if (s.image) params.set("image", s.image)
+  if (s.image && s.overlay) params.set("overlay", s.overlay)
+
+  const qs = params.toString()
+  return `${baseUrl}/sponsors/${encodeURIComponent(login)}.svg${qs ? `?${qs}` : ""}`
+}

--- a/packages/web/lib/studio-import.ts
+++ b/packages/web/lib/studio-import.ts
@@ -31,6 +31,7 @@ import {
 } from "@/lib/studio-shared"
 import { BUILDER_DEFAULTS, type BuilderState } from "@/lib/badge-builder-shared"
 import { HEADER_DEFAULTS, type HeaderPreset, type HeaderSize, type HeaderState } from "@/lib/header-builder-shared"
+import { SPONSORS_DEFAULTS, type SponsorsPreset, type SponsorsSize, type SponsorsState } from "@/lib/sponsors-builder-shared"
 
 // Minimal mdast shape — only the fields this parser reads.
 interface MdNode {
@@ -43,7 +44,7 @@ interface MdNode {
   position?: { start: { offset: number }; end: { offset: number } }
 }
 
-type ImgKind = "header" | "group" | "chart" | "badge" | "image"
+type ImgKind = "header" | "group" | "chart" | "badge" | "image" | "sponsors"
 
 interface ImgRef {
   src: string
@@ -82,6 +83,7 @@ function classifyUrl(src: string, baseUrl: string): ImgKind {
   if (first === "header") return "header"
   if (first === "group") return "group"
   if (first === "chart") return "chart"
+  if (first === "sponsors") return "sponsors"
   if (first === "badge") return "badge"
   const base = originOf(baseUrl)
   const relative = !/^https?:\/\//i.test(src)
@@ -208,6 +210,33 @@ function headerStateFromUrl(u: URL): HeaderState {
   }
 }
 
+/** Reverse a `/sponsors/{login}.svg?...` URL into a SponsorsState. */
+function sponsorsStateFromUrl(u: URL): SponsorsState {
+  const q = u.searchParams
+  const segs = u.pathname.split("/").filter(Boolean) // ["sponsors", "{login}.svg"]
+  const login = decodeURIComponent((segs[1] || "").replace(/\.(svg|png)$/i, ""))
+  const titleParam = q.get("title")
+  return {
+    ...SPONSORS_DEFAULTS,
+    login: login || SPONSORS_DEFAULTS.login,
+    // title=false hides it (empty string); a value overrides; absent = default.
+    title: titleParam === null ? "Sponsors" : titleParam === "false" ? "" : titleParam,
+    preset: ((q.get("preset") || "surface") as SponsorsPreset),
+    theme: q.get("theme") || "",
+    size: ((q.get("size") as SponsorsSize) || "64"),
+    names: q.get("names") !== "false",
+    special: q.get("special") || "",
+    backers: q.get("backers") || "",
+    limit: q.get("limit") || "",
+    mode: (q.get("mode") as "dark" | "light") || "dark",
+    font: q.get("font") || "inter",
+    border: q.get("border") !== "false",
+    watermark: q.get("watermark") === "true",
+    image: q.get("image") || "",
+    overlay: q.get("overlay") || "",
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Image refs → blocks (groups adjacent badges into one Badges block)
 // ---------------------------------------------------------------------------
@@ -239,6 +268,8 @@ function blocksFromImageRefs(refs: ImgRef[], align: Alignment, baseUrl: string):
       out.push(groupBlockFromUrl(ref, align, baseUrl))
     } else if (kind === "chart" && u) {
       out.push({ id: newId("chart"), type: "chart", alt: ref.alt, align, themeAware: ref.themeAware || undefined, state: chartStateFromUrl(u) })
+    } else if (kind === "sponsors" && u) {
+      out.push({ id: newId("sponsors"), type: "sponsors", alt: ref.alt, align, themeAware: ref.themeAware || undefined, state: sponsorsStateFromUrl(u) })
     } else {
       out.push({ id: newId("img"), type: "image", src: ref.src, alt: ref.alt, align, width: ref.width, link: ref.link })
     }

--- a/packages/web/lib/studio-shared.ts
+++ b/packages/web/lib/studio-shared.ts
@@ -20,6 +20,11 @@ import {
   buildHeaderUrl,
   type HeaderState,
 } from "@/lib/header-builder-shared"
+import {
+  SPONSORS_DEFAULTS,
+  buildSponsorsUrl,
+  type SponsorsState,
+} from "@/lib/sponsors-builder-shared"
 
 // ---------------------------------------------------------------------------
 // Chart state (the chart sandbox keeps state inline; the Studio needs it as a
@@ -130,7 +135,7 @@ export function buildChartUrl(s: ChartState, baseUrl: string): string | null {
 // Block model
 // ---------------------------------------------------------------------------
 
-export type BlockType = "markdown" | "header" | "badges" | "group" | "chart" | "table" | "image"
+export type BlockType = "markdown" | "header" | "badges" | "group" | "chart" | "table" | "image" | "sponsors"
 
 /** Default placeholder image source. */
 export const PLACEHOLDER_IMAGE = "https://placeholdpicsum.dev/photo/600/400"
@@ -221,6 +226,15 @@ export interface ChartBlock extends BaseBlock {
   state: ChartState
 }
 
+export interface SponsorsBlock extends BaseBlock {
+  type: "sponsors"
+  alt: string
+  align: Alignment
+  /** Emit a GitHub <picture> that swaps dark/light with the reader's theme. */
+  themeAware?: boolean
+  state: SponsorsState
+}
+
 export interface ImageBlock extends BaseBlock {
   type: "image"
   /** Image URL or absolute/relative path. */
@@ -245,7 +259,7 @@ export interface TableBlock extends BaseBlock {
   align?: Alignment
 }
 
-export type Block = MarkdownBlock | HeaderBlock | BadgesBlock | GroupBlock | ChartBlock | TableBlock | ImageBlock
+export type Block = MarkdownBlock | HeaderBlock | BadgesBlock | GroupBlock | ChartBlock | TableBlock | ImageBlock | SponsorsBlock
 
 export const BLOCK_LABELS: Record<BlockType, string> = {
   markdown: "Text",
@@ -255,6 +269,7 @@ export const BLOCK_LABELS: Record<BlockType, string> = {
   chart: "Chart",
   table: "Table",
   image: "Image",
+  sponsors: "Sponsors",
 }
 
 // ---------------------------------------------------------------------------
@@ -367,6 +382,16 @@ export function makeChartBlock(): ChartBlock {
   }
 }
 
+export function makeSponsorsBlock(): SponsorsBlock {
+  return {
+    id: newId("sponsors"),
+    type: "sponsors",
+    alt: "sponsors",
+    align: "center",
+    state: { ...SPONSORS_DEFAULTS },
+  }
+}
+
 export function makeTableBlock(): TableBlock {
   return {
     id: newId("table"),
@@ -418,6 +443,7 @@ export function makeBlock(type: BlockType): Block {
     case "chart": return makeChartBlock()
     case "table": return makeTableBlock()
     case "image": return makeImageBlock()
+    case "sponsors": return makeSponsorsBlock()
   }
 }
 
@@ -535,6 +561,18 @@ export function blockToMarkdown(block: Block, baseUrl: string, themeAware = fals
       }
       const url = buildChartUrl(block.state, baseUrl)
       if (!url) return ""
+      if (block.align === "left") return `![${block.alt}](${url})`
+      return alignWrap(block.align, `<img alt="${escapeAttr(block.alt)}" src="${escapeAttr(url)}" />`)
+    }
+
+    case "sponsors": {
+      if (adaptive) {
+        const dark = buildSponsorsUrl({ ...block.state, mode: "dark" }, baseUrl)
+        const light = buildSponsorsUrl({ ...block.state, mode: "light" }, baseUrl)
+        const pic = picture(dark, light, block.alt)
+        return block.align === "left" ? pic : `<p align="${block.align}">\n  ${pic}\n</p>`
+      }
+      const url = buildSponsorsUrl(block.state, baseUrl)
       if (block.align === "left") return `![${block.alt}](${url})`
       return alignWrap(block.align, `<img alt="${escapeAttr(block.alt)}" src="${escapeAttr(url)}" />`)
     }

--- a/packages/web/mdx-components.tsx
+++ b/packages/web/mdx-components.tsx
@@ -22,8 +22,9 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     BadgePreviewCard,
     ChartPreview,
     ChartSandbox,
-    // Headers reuse the generic full-width image preview.
+    // Headers and sponsors reuse the generic full-width image preview.
     HeaderPreview: ChartPreview,
+    SponsorsPreview: ChartPreview,
 
     // jalco-ui registry components
     CodeBlock,


### PR DESCRIPTION
## What

Adds **Sponsors** as a new image type across shieldcn — a portable SVG/PNG grid of an account's active public GitHub Sponsors, rendered in the same hand-built, sandbox-safe pipeline as headers and charts.

- **API** — `/sponsors/{login}.svg|.png|.json`. Fetches the public sponsor list via the GitHub Sponsors GraphQL API (through the token pool), inlines each avatar as a base64 data URI (sandboxed `<img>` SVGs can't hot-link), and renders a tiered avatar grid.
- **Manual tiers** — `?special=` and `?backers=` pin logins into larger "Special Sponsors" / smaller "Backers" rows; everyone else lands in the default row. (GitHub only exposes dollar-amount tiers to the sponsored account's own token, which the shared pool can't use — so tiers are arranged by the maintainer.)
- **Header-grade backgrounds** — reuses `resolveHeaderBackground()` so the card supports `preset`, `theme`, `gradient`, `pattern`, `glow`, `bg`/`transparent`, and photo backgrounds (`image`/`overlay`/`tint`), plus `size`, `limit`, `names`, `border`, `watermark`, `radius`, `font`, `mode`.
- **Graceful fallback** — any failure (no sponsors, unknown account, transient outage) degrades to a full card-shaped empty state, never a tiny scaled-up error badge. Short-cached so it self-heals.
- **Generator** at `/sponsors` + a navbar **Generator** dropdown (All badges / Headers / Sponsors) with a hover-safe bridge.
- **README Studio** gains a **Sponsors** block (palette, canvas, inspector, layers) with Markdown round-trip import.
- Docs page, sidebar, API reference, showcase, and README updated.

## Why

shieldcn could show a sponsor **count** badge but not the sponsors themselves. This brings the popular "sponsors wall" (à la create-better-t-stack) to any README as a single, cached image URL — no CI job or build step.

Closes #

## Type

- [x] `feat` — New feature

## Checklist

- [x] Branch follows conventional naming (`feat/sponsors-image`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tested locally with `pnpm dev` (verified against real accounts: shadcn, yyx990803, sindresorhus)
- [x] Badge renders correctly in SVG and PNG
- [x] Docs updated (new `/docs/sponsors` page, API reference, sidebar, meta)

## Testing

- `@shieldcn/core` test suite: **126 passing**, incl. new `sponsors-route.test.ts` (JSON shape, SVG avatar inlining, pinned tiers, empty state, card fallback).
- `tsc --noEmit` clean for `core`, `web`, and `engine`; web ESLint clean (lint-staged passed on commit).
- Live, token-backed verification: real avatars inline and crop to circles, special tier pins correctly, light/dark both render, generator + Studio block work end-to-end.

## Screenshots

Verified renders (local, real GitHub Sponsors data):
- **Tiered grid** — `/sponsors/shadcn.svg?special=…` → "Special Sponsors" row at larger size above the main grid, real avatars + names.
- **Backgrounds** — `?preset=glow&theme=blue` and `?gradient=…` render full header-grade backgrounds with auto text-contrast.
- **Fallback** — clean card-shaped "No public sponsors to show" empty state (not a red badge pill).
- **Studio** — "Sponsors" block in the ADD BLOCK palette, live canvas preview, and full inspector.

> Note: a small unrelated in-progress `aistack` change present in the working tree was intentionally **excluded** from this PR to keep it focused on sponsors.
