### PR TITLE
feat(sponsors): auto featured tier with tier, separator & align controls

### DIFF
--- a/packages/core/src/badges/render-sponsors.ts
+++ b/packages/core/src/badges/render-sponsors.ts
@@ -49,6 +49,19 @@ export interface SponsorsConfig {
   watermark: boolean
   /** Render a name caption under each avatar. */
   showNames: boolean
+  /** Horizontal alignment of the card title + its rule. Default "left". */
+  titleAlign?: "left" | "center" | "right"
+  /** Horizontal alignment of the avatar rows + tier headings. Default "center". */
+  avatarAlign?: "left" | "center" | "right"
+  /**
+   * How tiers are delimited:
+   *  - "label" (default): a centered text heading above each tier.
+   *  - "line": a hairline rule between tiers (no text headings).
+   *  - "none": just vertical spacing, no headings or lines.
+   */
+  separator?: "label" | "line" | "none"
+  /** Color (hex without #) of the "line" separator. Defaults to the border. */
+  separatorColor?: string | null
   /** Message shown when there are no public sponsors. */
   emptyText?: string
 
@@ -156,10 +169,16 @@ function layoutTier(
   const parts: string[] = []
   let y = top
 
+  // Text headings only render in "label" mode; "line"/"none" delimit tiers
+  // visually in the main loop instead.
+  const align = cfg.avatarAlign ?? "center"
+  const headingX = align === "left" ? padX : align === "right" ? width - padX : width / 2
+  const headingAnchor = align === "left" ? "start" : align === "right" ? "end" : "middle"
+
   const titleSize = 15
-  if (tier.title) {
+  if (tier.title && (cfg.separator ?? "label") === "label") {
     parts.push(
-      `<text x="${r2(width / 2)}" y="${r2(y + titleSize)}" text-anchor="middle" font-size="${titleSize}" font-weight="600" fill="${colors.muted}" font-family="${cfg.fontFamily}" letter-spacing="0.04em">${esc(tier.title)}</text>`,
+      `<text x="${r2(headingX)}" y="${r2(y + titleSize)}" text-anchor="${headingAnchor}" font-size="${titleSize}" font-weight="600" fill="${colors.muted}" font-family="${cfg.fontFamily}" letter-spacing="0.04em">${esc(tier.title)}</text>`,
     )
     y += titleSize + 18
   }
@@ -178,7 +197,12 @@ function layoutTier(
   while (i < tier.avatars.length) {
     const rowItems = tier.avatars.slice(i, i + perRow)
     const rowW = rowItems.length * cellW - gap
-    let x = r2((width - rowW) / 2)
+    let x =
+      align === "left"
+        ? padX
+        : align === "right"
+          ? r2(width - padX - rowW)
+          : r2((width - rowW) / 2)
     const rowTop = y
     for (const a of rowItems) {
       parts.push(renderAvatar(a, x, rowTop, size, colors.ring, colors.isLight))
@@ -245,8 +269,11 @@ export function renderSponsors(cfg: SponsorsConfig): { svg: string; height: numb
   // --- Title + hairline rule ---
   if (cfg.title) {
     const titleSize = 26
+    const ta = cfg.titleAlign ?? "left"
+    const tx = ta === "center" ? width / 2 : ta === "right" ? width - padX : padX
+    const tAnchor = ta === "center" ? "middle" : ta === "right" ? "end" : "start"
     body.push(
-      `<text x="${padX}" y="${r2(y + titleSize)}" font-size="${titleSize}" font-weight="700" fill="${fg}" font-family="${fontStack}" letter-spacing="-0.02em">${esc(cfg.title)}</text>`,
+      `<text x="${r2(tx)}" y="${r2(y + titleSize)}" text-anchor="${tAnchor}" font-size="${titleSize}" font-weight="700" fill="${fg}" font-family="${fontStack}" letter-spacing="-0.02em">${esc(cfg.title)}</text>`,
     )
     y += titleSize + 14
     const ruleColor = cfg.accent ? `#${cfg.accent.replace(/^#/, "")}` : probe.border
@@ -264,11 +291,25 @@ export function renderSponsors(cfg: SponsorsConfig): { svg: string; height: numb
     )
     y += 80
   } else {
+    const separator = cfg.separator ?? "label"
+    const lineColor = cfg.separatorColor ? `#${cfg.separatorColor.replace(/^#/, "")}` : probe.border
+    let firstRendered = true
     for (const tier of cfg.tiers) {
       if (tier.avatars.length === 0) continue
+      if (!firstRendered) {
+        // A "line" separator draws a centered hairline in the inter-tier gap.
+        if (separator === "line") {
+          y += 6
+          body.push(
+            `<rect x="${padX}" y="${r2(y)}" width="${r2(width - padX * 2)}" height="1" fill="${lineColor}" />`,
+          )
+          y += 22
+        }
+      }
       const laid = layoutTier(tier, y, width, padX, cfg, colors)
       body.push(laid.svg)
       y += laid.height + 34
+      firstRendered = false
     }
     y -= 34
   }

--- a/packages/core/src/badges/sponsors-route.test.ts
+++ b/packages/core/src/badges/sponsors-route.test.ts
@@ -10,6 +10,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { handleBadgeGET } from "../route-handler"
+import { parseFeaturedSponsors } from "../providers/github"
 
 // A 1x1 transparent PNG (smallest valid raster the inliner will accept).
 const PNG_1x1 = Buffer.from(
@@ -25,6 +26,46 @@ function sponsorNode(i: number) {
     avatarUrl: `https://avatars.githubusercontent.com/u/${i}?s=160`,
     url: `https://github.com/sponsor${i}`,
   }
+}
+
+/**
+ * Stub fetch for an account with 4 sponsors whose public page features
+ * sponsor2 + sponsor4 (so special=[2,4], middle=[1,3]). Used by the
+ * separator / tier-filter tests.
+ */
+function stubFeaturedFetch() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "https://api.github.com/graphql" && init?.method === "POST") {
+        return new Response(
+          JSON.stringify({
+            data: {
+              repositoryOwner: {
+                __typename: "User",
+                sponsors: {
+                  totalCount: 4,
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                  nodes: [sponsorNode(1), sponsorNode(2), sponsorNode(3), sponsorNode(4)],
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        )
+      }
+      if (url.startsWith("https://github.com/sponsors/")) {
+        return new Response(
+          `<h4>Featured sponsors</h4><img alt="@sponsor2"><img alt="@sponsor4"><h4>Current sponsors 4</h4>`,
+          { status: 200, headers: { "content-type": "text/html" } },
+        )
+      }
+      if (url.startsWith("https://avatars.githubusercontent.com/")) {
+        return new Response(PNG_1x1, { status: 200, headers: { "content-type": "image/png" } })
+      }
+      return new Response("not found", { status: 404 })
+    }),
+  )
 }
 
 beforeEach(() => {
@@ -189,5 +230,101 @@ describe("handleBadgeGET /sponsors", () => {
     expect(svg.toLowerCase()).not.toContain("#dc2626")
     expect(svg).toContain("No public sponsors to show")
     expect(svg).not.toContain("data:image/png")
+  })
+
+  it("aligns the card title via ?titleAlign", async () => {
+    stubFeaturedFetch()
+    const left = await (
+      await handleBadgeGET(new Request("https://x.dev/sponsors/align1.svg"), ["sponsors", "align1.svg"])
+    ).text()
+    expect(left).toMatch(/<text[^>]*text-anchor="start"[^>]*font-size="26"/)
+    const center = await (
+      await handleBadgeGET(new Request("https://x.dev/sponsors/align2.svg?titleAlign=center"), ["sponsors", "align2.svg"])
+    ).text()
+    expect(center).toMatch(/<text[^>]*text-anchor="middle"[^>]*font-size="26"/)
+  })
+
+  it("hides text tier headings with ?separator=line (avatars still render)", async () => {
+    stubFeaturedFetch()
+    const svg = await (
+      await handleBadgeGET(new Request("https://x.dev/sponsors/lineacct.svg?separator=line"), ["sponsors", "lineacct.svg"])
+    ).text()
+    expect(svg).not.toContain("Featured Sponsors")
+    expect((svg.match(/<a href=/g) || []).length).toBe(4)
+  })
+
+  it("renders only the requested tiers with ?tiers=", async () => {
+    stubFeaturedFetch()
+    const svg = await (
+      await handleBadgeGET(new Request("https://x.dev/sponsors/tiersacct.svg?tiers=featured"), ["sponsors", "tiersacct.svg"])
+    ).text()
+    expect(svg).toContain("Featured Sponsors")
+    // Only the featured tier (sponsor2 + sponsor4) renders — not the main grid.
+    expect((svg.match(/<a href=/g) || []).length).toBe(2)
+  })
+
+  it("auto-populates a Featured Sponsors tier from the public sponsors page", async () => {
+    // Unique login (avoids any cached list) whose public page features two of
+    // its sponsors. No manual ?special= is passed.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        if (url === "https://api.github.com/graphql" && init?.method === "POST") {
+          return new Response(
+            JSON.stringify({
+              data: {
+                repositoryOwner: {
+                  __typename: "User",
+                  sponsors: {
+                    totalCount: 4,
+                    pageInfo: { hasNextPage: false, endCursor: null },
+                    nodes: [sponsorNode(1), sponsorNode(2), sponsorNode(3), sponsorNode(4)],
+                  },
+                },
+              },
+            }),
+            { status: 200 },
+          )
+        }
+        if (url.startsWith("https://github.com/sponsors/")) {
+          return new Response(
+            `<h4>Featured sponsors</h4><a href="/sponsor2"><img alt="@sponsor2"></a><a href="/sponsor4"><img alt="@sponsor4"></a><h4>Current sponsors 4</h4><img alt="@sponsor1">`,
+            { status: 200, headers: { "content-type": "text/html" } },
+          )
+        }
+        if (url.startsWith("https://avatars.githubusercontent.com/")) {
+          return new Response(PNG_1x1, { status: 200, headers: { "content-type": "image/png" } })
+        }
+        return new Response("not found", { status: 404 })
+      }),
+    )
+
+    const json = (await (
+      await handleBadgeGET(new Request("https://x.dev/sponsors/featuredacct.json"), ["sponsors", "featuredacct.json"])
+    ).json()) as { featured: string[] }
+    expect(json.featured).toEqual(["sponsor2", "sponsor4"])
+
+    const svg = await (
+      await handleBadgeGET(new Request("https://x.dev/sponsors/featuredacct.svg"), ["sponsors", "featuredacct.svg"])
+    ).text()
+    expect(svg).toContain("Featured Sponsors")
+  })
+})
+
+describe("parseFeaturedSponsors", () => {
+  it("extracts featured logins, bounded to the section and self-excluded", () => {
+    const html =
+      `<h3>@acme's goal</h3><img alt="@acme">` +
+      `<h4>Featured sponsors</h4>` +
+      `<a href="/bigco"><img alt="@bigco"></a>` +
+      `<a href="/acme"><img alt="@acme"></a>` + // maintainer's own avatar — skipped
+      `<a href="/patron"><img alt="@Patron"></a>` + // case-normalized
+      `<h4>Current sponsors 5</h4><img alt="@bigco"><img alt="@someoneelse">` +
+      `<h4>Featured work</h4><img alt="@notasponsor">`
+    expect(parseFeaturedSponsors(html, "acme")).toEqual(["bigco", "patron"])
+  })
+
+  it("returns [] when there is no featured-sponsors section", () => {
+    expect(parseFeaturedSponsors(`<h4>Current sponsors</h4><img alt="@x">`, "acme")).toEqual([])
   })
 })

--- a/packages/core/src/badges/sponsors-route.test.ts
+++ b/packages/core/src/badges/sponsors-route.test.ts
@@ -10,7 +10,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { handleBadgeGET } from "../route-handler"
-import { parseFeaturedSponsors } from "../providers/github"
+import { parseFeaturedSponsors, parseSponsorsWall } from "../providers/github"
 
 // A 1x1 transparent PNG (smallest valid raster the inliner will accept).
 const PNG_1x1 = Buffer.from(
@@ -68,7 +68,13 @@ function stubFeaturedFetch() {
   )
 }
 
+// Most tests exercise the GraphQL list path; that path is only attempted when a
+// (potentially-scoped) token is configured, so set one for the suite.
+const SAVED_TOK = process.env.SPONSORS_GITHUB_TOKEN
+const SAVED_GH = process.env.GITHUB_TOKEN
+
 beforeEach(() => {
+  process.env.SPONSORS_GITHUB_TOKEN = "ghp_test"
   vi.stubGlobal(
     "fetch",
     vi.fn(async (url: string, init?: RequestInit) => {
@@ -114,6 +120,10 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllGlobals()
   vi.restoreAllMocks()
+  if (SAVED_TOK === undefined) delete process.env.SPONSORS_GITHUB_TOKEN
+  else process.env.SPONSORS_GITHUB_TOKEN = SAVED_TOK
+  if (SAVED_GH === undefined) delete process.env.GITHUB_TOKEN
+  else process.env.GITHUB_TOKEN = SAVED_GH
 })
 
 describe("handleBadgeGET /sponsors", () => {
@@ -232,6 +242,37 @@ describe("handleBadgeGET /sponsors", () => {
     expect(svg).not.toContain("data:image/png")
   })
 
+  it("falls back to scraping the public wall when no token is configured", async () => {
+    // No scoped token → GraphQL is skipped → list comes from the public page.
+    delete process.env.SPONSORS_GITHUB_TOKEN
+    delete process.env.GITHUB_TOKEN
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.startsWith("https://github.com/sponsors/")) {
+          return new Response(
+            `<h4>Current sponsors 2</h4>` +
+              `<img src="https://avatars.githubusercontent.com/u/1?s=60&v=4" alt="@alice">` +
+              `<img src="https://avatars.githubusercontent.com/u/2?s=60&v=4" alt="@bob">` +
+              `<h4>Past sponsors</h4><img alt="@past1">`,
+            { status: 200, headers: { "content-type": "text/html" } },
+          )
+        }
+        if (url.startsWith("https://avatars.githubusercontent.com/")) {
+          return new Response(PNG_1x1, { status: 200, headers: { "content-type": "image/png" } })
+        }
+        if (url === "https://api.github.com/graphql") throw new Error("GraphQL should not be called without a token")
+        return new Response("not found", { status: 404 })
+      }),
+    )
+    const json = (await (
+      await handleBadgeGET(new Request("https://x.dev/sponsors/htmlonly.json"), ["sponsors", "htmlonly.json"])
+    ).json()) as { publicCount: number; sponsors: { login: string }[] }
+    // Only the Current-sponsors wall (alice, bob) — not the past sponsor.
+    expect(json.sponsors.map((s) => s.login)).toEqual(["alice", "bob"])
+    expect(json.publicCount).toBe(2)
+  })
+
   it("aligns the card title via ?titleAlign", async () => {
     stubFeaturedFetch()
     const left = await (
@@ -308,6 +349,28 @@ describe("handleBadgeGET /sponsors", () => {
       await handleBadgeGET(new Request("https://x.dev/sponsors/featuredacct.svg"), ["sponsors", "featuredacct.svg"])
     ).text()
     expect(svg).toContain("Featured Sponsors")
+  })
+})
+
+describe("parseSponsorsWall", () => {
+  it("parses the current-sponsors wall (login + sized avatar), self-excluded", () => {
+    const html =
+      `<img alt="@maintainer">` + // header avatar, before the section — ignored
+      `<h4>Current sponsors 3</h4>` +
+      `<img src="https://avatars.githubusercontent.com/u/1?s=60&v=4" alt="@alice">` +
+      `<img src="https://avatars.githubusercontent.com/u/2?v=4" alt="@maintainer">` + // self — skipped
+      `<img src="https://avatars.githubusercontent.com/u/3?s=60&v=4" alt="@bob">` +
+      `<h4>Past sponsors</h4><img alt="@gone">`
+    const list = parseSponsorsWall(html, "maintainer")
+    expect(list.sponsors.map((s) => s.login)).toEqual(["alice", "bob"])
+    expect(list.totalCount).toBe(2)
+    // Avatar size bumped to 160 (added when missing, replaced when present).
+    expect(list.sponsors[0].avatarUrl).toContain("s=160")
+    expect(list.sponsors[1].avatarUrl).toContain("s=160")
+  })
+
+  it("returns an empty list when there is no current-sponsors section", () => {
+    expect(parseSponsorsWall(`<h4>Past sponsors</h4><img alt="@x">`, "acme").sponsors).toEqual([])
   })
 })
 

--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -869,3 +869,73 @@ export async function getGitHubSponsorsList(login: string): Promise<SponsorsList
   if (!resolvedAny) return null
   return { totalCount, sponsors }
 }
+
+// ---------------------------------------------------------------------------
+// Featured sponsors (public profile "Featured sponsors" selection)
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the "Featured sponsors" logins from a sponsors page's HTML. The
+ * featured block sits between the "Featured sponsors" heading and the next
+ * section ("Current sponsors" / "Past sponsors" / "Featured work"); each
+ * featured account renders an avatar with an `alt="@login"`. Exported for tests.
+ */
+export function parseFeaturedSponsors(html: string, login: string): string[] {
+  const lower = html.toLowerCase()
+  const start = lower.indexOf("featured sponsors")
+  if (start === -1) return []
+  // Bound the section at the next heading so we don't pull in current/past
+  // sponsors or featured repositories.
+  const ends = ["current sponsors", "past sponsors", "featured work"]
+    .map((h) => lower.indexOf(h, start + "featured sponsors".length))
+    .filter((i) => i > start)
+  const end = ends.length ? Math.min(...ends) : Math.min(start + 8000, html.length)
+  const segment = html.slice(start, end)
+
+  const out: string[] = []
+  const seen = new Set<string>()
+  const self = login.toLowerCase()
+  const re = /alt="@([A-Za-z0-9-]+)"/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(segment)) !== null) {
+    const l = m[1].toLowerCase()
+    // Skip the maintainer's own avatar and de-dupe; cap to a sane row.
+    if (l === self || seen.has(l)) continue
+    seen.add(l)
+    out.push(l)
+    if (out.length >= 12) break
+  }
+  return out
+}
+
+/**
+ * Fetch an account's public "Featured sponsors" — the sponsors the maintainer
+ * hand-picks to highlight on their GitHub Sponsors page. GitHub does NOT expose
+ * this via GraphQL (only featured *repositories* are) and sponsorship *amounts*
+ * are owner-only, so the rendered public page is the only source for an
+ * automatic "featured" tier.
+ *
+ * Best-effort + defensive: any failure (non-200, markup change, network, bad
+ * login) yields an empty list so the grid simply renders without a featured
+ * tier rather than erroring. Needs no token — the page is public HTML.
+ */
+export async function getGitHubFeaturedSponsors(login: string): Promise<string[]> {
+  if (!/^[A-Za-z0-9-]+$/.test(login)) return []
+  try {
+    const res = await raceTimeout(
+      fetch(`https://github.com/sponsors/${encodeURIComponent(login)}`, {
+        headers: {
+          // A browser-ish UA — GitHub serves a degraded page to some agents.
+          "User-Agent": "Mozilla/5.0 (compatible; shieldcn.dev/1.0; +https://shieldcn.dev)",
+          Accept: "text/html",
+        },
+        next: { revalidate: 1800 },
+      }),
+    )
+    if (!res || !res.ok) return []
+    const html = await res.text()
+    return parseFeaturedSponsors(html, login)
+  } catch {
+    return []
+  }
+}

--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -822,13 +822,30 @@ interface RawSponsorsConnection {
  */
 const SPONSORS_PAGE_CAP = 3
 
+/**
+ * Resolve an account's public sponsors. Prefers the GraphQL list (complete,
+ * with display names + hi-res avatars + an accurate total) when a potentially
+ * scoped token is configured; otherwise falls back to scraping the public
+ * sponsors wall — token-free, but capped at ~50 with login-only names.
+ *
+ * Enumerating `sponsors.nodes` over GraphQL needs the `read:user` scope, which
+ * the donor token pool deliberately lacks. So without `SPONSORS_GITHUB_TOKEN`
+ * (or a scoped `GITHUB_TOKEN`) the GraphQL list comes back empty — the HTML
+ * fallback keeps the feature working with no token at all.
+ */
 export async function getGitHubSponsorsList(login: string): Promise<SponsorsList | null> {
-  // Enumerating sponsor identities (`sponsors.nodes`) requires the `read:user`
-  // scope. The donor token pool is deliberately zero-scope, so it can read the
-  // aggregate `totalCount` (the count badge) but NOT the list. Prefer a
-  // dedicated maintainer token when configured; otherwise fall through to the
-  // pool (which yields no nodes → graceful empty card, never a crash).
   const sponsorToken = process.env.SPONSORS_GITHUB_TOKEN || undefined
+  // Only attempt GraphQL when a potentially-scoped token exists; the zero-scope
+  // pool can't read the node list, so skipping it avoids a doomed call.
+  if (sponsorToken || process.env.GITHUB_TOKEN) {
+    const viaGql = await fetchSponsorsViaGraphQL(login, sponsorToken)
+    if (viaGql && viaGql.sponsors.length > 0) return viaGql
+  }
+  // No usable scoped token — scrape the public sponsors wall instead.
+  return fetchSponsorsViaHtml(login)
+}
+
+async function fetchSponsorsViaGraphQL(login: string, sponsorToken: string | undefined): Promise<SponsorsList | null> {
   const sponsors: SponsorEntry[] = []
   let totalCount = 0
   let after: string | null = null
@@ -868,6 +885,69 @@ export async function getGitHubSponsorsList(login: string): Promise<SponsorsList
 
   if (!resolvedAny) return null
   return { totalCount, sponsors }
+}
+
+/** Bump (or add) the `s=` size param on a GitHub avatar URL. */
+function bumpAvatarSize(url: string, size: number): string {
+  if (/[?&]s=\d+/.test(url)) return url.replace(/([?&]s=)\d+/, `$1${size}`)
+  return url + (url.includes("?") ? "&" : "?") + "s=" + size
+}
+
+/**
+ * Parse the "Current sponsors" wall from a sponsors page's HTML into a
+ * SponsorsList. Token-free, but GitHub caps the public wall at ~50 sponsors and
+ * exposes only logins (no display names). Exported for tests.
+ */
+export function parseSponsorsWall(html: string, login: string): SponsorsList {
+  const lower = html.toLowerCase()
+  const start = lower.indexOf("current sponsors")
+  if (start === -1) return { totalCount: 0, sponsors: [] }
+  const ends = ["past sponsors", "featured work", "</main"]
+    .map((h) => lower.indexOf(h, start + "current sponsors".length))
+    .filter((i) => i > start)
+  const end = ends.length ? Math.min(...ends) : html.length
+  const seg = html.slice(start, end)
+
+  const sponsors: SponsorEntry[] = []
+  const seen = new Set<string>()
+  const self = login.toLowerCase()
+  for (const tag of seg.match(/<img\b[^>]*>/gi) ?? []) {
+    const altMatch = tag.match(/alt="@([A-Za-z0-9-]+)"/)
+    if (!altMatch) continue
+    const l = altMatch[1]
+    const key = l.toLowerCase()
+    if (key === self || seen.has(key)) continue
+    seen.add(key)
+    const srcMatch = tag.match(/src="([^"]+)"/)
+    const rawSrc = srcMatch ? srcMatch[1].replace(/&amp;/g, "&") : `https://github.com/${l}.png`
+    sponsors.push({
+      login: l,
+      name: null, // public HTML exposes the login only, not the display name
+      avatarUrl: bumpAvatarSize(rawSrc, 160),
+      url: `https://github.com/${l}`,
+      type: "User",
+    })
+  }
+  return { totalCount: sponsors.length, sponsors }
+}
+
+async function fetchSponsorsViaHtml(login: string): Promise<SponsorsList | null> {
+  if (!/^[A-Za-z0-9-]+$/.test(login)) return null
+  try {
+    const res = await raceTimeout(
+      fetch(`https://github.com/sponsors/${encodeURIComponent(login)}`, {
+        headers: {
+          "User-Agent": "Mozilla/5.0 (compatible; shieldcn.dev/1.0; +https://shieldcn.dev)",
+          Accept: "text/html",
+        },
+        next: { revalidate: 1800 },
+      }),
+    )
+    if (!res || !res.ok) return null
+    return parseSponsorsWall(await res.text(), login)
+  } catch {
+    return null
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -116,6 +116,7 @@ import {
   getGitHubUserStars,
   getGitHubSponsors,
   getGitHubSponsorsList,
+  getGitHubFeaturedSponsors,
   type SponsorEntry,
   githubRepoExists,
 } from "./providers/github"
@@ -2303,9 +2304,28 @@ async function handleSponsors(
   // smaller "backers" row; everyone else falls into the default "Sponsors" row.
   const specialLogins = parseLoginList(searchParams.get("special"))
   const backerLogins = parseLoginList(searchParams.get("backers"))
-  const specialTitle = searchParams.get("specialTitle") ?? "Special Sponsors"
+  const specialTitleParam = searchParams.get("specialTitle")
   const sponsorsTitle = searchParams.get("sponsorsTitle") ?? "Sponsors"
   const backersTitle = searchParams.get("backersTitle") ?? "Backers"
+  // Auto-featured tier: unless the maintainer pins `special` manually, the top
+  // tier is populated from GitHub's public "Featured sponsors" selection
+  // (scraped from the sponsors page — the only public source for it). Opt out
+  // with `?featured=false`.
+  const featuredEnabled = !falsy(searchParams.get("featured"))
+  // Alignment of the title and of the avatar rows (inside the image).
+  const alignOf = (v: string | null, fallback: "left" | "center" | "right") =>
+    v === "left" || v === "center" || v === "right" ? v : fallback
+  const titleAlign = alignOf(searchParams.get("titleAlign"), "left")
+  const avatarAlign = alignOf(searchParams.get("align"), "center")
+  // Tier separator style: text headings (default), a hairline, or just spacing.
+  const sepRaw = searchParams.get("separator")
+  const separator = sepRaw === "line" ? "line" : sepRaw === "none" ? "none" : "label"
+  const separatorColor = resolveColor(searchParams.get("separatorColor"))
+  // Optional tier filter: `?tiers=featured,sponsors` shows only those rows
+  // (keys: featured/special, sponsors, backers). Omitted = all tiers.
+  const tiersParam = searchParams.get("tiers")
+  const tiersAllow = tiersParam !== null ? new Set(parseLoginList(tiersParam)) : null
+  const tierAllowed = (...keys: string[]) => !tiersAllow || keys.some((k) => tiersAllow.has(k))
 
   // Image response helper (svg or png), shared by the success + fallback paths.
   const imageResponse = async (svg: string, headers: Record<string, string>): Promise<Response> => {
@@ -2330,6 +2350,10 @@ async function handleSponsors(
       border,
       watermark,
       showNames,
+      titleAlign,
+      avatarAlign,
+      separator,
+      separatorColor,
       ...bgParams,
       emptyText: message,
     })
@@ -2366,12 +2390,22 @@ async function handleSponsors(
 
   const cacheHeaders = servedStale ? ERROR_CACHE_HEADERS : CACHE_HEADERS
 
+  // When no `special` set is pinned, auto-derive the featured tier from the
+  // public "Featured sponsors" section. Best-effort: yields [] on any failure.
+  let autoFeatured: string[] = []
+  if (featuredEnabled && specialLogins.length === 0) {
+    autoFeatured = await getGitHubFeaturedSponsors(login)
+  }
+  const effectiveSpecial = specialLogins.length ? specialLogins : autoFeatured
+  const usingFeatured = specialLogins.length === 0 && autoFeatured.length > 0
+  const specialTitle = specialTitleParam ?? (usingFeatured ? "Featured Sponsors" : "Special Sponsors")
+
   // Partition the public sponsors into tiers.
-  const specialSet = new Set(specialLogins)
+  const specialSet = new Set(effectiveSpecial)
   const backerSet = new Set(backerLogins)
   const byLogin = new Map(list.sponsors.map((s) => [s.login.toLowerCase(), s]))
 
-  const special: SponsorEntry[] = specialLogins.map((l) => byLogin.get(l)).filter((s): s is SponsorEntry => !!s)
+  const special: SponsorEntry[] = effectiveSpecial.map((l) => byLogin.get(l)).filter((s): s is SponsorEntry => !!s)
   const backers: SponsorEntry[] = backerLogins.map((l) => byLogin.get(l)).filter((s): s is SponsorEntry => !!s)
   const middle: SponsorEntry[] = list.sponsors.filter(
     (s) => !specialSet.has(s.login.toLowerCase()) && !backerSet.has(s.login.toLowerCase()),
@@ -2389,6 +2423,7 @@ async function handleSponsors(
         login,
         totalCount: list.totalCount,
         publicCount: list.sponsors.length,
+        featured: effectiveSpecial,
         shown: special.length + middleShown.length + backers.length,
         sponsors: list.sponsors.map((s) => ({ login: s.login, name: s.name, url: s.url, type: s.type })),
       },
@@ -2409,15 +2444,19 @@ async function handleSponsors(
   const sizes = tierSizes(baseSize)
   const tiers: SponsorTier[] = []
   const hasPinned = special.length > 0 || backers.length > 0
-  if (special.length) tiers.push({ title: specialTitle, size: sizes.special, avatars: special.map(toAvatar) })
-  if (middleShown.length) {
+  if (special.length && tierAllowed("featured", "special")) {
+    tiers.push({ title: specialTitle, size: sizes.special, avatars: special.map(toAvatar) })
+  }
+  if (middleShown.length && tierAllowed("sponsors")) {
     tiers.push({
       title: hasPinned ? sponsorsTitle : undefined,
       size: sizes.sponsors,
       avatars: middleShown.map(toAvatar),
     })
   }
-  if (backers.length) tiers.push({ title: backersTitle, size: sizes.backers, avatars: backers.map(toAvatar) })
+  if (backers.length && tierAllowed("backers")) {
+    tiers.push({ title: backersTitle, size: sizes.backers, avatars: backers.map(toAvatar) })
+  }
   if (tiers.length === 0) tiers.push({ size: sizes.sponsors, avatars: [] })
 
   const { svg } = renderSponsors({
@@ -2430,6 +2469,10 @@ async function handleSponsors(
     border,
     watermark,
     showNames,
+    titleAlign,
+    avatarAlign,
+    separator,
+    separatorColor,
     ...bgParams,
     emptyText: `No public sponsors yet — sponsor @${login}`,
   })

--- a/packages/web/components/sponsors-builder.tsx
+++ b/packages/web/components/sponsors-builder.tsx
@@ -11,7 +11,7 @@
 "use client"
 
 import { useState, useCallback, useMemo, useSyncExternalStore } from "react"
-import { Copy, Check, Shuffle } from "lucide-react"
+import { Copy, Check, Shuffle, AlignLeft, AlignCenter, AlignRight } from "lucide-react"
 import { useTheme } from "next-themes"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -60,6 +60,27 @@ const COPY_FORMATS: { value: CopyFormat; label: string }[] = [
 
 function FieldLabel({ children }: { children: React.ReactNode }) {
   return <Label className="text-xs text-muted-foreground">{children}</Label>
+}
+
+type Align = "left" | "center" | "right"
+function AlignField({ label, value, onChange }: { label: string; value: Align; onChange: (v: Align) => void }) {
+  return (
+    <div className="space-y-1.5">
+      <FieldLabel>{label}</FieldLabel>
+      <ToggleGroup
+        type="single"
+        value={value}
+        onValueChange={(v) => v && onChange(v as Align)}
+        variant="outline"
+        size="sm"
+        className="w-full"
+      >
+        <ToggleGroupItem value="left" aria-label="Align left" className="flex-1"><AlignLeft className="size-3.5" /></ToggleGroupItem>
+        <ToggleGroupItem value="center" aria-label="Align center" className="flex-1"><AlignCenter className="size-3.5" /></ToggleGroupItem>
+        <ToggleGroupItem value="right" aria-label="Align right" className="flex-1"><AlignRight className="size-3.5" /></ToggleGroupItem>
+      </ToggleGroup>
+    </div>
+  )
 }
 
 export function SponsorsBuilder() {
@@ -190,12 +211,26 @@ export function SponsorsBuilder() {
 
         {/* Tiers */}
         <div className="space-y-3">
+          <label className="flex items-start gap-2 cursor-pointer">
+            <ShadcnCheckbox
+              checked={s.featured}
+              onCheckedChange={(v) => set("featured", v === true)}
+              disabled={!!s.special.trim()}
+              className="mt-0.5"
+            />
+            <span className="text-xs leading-snug">
+              Auto featured tier
+              <span className="block text-muted-foreground">
+                Uses your GitHub “Featured sponsors” as the top row. Overridden by Special sponsors below.
+              </span>
+            </span>
+          </label>
           <div className="space-y-1.5">
             <FieldLabel>Special sponsors (comma-separated logins)</FieldLabel>
             <Input
               value={s.special}
               onChange={(e) => set("special", e.target.value)}
-              placeholder="vercel, clerk"
+              placeholder={s.featured ? "auto from Featured sponsors" : "vercel, clerk"}
               className="h-9 text-sm"
             />
           </div>
@@ -319,6 +354,46 @@ export function SponsorsBuilder() {
                 ))}
               </SelectContent>
             </Select>
+          </div>
+        </div>
+
+        {/* Alignment */}
+        <div className="grid grid-cols-2 gap-3">
+          <AlignField label="Title alignment" value={s.titleAlign} onChange={(v) => set("titleAlign", v)} />
+          <AlignField label="Avatar alignment" value={s.avatarAlign} onChange={(v) => set("avatarAlign", v)} />
+        </div>
+
+        {/* Tier separator + visibility */}
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <FieldLabel>Tier separator</FieldLabel>
+            <Select value={s.separator} onValueChange={(v) => set("separator", v as SponsorsState["separator"])}>
+              <SelectTrigger className="h-9 w-full text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="label">Text labels</SelectItem>
+                <SelectItem value="line">Line only</SelectItem>
+                <SelectItem value="none">None (spacing)</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5">
+            <FieldLabel>Show tiers</FieldLabel>
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <ShadcnCheckbox checked={s.tierFeatured} onCheckedChange={(v) => set("tierFeatured", v === true)} />
+                <span className="text-xs">Featured</span>
+              </label>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <ShadcnCheckbox checked={s.tierSponsors} onCheckedChange={(v) => set("tierSponsors", v === true)} />
+                <span className="text-xs">Sponsors</span>
+              </label>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <ShadcnCheckbox checked={s.tierBackers} onCheckedChange={(v) => set("tierBackers", v === true)} />
+                <span className="text-xs">Backers</span>
+              </label>
+            </div>
           </div>
         </div>
 

--- a/packages/web/components/studio/inspectors.tsx
+++ b/packages/web/components/studio/inspectors.tsx
@@ -466,8 +466,9 @@ export function SponsorsInspector({ block, onChange }: { block: SponsorsBlock; o
       </Field>
 
       <Separator />
+      <ToggleField label="Auto featured tier" checked={s.featured} onCheckedChange={v => set({ featured: v })} />
       <Field label="Special sponsors (logins)" htmlFor="sp-special">
-        <Input id="sp-special" value={s.special} onChange={e => set({ special: e.target.value })} placeholder="vercel, clerk" />
+        <Input id="sp-special" value={s.special} onChange={e => set({ special: e.target.value })} placeholder={s.featured ? "auto from Featured sponsors" : "vercel, clerk"} />
       </Field>
       <Field label="Backers (logins)" htmlFor="sp-backers">
         <Input id="sp-backers" value={s.backers} onChange={e => set({ backers: e.target.value })} placeholder="octocat" />
@@ -518,6 +519,43 @@ export function SponsorsInspector({ block, onChange }: { block: SponsorsBlock; o
           </Select>
         </Field>
       </Row>
+
+      <Separator />
+      <Row>
+        <Field label="Title align">
+          <Select value={s.titleAlign} onValueChange={v => set({ titleAlign: v as SponsorsState["titleAlign"] })}>
+            <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="left">Left</SelectItem>
+              <SelectItem value="center">Center</SelectItem>
+              <SelectItem value="right">Right</SelectItem>
+            </SelectContent>
+          </Select>
+        </Field>
+        <Field label="Avatar align">
+          <Select value={s.avatarAlign} onValueChange={v => set({ avatarAlign: v as SponsorsState["avatarAlign"] })}>
+            <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="left">Left</SelectItem>
+              <SelectItem value="center">Center</SelectItem>
+              <SelectItem value="right">Right</SelectItem>
+            </SelectContent>
+          </Select>
+        </Field>
+      </Row>
+      <Field label="Tier separator">
+        <Select value={s.separator} onValueChange={v => set({ separator: v as SponsorsState["separator"] })}>
+          <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="label">Text labels</SelectItem>
+            <SelectItem value="line">Line only</SelectItem>
+            <SelectItem value="none">None (spacing)</SelectItem>
+          </SelectContent>
+        </Select>
+      </Field>
+      <ToggleField label="Show Featured tier" checked={s.tierFeatured} onCheckedChange={v => set({ tierFeatured: v })} />
+      <ToggleField label="Show Sponsors tier" checked={s.tierSponsors} onCheckedChange={v => set({ tierSponsors: v })} />
+      <ToggleField label="Show Backers tier" checked={s.tierBackers} onCheckedChange={v => set({ tierBackers: v })} />
 
       <Separator />
       <ToggleField label="Names" checked={s.names} onCheckedChange={v => set({ names: v })} />

--- a/packages/web/content/docs/sponsors/index.mdx
+++ b/packages/web/content/docs/sponsors/index.mdx
@@ -48,13 +48,31 @@ Or center it with an HTML block:
 
 ## Tiers
 
-GitHub only exposes sponsor **dollar amounts** to the sponsored account's own
-token. shieldcn fetches through a shared pool of community tokens, so it can
-read the **public sponsor list** but not each sponsor's tier. Instead, you
-arrange tiers yourself by pinning logins:
+### Automatic featured tier
+
+By default, the top row is populated from your GitHub Sponsors **"Featured
+sponsors"** selection — the sponsors you hand-pick to highlight on your
+[sponsors profile](https://github.com/sponsors). shieldcn reads that public
+selection and renders it as a larger **"Featured Sponsors"** row automatically,
+with everyone else in the default "Sponsors" row. No configuration needed:
+
+```md
+![Sponsors](https://shieldcn.dev/sponsors/your-login.svg)
+```
+
+Manage which sponsors are featured from your GitHub Sponsors dashboard. Turn the
+automatic tier off with `?featured=false`.
+
+> GitHub only exposes sponsor **dollar amounts** to the sponsored account's own
+> token, so amount-based tiers (e.g. by monthly value) aren't possible from a
+> shared service — the public "Featured sponsors" selection is what's available.
+
+### Manual tiers
+
+To override the automatic tier, pin logins yourself:
 
 - `special` — a comma-separated list of logins shown **larger**, at the top, in
-  a "Special Sponsors" row.
+  a "Special Sponsors" row (overrides the automatic featured tier).
 - `backers` — a comma-separated list of logins shown **smaller**, at the
   bottom, in a "Backers" row.
 - Everyone else falls into the default "Sponsors" row.
@@ -72,6 +90,33 @@ arrange tiers yourself by pinning logins:
 Rename the rows with `specialTitle`, `sponsorsTitle`, and `backersTitle`. A
 `@login` prefix is accepted and ignored, so `special=@vercel` also works.
 
+### Choosing which tiers show
+
+Use `tiers` to render only certain rows — a comma-separated subset of
+`featured`, `sponsors`, `backers`. Omit it to show all of them.
+
+```md
+![Featured only](https://shieldcn.dev/sponsors/your-login.svg?tiers=featured)
+![No backers](https://shieldcn.dev/sponsors/your-login.svg?tiers=featured,sponsors)
+```
+
+### Tier separators
+
+By default each tier has a centered text heading. Set `separator` to change how
+tiers are delimited:
+
+| `separator` | Result |
+| --- | --- |
+| `label` | Centered text heading above each tier. The default. |
+| `line` | A hairline rule between tiers — **no text headings**. |
+| `none` | Just vertical spacing, no headings or lines. |
+
+Color the line with `separatorColor` (hex without `#`).
+
+```md
+![Line separators](https://shieldcn.dev/sponsors/your-login.svg?separator=line)
+```
+
 ## Sizing and layout
 
 The `size` parameter sets the base avatar diameter; the special and backers
@@ -84,6 +129,11 @@ wrap into as many rows as needed.
 | `width` | 320–2000 (px) | 800 |
 | `limit` | 1–80 | 60 |
 | `names` | `true`, `false` | `true` |
+| `titleAlign` | `left`, `center`, `right` | `left` |
+| `align` | `left`, `center`, `right` (avatars) | `center` |
+| `tiers` | subset of `featured,sponsors,backers` | all |
+| `separator` | `label`, `line`, `none` | `label` |
+| `separatorColor` | hex without `#` | border |
 | `radius` | 0–80 (px) | 12 |
 | `border` | `true`, `false` | `true` |
 | `watermark` | `true`, `false` | `false` |
@@ -159,11 +209,17 @@ In addition to the shared `mode` and `font` parameters from the
 
 | Parameter | Values | Default |
 | --- | --- | --- |
-| `special` | comma-separated logins | — |
+| `featured` | `true`, `false` | `true` (auto featured tier) |
+| `special` | comma-separated logins | auto (Featured sponsors) |
 | `backers` | comma-separated logins | — |
-| `specialTitle` | string | `Special Sponsors` |
+| `specialTitle` | string | `Featured Sponsors` / `Special Sponsors` |
 | `sponsorsTitle` | string | `Sponsors` |
 | `backersTitle` | string | `Backers` |
+| `tiers` | subset of `featured,sponsors,backers` | all |
+| `separator` | `label`, `line`, `none` | `label` |
+| `separatorColor` | hex without `#` | border |
+| `titleAlign` | `left`, `center`, `right` | `left` |
+| `align` | `left`, `center`, `right` (avatars) | `center` |
 | `title` | string, or `false` | `Sponsors` |
 | `size` | 32–140 (px) | 64 |
 | `width` | 320–2000 (px) | 800 |

--- a/packages/web/content/docs/sponsors/index.mdx
+++ b/packages/web/content/docs/sponsors/index.mdx
@@ -242,9 +242,20 @@ In addition to the shared `mode` and `font` parameters from the
 
 ## Data source
 
-Sponsor data comes from the [GitHub Sponsors GraphQL API](https://docs.github.com/en/graphql/reference/objects#sponsorconnection),
-fetched through shieldcn's community token pool. Only **public** sponsors are
-listed; private sponsors are counted in the total but never shown. Avatars are
-fetched once and inlined into the image, and the list is cached for 30 minutes
-(serving the last-known-good list during any GitHub outage). Accounts without
-GitHub Sponsors enabled render an empty-state message.
+Only **public** sponsors are ever shown. Sponsor data comes from one of two
+sources:
+
+- **GitHub Sponsors GraphQL API** (when a token is available) — the complete
+  list with display names, hi-res avatars, and an accurate total.
+- **Public sponsors page** (token-free fallback) — when no token is configured,
+  the current-sponsor wall is read from `github.com/sponsors/{login}`. This
+  needs no token but GitHub caps that page at ~50 sponsors and exposes logins
+  only (no display names), so large accounts are truncated.
+
+The **featured tier** is always read from the public page (token-free). Avatars
+are fetched once and inlined into the image, and the list is cached for 30
+minutes (serving the last-known-good list during any GitHub outage). Accounts
+without GitHub Sponsors enabled render an empty-state message.
+
+Self-hosters can set a `read:user` token via `SPONSORS_GITHUB_TOKEN` to get the
+full GraphQL list instead of the ~50-capped public-page fallback.

--- a/packages/web/lib/sponsors-builder-shared.ts
+++ b/packages/web/lib/sponsors-builder-shared.ts
@@ -42,10 +42,25 @@ export interface SponsorsState {
   size: SponsorsSize
   /** Show a name caption under each avatar. */
   names: boolean
+  /** Alignment of the card title. */
+  titleAlign: "left" | "center" | "right"
+  /** Alignment of the avatar rows. */
+  avatarAlign: "left" | "center" | "right"
+  /**
+   * Auto-populate the top "Featured Sponsors" tier from the account's public
+   * GitHub "Featured sponsors" selection. Ignored when `special` is set.
+   */
+  featured: boolean
   /** Comma-separated logins pinned into the larger "Special Sponsors" row. */
   special: string
   /** Comma-separated logins pinned into the smaller "Backers" row. */
   backers: string
+  /** Tier separator style: text headings, a hairline, or just spacing. */
+  separator: "label" | "line" | "none"
+  /** Per-tier visibility — a tier is hidden when its flag is false. */
+  tierFeatured: boolean
+  tierSponsors: boolean
+  tierBackers: boolean
   /** Max avatars in the default row (string for the input). */
   limit: string
   mode: "dark" | "light"
@@ -65,8 +80,15 @@ export const SPONSORS_DEFAULTS: SponsorsState = {
   theme: "",
   size: "64",
   names: true,
+  titleAlign: "left",
+  avatarAlign: "center",
+  featured: true,
   special: "",
   backers: "",
+  separator: "label",
+  tierFeatured: true,
+  tierSponsors: true,
+  tierBackers: true,
   limit: "",
   mode: "dark",
   font: "inter",
@@ -89,8 +111,20 @@ export function buildSponsorsUrl(s: SponsorsState, baseUrl: string): string {
   if (s.theme) params.set("theme", s.theme)
   if (s.size && s.size !== "64") params.set("size", s.size)
   if (!s.names) params.set("names", "false")
+  if (s.titleAlign && s.titleAlign !== "left") params.set("titleAlign", s.titleAlign)
+  if (s.avatarAlign && s.avatarAlign !== "center") params.set("align", s.avatarAlign)
+  // The featured tier is auto-derived by default; only emit when disabled, and
+  // it's moot once an explicit `special` set overrides it.
+  if (!s.featured && !s.special.trim()) params.set("featured", "false")
   if (s.special.trim()) params.set("special", s.special.trim())
   if (s.backers.trim()) params.set("backers", s.backers.trim())
+  if (s.separator && s.separator !== "label") params.set("separator", s.separator)
+  // Emit `tiers` only when a row is hidden (all-on = default = omitted).
+  const tierKeys: string[] = []
+  if (s.tierFeatured) tierKeys.push("featured")
+  if (s.tierSponsors) tierKeys.push("sponsors")
+  if (s.tierBackers) tierKeys.push("backers")
+  if (tierKeys.length < 3) params.set("tiers", tierKeys.join(","))
   if (s.limit.trim()) params.set("limit", s.limit.trim())
   // Always include mode so the URL changes with the site theme (cache-safe).
   params.set("mode", s.mode)

--- a/packages/web/lib/studio-import.ts
+++ b/packages/web/lib/studio-import.ts
@@ -225,8 +225,25 @@ function sponsorsStateFromUrl(u: URL): SponsorsState {
     theme: q.get("theme") || "",
     size: ((q.get("size") as SponsorsSize) || "64"),
     names: q.get("names") !== "false",
+    titleAlign: ((v) => (v === "center" || v === "right" ? v : "left"))(q.get("titleAlign")),
+    avatarAlign: ((v) => (v === "left" || v === "right" ? v : "center"))(q.get("align")),
+    featured: q.get("featured") !== "false",
     special: q.get("special") || "",
     backers: q.get("backers") || "",
+    separator: ((): "label" | "line" | "none" => {
+      const v = q.get("separator")
+      return v === "line" ? "line" : v === "none" ? "none" : "label"
+    })(),
+    ...(() => {
+      const raw = q.get("tiers")
+      if (raw === null) return { tierFeatured: true, tierSponsors: true, tierBackers: true }
+      const set = new Set(raw.split(",").map(t => t.trim().toLowerCase()))
+      return {
+        tierFeatured: set.has("featured") || set.has("special"),
+        tierSponsors: set.has("sponsors"),
+        tierBackers: set.has("backers"),
+      }
+    })(),
     limit: q.get("limit") || "",
     mode: (q.get("mode") as "dark" | "light") || "dark",
     font: q.get("font") || "inter",


### PR DESCRIPTION
## What

Builds on the merged sponsors feature with **automatic tiering** and full **display control**:

- **Auto "Featured Sponsors" tier** — populated from the account's public GitHub *Featured sponsors* selection, scraped from the sponsors page. (GitHub exposes featured sponsors only in HTML and never reveals sponsorship *amounts* to a third-party token, so this is the only viable source for automatic tiering on a shared service.) Defensive + best-effort: any failure falls back to a flat grid.
- **`?tiers=`** — render only chosen rows (`featured`, `sponsors`, `backers`).
- **`?separator=label|line|none`** (+ `?separatorColor`) — `line` drops the text headings for a clean hairline between tiers.
- **`?titleAlign`** and **`?align`** — align the card title and the avatar rows independently.
- **`?featured=false`** opts out; a manual **`?special=`** still overrides the auto tier.

All of it is wired through the **generator** (`/sponsors`), the **README Studio** Sponsors inspector, **Markdown round-trip import**, and the **docs**.

## Why

The original feature needed manual `special=`/`backers=` pinning for tiers. This makes the common case automatic (your GitHub-chosen featured sponsors just appear), and adds the display controls requested: choose which tiers show, swap text headings for a line separator, and align the title/avatars.

Closes #

## Type

- [x] `feat` — New feature

## Checklist

- [x] Branch follows conventional naming (`feat/sponsors-featured-tier`)
- [x] Commits follow Conventional Commits
- [x] Tested locally with `pnpm dev` (verified against real `jal-co` featured sponsors)
- [x] Badge renders correctly in SVG and PNG
- [x] Docs updated (`/docs/sponsors`: auto-featured, tiers, separators, alignment + params)

## Testing

- `@shieldcn/core`: **134 passing**, incl. new tests for the HTML featured-sponsor parser, the auto-featured route, `?tiers=` filtering, `?separator=line`, and `?titleAlign`.
- `tsc --noEmit` clean (core + web); web ESLint clean.
- Live, token-backed: `jal-co` auto-renders a Featured Sponsors tier (Notra + Chánh Đại); `separator=line`, `tiers=featured`, and `titleAlign`/`align` all verified visually.

## Notes

> Requires the `SPONSORS_GITHUB_TOKEN` env from #150 to fetch sponsor lists in production. The featured-sponsor scrape itself needs no token (public HTML).
