### PR TITLE
fix(sponsors): use a dedicated read:user token for the sponsor list

### DIFF
--- a/packages/core/src/badges/sponsors-route.test.ts
+++ b/packages/core/src/badges/sponsors-route.test.ts
@@ -94,6 +94,48 @@ describe("handleBadgeGET /sponsors", () => {
     expect(body.sponsors.map((s) => s.login)).toEqual(["sponsor1", "sponsor2", "sponsor3"])
   })
 
+  it("uses SPONSORS_GITHUB_TOKEN for the list query when set", async () => {
+    // Listing sponsor nodes needs read:user, which the zero-scope pool lacks —
+    // a dedicated maintainer token must be used for the GraphQL list call.
+    const prev = process.env.SPONSORS_GITHUB_TOKEN
+    process.env.SPONSORS_GITHUB_TOKEN = "ghp_override_token"
+    let listAuth: string | null = null
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        if (url === "https://api.github.com/graphql" && init?.method === "POST") {
+          const headers = (init.headers ?? {}) as Record<string, string>
+          const body = JSON.parse(String(init.body)) as { query: string }
+          if (body.query.includes("nodes")) listAuth = headers.Authorization ?? null
+          return new Response(
+            JSON.stringify({
+              data: {
+                repositoryOwner: {
+                  __typename: "User",
+                  sponsors: { totalCount: 1, pageInfo: { hasNextPage: false, endCursor: null }, nodes: [sponsorNode(1)] },
+                },
+              },
+            }),
+            { status: 200 },
+          )
+        }
+        if (url.startsWith("https://avatars.githubusercontent.com/")) {
+          return new Response(PNG_1x1, { status: 200, headers: { "content-type": "image/png" } })
+        }
+        return new Response("not found", { status: 404 })
+      }),
+    )
+    try {
+      // Unique login so the list isn't served from another test's cache entry.
+      const res = await handleBadgeGET(new Request("https://x.dev/sponsors/token-override-acct.json"), ["sponsors", "token-override-acct.json"])
+      expect(res.status).toBe(200)
+      expect(listAuth).toBe("Bearer ghp_override_token")
+    } finally {
+      if (prev === undefined) delete process.env.SPONSORS_GITHUB_TOKEN
+      else process.env.SPONSORS_GITHUB_TOKEN = prev
+    }
+  })
+
   it("strips a leading @ from the login (intuitive hand-written URLs)", async () => {
     // /sponsors/@jal-co.svg should resolve the same account as /sponsors/jal-co.
     const req = new Request("https://x.dev/sponsors/@jal-co.json")

--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -98,11 +98,15 @@ async function githubGraphQL(
   query: string,
   variables: Record<string, unknown>,
   revalidate: number = 3600,
+  tokenOverride?: string,
 ): Promise<Record<string, unknown> | null> {
   if (isBackedOff("github")) return null
 
   try {
-    const token = await pickToken()
+    // An explicit override (e.g. the maintainer's read:user token for the
+    // sponsors list) bypasses the zero-scope donor pool; otherwise pick a
+    // pooled token as usual.
+    const token = tokenOverride ?? (await pickToken())
     const doFetch = (auth?: string) =>
       raceTimeout(
         fetch("https://api.github.com/graphql", {
@@ -124,7 +128,8 @@ async function githubGraphQL(
     // still serves public data unauthenticated at a low limit). Rotating out a
     // revoked pooled token and retrying is still correct; the bare retry only
     // helps when a fresh token is available — otherwise it 401s again → null.
-    if (response.status === 401 && token) {
+    // Never invalidate an explicit override token — it isn't in the pool.
+    if (response.status === 401 && token && !tokenOverride) {
       await invalidateToken(token)
       response = await doFetch()
       if (!response) return null
@@ -818,13 +823,19 @@ interface RawSponsorsConnection {
 const SPONSORS_PAGE_CAP = 3
 
 export async function getGitHubSponsorsList(login: string): Promise<SponsorsList | null> {
+  // Enumerating sponsor identities (`sponsors.nodes`) requires the `read:user`
+  // scope. The donor token pool is deliberately zero-scope, so it can read the
+  // aggregate `totalCount` (the count badge) but NOT the list. Prefer a
+  // dedicated maintainer token when configured; otherwise fall through to the
+  // pool (which yields no nodes → graceful empty card, never a crash).
+  const sponsorToken = process.env.SPONSORS_GITHUB_TOKEN || undefined
   const sponsors: SponsorEntry[] = []
   let totalCount = 0
   let after: string | null = null
   let resolvedAny = false
 
   for (let page = 0; page < SPONSORS_PAGE_CAP; page++) {
-    const data: Record<string, unknown> | null = await githubGraphQL(SPONSORS_LIST_QUERY, { login, after })
+    const data: Record<string, unknown> | null = await githubGraphQL(SPONSORS_LIST_QUERY, { login, after }, 3600, sponsorToken)
     const owner = data?.repositoryOwner as { sponsors?: RawSponsorsConnection } | null | undefined
     const conn = owner?.sponsors
     if (!conn) {


### PR DESCRIPTION
## What

The `/sponsors/{login}` image always showed the empty "No public sponsors" card in production, even for accounts with sponsors. Root cause: listing sponsor identities (`sponsors.nodes`) requires the **`read:user`** scope, but the donor token pool is intentionally **zero-scope** — so it could read the aggregate `totalCount` (why the count badge works) but never the list.

This adds an optional token override to `githubGraphQL` and has `getGitHubSponsorsList` prefer `process.env.SPONSORS_GITHUB_TOKEN`, bypassing the pool for that one query. When the env var is unset it falls through to the pool (no nodes → graceful empty card), so local dev and unconfigured deploys never crash. The override token is never invalidated on 401 (it isn't a pool token).

## Why

Diagnosed against production: `/github/sponsors/shadcn` (GraphQL `totalCount`) returns "50", but `/sponsors/shadcn.json` returns 404 for the same login — confirming the pool works for the count but not the list. Verified the differentiator: a token with the `user` scope reads `sponsors.nodes` fine; the zero-scope pool can't.

Closes #

## Type

- [x] `fix` — Bug fix

## Checklist

- [x] Branch follows conventional naming (`fix/sponsors-token`)
- [x] Commits follow Conventional Commits
- [x] Tested locally with `pnpm dev`
- [x] Badge renders correctly in SVG and PNG
- [x] Docs updated (n/a — env-only; see deploy note below)

## Testing

- `@shieldcn/core`: **128 passing**, incl. a new test asserting the list query carries `Bearer <SPONSORS_GITHUB_TOKEN>` when set.
- `tsc --noEmit` clean.

## Deploy note (required for prod)

Set a **`SPONSORS_GITHUB_TOKEN`** env var in Vercel (Production) — a GitHub PAT with `read:user`. Without it, the sponsors image keeps showing the empty card. The donor pool stays zero-scope and unchanged.
