### PR TITLE
feat(studio): overhaul README Studio editor and add project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,363 +1,51 @@
+<p align="left">
+  <picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/header/graph.svg?title=shieldcn&amp;subtitle=EVERYTHING+for+your+readme&amp;logo=shieldcn&amp;logoColor=848484&amp;mode=dark&amp;align=left&amp;font=geist-mono&amp;border=false" /><img alt="shieldcn" src="https://shieldcn.dev/header/graph.svg?title=shieldcn&amp;subtitle=EVERYTHING+for+your+readme&amp;logo=shieldcn&amp;logoColor=848484&amp;mode=light&amp;align=left&amp;font=geist-mono&amp;border=false" /></picture>
+</p>
+
+<div align="center">
+
+Before anyone reaches your docs, they land on your README, the front door of every open-source project. **shieldcn** makes that first impression count: badges, charts, headers, and sponsor walls, rendered as real [shadcn/ui](https://ui.shadcn.com) components. A [shields.io](https://shields.io) alternative.
+
+<div align="center">
+
+[Homepage](https://shieldcn.dev) · [Docs](https://shieldcn.dev/docs) · [Studio](https://shieldcn.dev/studio) · [𝕏](https://x.com/jalcowastaken)
+
+</div>
+
+</div>
+
 <p align="center">
-  <a href="https://shieldcn.dev">
-    <img alt="shieldcn" src="https://shieldcn.dev/header/graph.svg?title=shieldcn&subtitle=badges%2C+headers%2C+and+charts+for+your+readme&logo=shieldcn&logoColor=848484&mode=dark&align=left&font=geist-mono&border=false" />
-  </a>
+  <a href="https://github.com/jal-co/shieldcn"><picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/group/github/jal-co/shieldcn/stars+github/jal-co/shieldcn/license+github/jal-co/shieldcn/contributors+github/jal-co/shieldcn/last-commit.svg?variant=branded&amp;size=xs" /><img alt="shieldcn stats" src="https://shieldcn.dev/group/github/jal-co/shieldcn/stars+github/jal-co/shieldcn/license+github/jal-co/shieldcn/contributors+github/jal-co/shieldcn/last-commit.svg?variant=branded&amp;size=xs&amp;mode=light" /></picture></a>
 </p>
 
 <p align="center">
-  Beautiful README badges.<br />
-  A <a href="https://shields.io">shields.io</a> alternative styled as <a href="https://ui.shadcn.com">shadcn/ui</a> buttons. Never paywalled.
+  <a href="https://vercel.com/oss"><picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/badge/Vercel_OSS_Program_Member.svg?variant=branded&amp;size=xs&amp;logo=vercel" /><img alt="Vercel OSS Program Member" src="https://shieldcn.dev/badge/Vercel_OSS_Program_Member.svg?variant=branded&amp;size=xs&amp;mode=light&amp;logo=vercel" /></picture></a>
+  <a href="https://openpanel.dev?ref=justinlevine.me"><picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/badge/analytics%20by-openpanel.svg?variant=branded&amp;size=xs&amp;logo=openpanel" /><img alt="analytics by openpanel" src="https://shieldcn.dev/badge/analytics%20by-openpanel.svg?variant=branded&amp;size=xs&amp;mode=light&amp;logo=openpanel" /></picture></a>
 </p>
-
-<p align="center">
-  <a href="https://shieldcn.dev">Homepage</a> · <a href="https://shieldcn.dev/docs">Docs</a> · <a href="https://shieldcn.dev/docs/cli">CLI</a> · <a href="https://shieldcn.dev/docs/api-reference">API Reference</a> · <a href="https://x.com/jalcowastaken">𝕏</a>
-</p>
-
-<p align="center">
-  <img src="https://shieldcn.dev/group/github/stars/jal-co/shieldcn%2Bgithub/license/jal-co/shieldcn%2Bgithub/contributors/jal-co/shieldcn%2Bgithub/last-commit/jal-co/shieldcn.svg?variant=branded" alt="shieldcn stats" />
-</p>
-
-<p align="center">
-  <a href="https://vercel.com/oss"><img src="https://shieldcn.dev/badge/Vercel_OSS_Program_Member.svg?variant=branded&logo=vercel" alt="Vercel OSS Program Member" /></a>
-</p>
-
-<p align="center">
-  <a href="https://shieldcn.dev/docs/self-hosting"><img src="https://shieldcn.dev/badge/host%20with-docker-2496ED.svg?variant=branded&logo=docker" alt="host with docker" /></a>
-  <a href="https://openpanel.dev?ref=justinlevine.me"><img src="https://shieldcn.dev/badge/analytics%20by-openpanel.svg?variant=branded&logo=openpanel" alt="analytics by openpanel" /></a>
-  <a href="https://sentry.io/?utm_source=shieldcn.dev"><img src="https://shieldcn.dev/badge/monitored%20by-sentry.svg?variant=branded&logo=sentry" alt="monitored by sentry" /></a>
-  <a href="https://shadcncraft.com?utm_source=shieldcn.dev"><img src="https://shieldcn.dev/badge/built%20with-shadcncraft-171717.svg?logo=shadcncraft&logoColor=fff&variant=branded" alt="built with shadcncraft" /></a>
-  <a href="https://www.shadcnblocks.com?utm_source=shieldcn.dev"><img src="https://shieldcn.dev/badge/built%20with-shadcnblocks-000000.svg?logo=shadcnblocks&logoColor=fff&variant=branded" alt="built with shadcnblocks" /></a>
-</p>
-
-## About
-
-shieldcn is an open-source badge service by [Justin Levine](https://justinlevine.me). Every badge is free, every endpoint is public, and that's not changing.
-
-Badges are rendered as actual [shadcn/ui](https://ui.shadcn.com) Button components via [Satori](https://github.com/vercel/satori) — same font (Inter), same border-radius, same padding, same color tokens per variant and size. Not "inspired by" — the real thing, as SVG.
-
-Built with [jal-co/ui](https://ui.justinlevine.me) components.
-
-## CLI
-
-Generate badges from your terminal:
-
-```bash
-# Scan current repo and generate badge markdown
-npx shieldcn-cli
-
-# Scan a GitHub repo
-npx shieldcn-cli vercel/next.js --variant branded
-
-# Inject badges into README
-npx shieldcn-cli --inject
-
-# Migrate shields.io URLs to shieldcn
-npx shieldcn-cli migrate
-```
-
-See the [CLI docs](https://shieldcn.dev/docs/cli) for full usage.
 
 ## Usage
 
+Drop a badge into any README and it renders as a real shadcn Button.
+
 ```md
 ![npm](https://shieldcn.dev/npm/react.svg)
-![stars](https://shieldcn.dev/github/stars/vercel/next.js.svg)
-![CI](https://shieldcn.dev/github/ci/jal-co/ui.svg)
-![license](https://shieldcn.dev/github/license/vercel/next.js.svg)
-![discord](https://shieldcn.dev/discord/1316199667142496307.svg)
+![stars](https://shieldcn.dev/github/vercel/next.js/stars.svg)
 ```
 
-### Badge groups
+## Star History
 
-Combine multiple badges into a single joined image — like a [shadcn ButtonGroup](https://ui.shadcn.com/docs/components/radix/button-group):
-
-<p>
-  <img src="https://shieldcn.dev/group/npm/react%2Bgithub/stars/vercel/next.js%2Bgithub/license/vercel/next.js.svg?variant=branded" alt="badge group" />
+<p align="center">
+  <picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/chart/github/stars/jal-co/shieldcn.svg?theme=zinc&amp;bg=transparent&amp;border=false&amp;logo=false&amp;icon=Star" /><img alt="shieldcn star history" src="https://shieldcn.dev/chart/github/stars/jal-co/shieldcn.svg?mode=light&amp;theme=zinc&amp;bg=transparent&amp;border=false&amp;logo=false&amp;icon=Star" /></picture>
 </p>
 
-```md
-![group](https://shieldcn.dev/group/npm/react+github/stars/vercel/next.js+github/license/vercel/next.js.svg?variant=branded)
-```
+## Sponsors
 
-Join any badge paths with `+` under `/group/`. Query params apply to all segments. See the [Badge Group docs](https://shieldcn.dev/docs/badges/group).
-
-### Animated badges
-
-<p>
-  <img src="https://shieldcn.dev/badge/shieldcn-animated%20badges.gif?variant=branded&size=lg&logo=shieldcn&logoColor=fff&color=8b5cf6&animate=shimmer" alt="animated shieldcn badge" />
+<p align="center">
+  <picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/sponsors/jal-co.svg?title=false&amp;preset=transparent&amp;size=80&amp;names=false&amp;special=usenotra&amp;separator=line&amp;mode=dark&amp;border=false" /><img alt="sponsors" src="https://shieldcn.dev/sponsors/jal-co.svg?title=false&amp;preset=transparent&amp;size=80&amp;names=false&amp;special=usenotra&amp;separator=line&amp;mode=light&amp;border=false" /></picture>
 </p>
 
-Add `?animate=pulse`, `glow`, or `shimmer` to bring a badge to life:
+<div align="center">
 
-- **`pulse`** / **`glow`** animate the status dot (great for live, CI, or "online" badges)
-- **`shimmer`** sweeps a highlight across the whole badge
+[MIT](https://github.com/jal-co/shieldcn/blob/main/LICENSE) · Built by [Justin Levine](https://justinlevine.me) · [Contribute](https://github.com/jal-co/shieldcn)
 
-For `.svg` badges the animation is pure CSS — no JavaScript — and automatically goes static for visitors with reduced motion enabled. Because GitHub sanitizes animated SVGs, request the **`.gif`** extension to animate inside a GitHub README:
-
-```md
-<!-- animates everywhere except GitHub READMEs (static frame there) -->
-![status](https://shieldcn.dev/badge/status-online-22c55e.svg?statusDot=true&animate=pulse)
-
-<!-- animated GIF — animates inside GitHub READMEs too -->
-![status](https://shieldcn.dev/badge/status-online-22c55e.gif?statusDot=true&animate=pulse)
-```
-
-See the [API reference](https://shieldcn.dev/docs/api-reference) for the full list of animation options.
-
-### Charts
-
-Shadcn-styled line/area graphs — GitHub star history (like
-[starcharts](https://github.com/caarlos0/starcharts)), issues over time, npm
-downloads, and your own JSON data — all as portable SVGs:
-
-<p>
-  <img src="https://shieldcn.dev/chart/github/stars/vercel/next.js.svg" alt="vercel/next.js star history" />
-</p>
-
-```md
-![Star History](https://shieldcn.dev/chart/github/stars/vercel/next.js.svg)
-![Issues](https://shieldcn.dev/chart/github/issues/honojs/hono.svg)
-![npm downloads](https://shieldcn.dev/chart/npm/zod.svg)
-![Custom](https://shieldcn.dev/chart/json.svg?values=10,25,40,30,60&title=Metric)
-```
-
-Available as `.svg`, `.png`, and `.json`. Customize with `mode`, `theme`,
-`color`, `fill`, `area`, `bg`, `border`, `font`, `width`, `height`, and
-`title`. See the [Charts docs](https://shieldcn.dev/docs/charts).
-
-### Headers
-
-Repository header banners for the top of your README — your logo, a premade
-shadcn-styled background, a title, and a tagline, all from one image URL:
-
-<p>
-  <img src="https://shieldcn.dev/header/dots.svg?title=Acme+Toolkit&subtitle=A+delightful+component+library&logo=react" alt="Acme Toolkit repository header" />
-</p>
-
-```md
-![Header](https://shieldcn.dev/header/dots.svg?title=Acme+Toolkit&subtitle=A+delightful+component+library&logo=react)
-```
-
-Premade backgrounds: `surface`, `gradient`, `dots`, `grid`, `graph`, `glow`,
-`transparent`. Available as `.svg`, `.png`, and `.json`. Customize with `title`,
-`subtitle`, `logo`, `size`, `align`, `theme`, `gradient`, `bg` (incl.
-`transparent`), and more. Build one with the
-[header generator](https://shieldcn.dev/header) or see the
-[Headers docs](https://shieldcn.dev/docs/headers).
-
-### Sponsors
-
-A grid of your account's active public GitHub Sponsors — every sponsor's
-avatar, name, and link — as one portable image:
-
-```md
-![Sponsors](https://shieldcn.dev/sponsors/shadcn.svg)
-```
-
-Pin logins into larger `special` and smaller `backers` rows; everyone else
-lands in the default `Sponsors` row. Available as `.svg`, `.png`, and `.json`.
-Customize with `special`, `backers`, `title`, `size`, `limit`, `names`, `bg`,
-and more. See the [Sponsors docs](https://shieldcn.dev/docs/sponsors).
-
-## Supported providers
-
-See the [docs](https://shieldcn.dev/docs) for full endpoint details, interactive sandboxes, and copy-paste examples.
-
-### Package registries
-
-| Provider | Badges | Endpoint |
-|----------|--------|----------|
-| **npm** | version, downloads, license, node, types, dependents | `/npm/{package}` |
-| **PyPI** | version, downloads, license, python version | `/pypi/{package}` |
-| **Crates.io** | version, downloads, license | `/crates/{crate}` |
-| **Docker Hub** | pulls, stars, version, image size | `/docker/pulls/{image}` |
-| **Packagist** | version, downloads, license | `/packagist/v/{vendor}/{package}` |
-| **RubyGems** | version, downloads, license | `/rubygems/{gem}` |
-| **NuGet** | version, downloads | `/nuget/{package}` |
-| **Pub.dev** | version, likes, points, popularity | `/pub/{package}` |
-| **Homebrew** | version (formula + cask), installs, downloads | `/homebrew/{formula}` |
-| **Maven Central** | version | `/maven/{groupId}/{artifactId}` |
-| **CocoaPods** | version | `/cocoapods/{pod}` |
-| **JSR** | version, score | `/jsr/{@scope}/{name}` |
-| **Bundlephobia** | min size, minzip size, tree-shaking | `/bundlephobia/minzip/{package}` |
-| **Conda** | version, downloads, platform | `/conda/v/{channel}/{package}` |
-| **jsDelivr** | CDN hits, rank | `/jsdelivr/hits/npm/{package}` |
-| **Chocolatey** | version, downloads | `/chocolatey/v/{package}` |
-| **Snapcraft** | version | `/snapcraft/v/{snap}` |
-
-### Code platforms
-
-| Provider | Badges | Endpoint |
-|----------|--------|----------|
-| **GitHub** | stars, forks, watchers, license, release, CI, checks, issues, PRs, milestones, commits, downloads (all/specific asset, all/latest/tag), dependabot, and more | `/github/{owner}/{repo}/{topic}` |
-| **GitLab** | stars, forks, issues, pipeline, license, release, contributors | `/gitlab/{owner}/{repo}/{topic}` |
-| **Codecov** | coverage percentage (color-coded) | `/codecov/{service}/{owner}/{repo}` |
-| **Coveralls** | coverage percentage (color-coded) | `/coveralls/{service}/{owner}/{repo}` |
-| **SonarCloud** | quality gate, bugs, vulnerabilities, coverage, maintainability, reliability, security | `/sonar/{topic}/{component}` |
-| **VS Code Marketplace** | installs, rating, version | `/vscode/installs/{publisher}/{extension}` |
-| **Open VSX** | version, downloads, rating | `/openvsx/v/{namespace}/{extension}` |
-
-### App stores
-
-| Provider | Badges | Endpoint |
-|----------|--------|----------|
-| **Chrome Web Store** | version, users, rating | `/chrome/v/{extensionId}` |
-| **Mozilla Add-ons** | version, users, rating, downloads | `/amo/v/{slug}` |
-| **Flathub** | version, downloads | `/flathub/v/{appId}` |
-| **F-Droid** | version | `/fdroid/v/{appId}` |
-
-### Social & Community
-
-| Provider | Badges | Endpoint |
-|----------|--------|----------|
-| **Discord** | online count, members | `/discord/{serverId}` |
-| **NBA** | team fan badges with logos and team colors (2026 Champs Knicks by default) | `/nba` or `/nba/{team}` |
-| **Reddit** | karma, subscribers | `/reddit/subscribers/r/{subreddit}` |
-| **Bluesky** | followers, following, posts | `/bluesky/{handle}` |
-| **X / Twitter** | follow CTA, mention CTA | `/x/follow/{username}` |
-| **YouTube** | subscribers, channel views, video views, likes, comments | `/youtube/subscribers/{channelId}` |
-| **Mastodon** | followers, following, posts | `/mastodon/followers/{instance}/{acct}` |
-| **Lemmy** | subscribers, posts, comments | `/lemmy/subscribers/{instance}/{community}` |
-| **Hacker News** | karma | `/hackernews/{userId}` |
-| **Twitch** | live status, followers | `/twitch/status/{login}` |
-| **Discourse** | topics, posts, users, likes | `/discourse/topics/{server}` |
-| **Matrix** | room members | `/matrix/members/{roomAlias}` |
-| **Stack Exchange** | tag questions, user reputation | `/stackexchange/tag/{tag}` |
-
-### Funding & Tools
-
-| Provider | Badges | Endpoint |
-|----------|--------|----------|
-| **Open Collective** | backers, sponsors, contributors, balance, budget | `/opencollective/backers/{slug}` |
-| **Liberapay** | receiving, patrons, goal | `/liberapay/receiving/{username}` |
-| **WakaTime** | coding time | `/wakatime/{username}` |
-| **Weblate** | translation %, language count | `/weblate/translation/{server}/{project}/{component}` |
-| **Modrinth** | downloads, followers, version, game versions | `/modrinth/downloads/{slug}` |
-| **Tokscale** | tokens, cost, rank, active days | `/tokscale/{username}` |
-| **skills.sh** | skill installs, rank, trending, hot | `/skills/installs/{owner}/{repo}/{skill}` |
-| **Country Flags** | “built in {country}” with a flag chip (265 countries/regions) | `/flag/{code}` |
-
-### Custom badges
-
-| Type | Description | Endpoint |
-|------|-------------|----------|
-| **Badge Group** | Multiple badges joined in one image | `/group/{badge1}+{badge2}+{badge3}` |
-| **Static** | Custom label/message/color | `/badge/{label}-{message}-{color}` |
-| **Dynamic JSON** | Fetch any JSON API | `/badge/dynamic/json?url=...&query=...` |
-| **HTTPS Endpoint** | Proxy any JSON endpoint | `/https/{hostname}/{path}` |
-| **Memo** | User-stored badges (PUT API) | `/memo/{key}` |
-
-## Variants & sizes
-
-Every badge supports shadcn Button variants and sizes:
-
-```md
-![default](https://shieldcn.dev/npm/react.svg)
-![secondary](https://shieldcn.dev/npm/react.svg?variant=secondary)
-![outline](https://shieldcn.dev/npm/react.svg?variant=outline)
-![ghost](https://shieldcn.dev/npm/react.svg?variant=ghost)
-![destructive](https://shieldcn.dev/npm/react.svg?variant=destructive)
-![branded](https://shieldcn.dev/npm/react.svg?variant=branded)
-
-![xs](https://shieldcn.dev/npm/react.svg?size=xs)
-![sm](https://shieldcn.dev/npm/react.svg?size=sm)
-![default](https://shieldcn.dev/npm/react.svg?size=default)
-![lg](https://shieldcn.dev/npm/react.svg?size=lg)
-```
-
-## Icons
-
-Three icon libraries (40,000+ icons) plus custom SVG upload:
-
-- **[Simple Icons](https://simpleicons.org)** — `?logo=react`
-- **[React Icons](https://react-icons.github.io/react-icons/)** — `?logo=ri:GoStarFill`
-- **[React Icons](https://react-icons.github.io/react-icons/)** — `?logo=ri:FaReact`
-- **Custom SVG** — `?logo=data:image/svg+xml;base64,...` — upload any SVG icon via the Badge Builder or encode it yourself
-
-## Response formats
-
-- **`.svg`** — SVG image (crisp, scalable, recommended default)
-- **`.png`** — PNG image (raster fallback for clients that reject SVG)
-- **`.json`** — raw badge data
-- **`/shields.json`** — shields.io-compatible endpoint
-
-Use `.svg` for the sharpest result. Use `.png` only where SVG images are not accepted.
-
-## Design principles
-
-- **shadcn buttons, not shields.io rectangles** — badges are rendered as actual shadcn Button components with real Inter font outlines via Satori
-- **Everything configurable** — variant, size, mode, colors, icons, opacity, split, dot — but sensible defaults so you don't have to configure anything
-- **Shields.io compatible** — same URL patterns for static/dynamic badges, same text encoding, shields.io JSON endpoint support
-- **Open source, never paywalled** — every badge type, every variant, every icon source is free
-
-## Agent skill
-
-Install the shieldcn skill to let AI coding agents (Claude Code, Cursor, Codex, and [40+ more](https://github.com/vercel-labs/skills#supported-agents)) add badges to your projects:
-
-```bash
-npx skills add jal-co/shieldcn
-```
-
-Once installed, ask your agent to _"add shieldcn badges to the README"_ — it knows all providers, URL patterns, and query parameters.
-
-Learn more in the [skill docs](https://shieldcn.dev/docs/skill).
-
-## Self-Hosting
-
-Run your own badge engine with Docker:
-
-```bash
-git clone https://github.com/jal-co/shieldcn.git
-cd shieldcn
-docker compose -f packages/engine/docker-compose.yml up -d
-
-# Test it
-curl http://localhost:3000/badge/self--hosted-green.svg
-```
-
-Or pull the pre-built image:
-
-```bash
-docker pull ghcr.io/jal-co/shieldcn/engine:latest
-```
-
-See the [Self-Hosting Guide](https://shieldcn.dev/docs/self-hosting) for full setup details.
-
-## Local Development
-
-```bash
-pnpm install             # install all workspace deps
-pnpm dev:web             # start the web site
-pnpm dev:engine          # start the self-hosted engine
-pnpm build:web           # build the web site
-pnpm build:engine        # build the engine
-```
-
-The repo is a Turborepo monorepo with three packages:
-- `packages/core` — shared badge engine library
-- `packages/web` — marketing site (Vercel)
-- `packages/engine` — self-hosted Docker image
-
-
-## Token pool
-
-shieldcn uses a [token pool](https://shieldcn.dev/token-pool) (inspired by [shields.io](https://shields.io/blog/2024-11-14-how-shields-io-uses-the-github-api)) to distribute GitHub API requests across many tokens. You can help by authorizing the OAuth app — read-only, zero scopes, revocable anytime.
-
-## Credits
-
-- **[shields.io](https://shields.io)** — the original badge service. Inspiration for URL patterns, static badge format, and the token pool system.
-- **[badgen.net](https://badgen.net)** — inspiration for many badge types and endpoint structures, especially the GitHub badge coverage.
-- **[shadcn/ui](https://ui.shadcn.com)** — the design system these badges are built on.
-- **[Satori](https://github.com/vercel/satori)** — Vercel's JSX-to-SVG engine that makes rendering React components as badge images possible.
-- **[jal-co/ui](https://ui.justinlevine.me)** — the component library powering the docs site.
-- **[@k33bs](https://github.com/k33bs)** — creator of [shieldcngen](https://github.com/k33bs/shieldcngen), the badge generator tool powering the [`/gen`](https://shieldcn.dev/gen) page.
-
-## Contributing
-
-PRs welcome. See [AGENTS.md](./AGENTS.md) for architecture overview.
-
-To add shadcn components: `cd packages/web && pnpm dlx shadcn@latest add {component}`
-
-## License
-
-[MIT](./LICENSE)
+</div>

--- a/packages/web/components/studio/canvas.tsx
+++ b/packages/web/components/studio/canvas.tsx
@@ -34,10 +34,13 @@ import { IconTrending5 } from "@central-icons-react/round-filled-radius-3-stroke
 import { IconLayoutGrid2 } from "@central-icons-react/round-filled-radius-3-stroke-1.5/IconLayoutGrid2"
 import { IconAddImage } from "@central-icons-react/round-filled-radius-3-stroke-1.5/IconAddImage"
 import { IconPeople } from "@central-icons-react/round-filled-radius-3-stroke-1.5/IconPeople"
-import { IconAlignmentLeft } from "@central-icons-react/round-filled-radius-1-stroke-1.5/IconAlignmentLeft"
-import { IconAlignmentCenter } from "@central-icons-react/round-filled-radius-1-stroke-1.5/IconAlignmentCenter"
-import { IconAlignmentRight } from "@central-icons-react/round-filled-radius-1-stroke-1.5/IconAlignmentRight"
+import { IconAlignmentLeft } from "@central-icons-react/round-outlined-radius-3-stroke-1.5/IconAlignmentLeft"
+import { IconAlignmentCenter } from "@central-icons-react/round-outlined-radius-3-stroke-1.5/IconAlignmentCenter"
+import { IconAlignmentRight } from "@central-icons-react/round-outlined-radius-3-stroke-1.5/IconAlignmentRight"
+import { IconSquareDotedBehindSquare } from "@central-icons-react/round-outlined-radius-3-stroke-1.5/IconSquareDotedBehindSquare"
+import { IconTrashCan } from "@central-icons-react/round-outlined-radius-3-stroke-1.5/IconTrashCan"
 import { withBadgeMode } from "@/lib/use-badge-mode"
+import { Tray, Chamber, TrayButton } from "@/components/studio/toolbar-ui"
 import { cn } from "@/lib/utils"
 import {
   ContextMenu,
@@ -185,6 +188,7 @@ function ImageContent({ block, selected, onChange }: { block: ImageBlock; select
           ref={imgRef}
           src={block.src}
           alt={block.alt}
+          draggable={false}
           style={width ? { width } : undefined}
           className="block max-w-full rounded-md"
         />
@@ -232,9 +236,9 @@ function BlockContent({
       const mode = themeAware ? siteMode : block.state.mode
       const url = buildHeaderUrl({ ...block.state, mode }, "")
       return (
-        <div className="flex justify-center">
+        <div className={cn("flex", block.state.align === "left" ? "justify-start" : "justify-center")}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={url} alt={block.alt} className="max-w-full rounded-md" />
+          <img src={url} alt={block.alt} draggable={false} className="max-w-full rounded-md" />
         </div>
       )
     }
@@ -250,7 +254,7 @@ function BlockContent({
             const url = withBadgeMode(buildBadgeUrl({ ...b.state, mode }, ""), mode)
             return (
               // eslint-disable-next-line @next/next/no-img-element
-              <img key={b.id} src={url} alt={b.alt} className="max-w-full" />
+              <img key={b.id} src={url} alt={b.alt} draggable={false} className="max-w-full" />
             )
           })}
         </div>
@@ -280,7 +284,7 @@ function BlockContent({
       return (
         <div className={cn("flex", ALIGN_CLASS[block.align])}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={url} alt={block.alt} className="max-w-full rounded-md" />
+          <img src={url} alt={block.alt} draggable={false} className="max-w-full rounded-md" />
         </div>
       )
     }
@@ -293,7 +297,7 @@ function BlockContent({
       return (
         <div className={cn("flex", ALIGN_CLASS[block.align])}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={url} alt={block.alt} className="max-w-full rounded-md" />
+          <img src={url} alt={block.alt} draggable={false} className="max-w-full rounded-md" />
         </div>
       )
     }
@@ -305,7 +309,7 @@ function BlockContent({
       return (
         <div className={cn("flex", ALIGN_CLASS[block.align])}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={url} alt={block.alt} className="max-w-full rounded-md" />
+          <img src={url} alt={block.alt} draggable={false} className="max-w-full rounded-md" />
         </div>
       )
     }
@@ -321,31 +325,6 @@ function BlockContent({
 // (alignment + duplicate + delete). Heavier config stays in the right drawer.
 // ---------------------------------------------------------------------------
 
-function ToolbarBtn({ label, active, danger, onClick, children }: {
-  label: string
-  active?: boolean
-  danger?: boolean
-  onClick: () => void
-  children: React.ReactNode
-}) {
-  return (
-    <button
-      type="button"
-      aria-label={label}
-      title={label}
-      aria-pressed={active}
-      onClick={onClick}
-      className={cn(
-        "flex size-7 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground",
-        active && "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground",
-        danger && "hover:bg-destructive/10 hover:text-destructive",
-      )}
-    >
-      {children}
-    </button>
-  )
-}
-
 function BlockToolbar({ block, onChange, onDuplicate, onDelete }: {
   block: Block
   onChange: (b: Block) => void
@@ -359,18 +338,21 @@ function BlockToolbar({ block, onChange, onDuplicate, onDelete }: {
   return (
     <div
       onClick={e => e.stopPropagation()}
-      className="absolute right-1 top-0 z-30 flex -translate-y-[calc(100%+6px)] items-center gap-0.5 rounded-lg border border-border bg-popover p-1 shadow-md"
+      className="absolute right-1 top-0 z-30 -translate-y-[calc(100%+8px)]"
     >
-      {canAlign ? (
-        <>
-          <ToolbarBtn label="Align left" active={current === "left"} onClick={() => setAlign("left")}><IconAlignmentLeft size={14} /></ToolbarBtn>
-          <ToolbarBtn label="Align center" active={current === "center"} onClick={() => setAlign("center")}><IconAlignmentCenter size={14} /></ToolbarBtn>
-          <ToolbarBtn label="Align right" active={current === "right"} onClick={() => setAlign("right")}><IconAlignmentRight size={14} /></ToolbarBtn>
-          <span className="mx-0.5 h-5 w-px bg-border" />
-        </>
-      ) : null}
-      <ToolbarBtn label="Duplicate block" onClick={onDuplicate}><Copy className="size-3.5" /></ToolbarBtn>
-      <ToolbarBtn label="Delete block" danger onClick={onDelete}><Trash2 className="size-3.5" /></ToolbarBtn>
+      <Tray floating>
+        {canAlign ? (
+          <Chamber>
+            <TrayButton label="Align left" active={current === "left"} onClick={() => setAlign("left")}><IconAlignmentLeft size={15} /></TrayButton>
+            <TrayButton label="Align center" active={current === "center"} onClick={() => setAlign("center")}><IconAlignmentCenter size={15} /></TrayButton>
+            <TrayButton label="Align right" active={current === "right"} onClick={() => setAlign("right")}><IconAlignmentRight size={15} /></TrayButton>
+          </Chamber>
+        ) : null}
+        <Chamber>
+          <TrayButton label="Duplicate block" onClick={onDuplicate}><IconSquareDotedBehindSquare size={15} /></TrayButton>
+          <TrayButton label="Delete block" danger onClick={onDelete}><IconTrashCan size={15} /></TrayButton>
+        </Chamber>
+      </Tray>
     </div>
   )
 }
@@ -384,19 +366,21 @@ interface BlockFrameProps {
   isDragging: boolean
   /** Which edge to draw the insertion line on (null = not a drop target). */
   dropEdge: "top" | "bottom" | null
+  /** `move` reorders an existing block (blue); `add` inserts a new block (green + plus). */
+  dropVariant: "move" | "add"
   onSelect: () => void
   onDelete: () => void
   onDuplicate: () => void
   onInsertBelow: (type: BlockType) => void
   onChange: (b: Block) => void
   onDragStart: () => void
-  onDragEnter: () => void
+  onDragEnter: (edge: "top" | "bottom") => void
   onDrop: () => void
   onDragEnd: () => void
 }
 
 export const BlockFrame = memo(function BlockFrame({
-  block, index, selected, siteMode, themeAware, isDragging, dropEdge,
+  block, index, selected, siteMode, themeAware, isDragging, dropEdge, dropVariant,
   onSelect, onDelete, onDuplicate, onInsertBelow, onChange, onDragStart, onDragEnter, onDrop, onDragEnd,
 }: BlockFrameProps) {
   return (
@@ -414,10 +398,30 @@ export const BlockFrame = memo(function BlockFrame({
         if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onSelect() }
         else if (e.key === "Delete" || e.key === "Backspace") { e.preventDefault(); onDelete() }
       }}
-      onDragOver={e => { e.preventDefault(); e.dataTransfer.dropEffect = "move"; onDragEnter() }}
-      onDrop={e => { e.preventDefault(); onDrop() }}
+      draggable
+      onDragStart={e => {
+        // The whole block body is a drag handle — but never hijack a drag that
+        // starts on interactive content (the inline editor, inputs, links, the
+        // image resize handle, or the floating toolbar). preventDefault here
+        // also lets the contenteditable keep its own text selection.
+        const t = e.target as HTMLElement
+        if (t.closest('[contenteditable="true"], input, textarea, button, a, [role="slider"]')) {
+          e.preventDefault()
+          return
+        }
+        e.dataTransfer.effectAllowed = "move"
+        e.dataTransfer.setData("text/plain", String(index))
+        onDragStart()
+      }}
+      onDragEnd={onDragEnd}
+      onDragOver={e => {
+        e.preventDefault()
+        const rect = e.currentTarget.getBoundingClientRect()
+        onDragEnter(e.clientY < rect.top + rect.height / 2 ? "top" : "bottom")
+      }}
+      onDrop={e => { e.preventDefault(); e.stopPropagation(); onDrop() }}
       className={cn(
-        "group relative cursor-pointer rounded-lg border-2 border-transparent px-4 py-3 transition-colors",
+        "group relative cursor-grab rounded-lg border-2 border-transparent px-4 py-3 transition-colors active:cursor-grabbing",
         "hover:border-border/70 hover:bg-muted/30",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         selected && "border-primary bg-primary/[0.03] hover:border-primary",
@@ -426,24 +430,31 @@ export const BlockFrame = memo(function BlockFrame({
     >
       {/* Floating quick-action toolbar (alignment + duplicate + delete). */}
       {selected ? <BlockToolbar block={block} onChange={onChange} onDuplicate={onDuplicate} onDelete={onDelete} /> : null}
-      {/* Insertion line — shows exactly where the dragged block will land. */}
+      {/* Insertion line — shows where the dragged block lands. Blue = reorder an
+          existing block; green + plus = drop in a NEW block from the palette. */}
       {dropEdge ? (
         <div
           className={cn(
-            "pointer-events-none absolute inset-x-1 z-20 flex items-center",
+            "pointer-events-none absolute inset-x-1 z-20 flex items-center gap-1",
             dropEdge === "top" ? "-top-1" : "-bottom-1",
           )}
           aria-hidden
         >
-          <span className="size-2 shrink-0 rounded-full bg-primary ring-2 ring-background" />
-          <span className="h-0.5 flex-1 rounded-full bg-primary" />
-          <span className="size-2 shrink-0 rounded-full bg-primary ring-2 ring-background" />
+          {dropVariant === "add" ? (
+            <span className="flex size-4 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-white shadow-sm ring-2 ring-background">
+              <Plus className="size-3" />
+            </span>
+          ) : (
+            <span className="size-2 shrink-0 rounded-full bg-blue-500 ring-2 ring-background" />
+          )}
+          <span className={cn("h-0.5 flex-1 rounded-full", dropVariant === "add" ? "bg-emerald-500" : "bg-blue-500")} />
+          <span className={cn("size-2 shrink-0 rounded-full ring-2 ring-background", dropVariant === "add" ? "bg-emerald-500" : "bg-blue-500")} />
         </div>
       ) : null}
       {/* Drag handle (left gutter) — only this initiates a reorder drag. */}
       <div
         draggable
-        onDragStart={e => { e.dataTransfer.effectAllowed = "move"; e.dataTransfer.setData("text/plain", String(index)); onDragStart() }}
+        onDragStart={e => { e.stopPropagation(); e.dataTransfer.effectAllowed = "move"; e.dataTransfer.setData("text/plain", String(index)); onDragStart() }}
         onDragEnd={onDragEnd}
         onClick={e => e.stopPropagation()}
         title="Drag to reorder"

--- a/packages/web/components/studio/inspectors.tsx
+++ b/packages/web/components/studio/inspectors.tsx
@@ -209,11 +209,23 @@ function presetMatchesSearch(p: BadgePreset, search: string, serviceFilter: stri
 /** Reverse-match a badge path back to a preset index + param values. */
 function findPresetForPath(path: string): { preset: BadgePreset; idx: number; values: Record<string, string> } | null {
   const clean = path.replace(/\?.*$/, "")
+  // Escape every regex metacharacter in the literal chunks of a template. This
+  // matters for "Group" presets whose templates contain a literal "+" (the group
+  // segment joiner) — left unescaped, "+" becomes a quantifier and corrupts param
+  // extraction, which is what made the package/owner fields keep gaining a "+".
+  const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
   for (let idx = 0; idx < BADGE_PRESETS.length; idx++) {
     const preset = BADGE_PRESETS[idx]
     if (preset.customResolver === "static") continue
-    let pattern = preset.template.replace(/\./g, "\\.").replace(/\{([^}]+)\}/g, "([^/]+)")
-    pattern = `^${pattern}$`
+    const placeholder = /\{([^}]+)\}/g
+    let pattern = "^"
+    let lastIndex = 0
+    let m: RegExpExecArray | null
+    while ((m = placeholder.exec(preset.template)) !== null) {
+      pattern += escapeRe(preset.template.slice(lastIndex, m.index)) + "([^/]+)"
+      lastIndex = placeholder.lastIndex
+    }
+    pattern += escapeRe(preset.template.slice(lastIndex)) + "$"
     const match = clean.match(new RegExp(pattern))
     if (match) {
       const values: Record<string, string> = {}

--- a/packages/web/components/studio/studio.tsx
+++ b/packages/web/components/studio/studio.tsx
@@ -18,14 +18,22 @@
 
 import { useCallback, useEffect, useRef, useState } from "react"
 import {
-  Check, RotateCcw, Plus, Trash2, Copy as Duplicate,
-  ChevronUp, ChevronDown, Type, GripVertical, X,
+  Plus, Trash2, Copy as Duplicate,
+  ChevronUp, ChevronDown, Type, GripVertical, X, MoreHorizontal,
 } from "lucide-react"
-import { IconAppearanceDarkMode } from "@central-icons-react/round-filled-radius-1-stroke-1.5/IconAppearanceDarkMode"
-import { IconMarkdown } from "@central-icons-react/round-filled-radius-1-stroke-1.5/IconMarkdown"
-import { IconEyeOpen } from "@central-icons-react/round-filled-radius-1-stroke-1.5/IconEyeOpen"
-import { IconClipboard2 } from "@central-icons-react/round-filled-radius-1-stroke-1.5/IconClipboard2"
-import { IconFileDownload } from "@central-icons-react/round-filled-radius-1-stroke-1.5/IconFileDownload"
+import { motion, AnimatePresence, useReducedMotion, type Transition } from "motion/react"
+import { IconMarkdown } from "@central-icons-react/round-outlined-radius-3-stroke-1.5/IconMarkdown"
+import { IconEyeOpen } from "@central-icons-react/round-outlined-radius-3-stroke-1.5/IconEyeOpen"
+import { IconClipboard2 } from "@central-icons-react/round-outlined-radius-3-stroke-1.5/IconClipboard2"
+import { IconFileDownload } from "@central-icons-react/round-outlined-radius-3-stroke-1.5/IconFileDownload"
+import { IconArrowUndoUp } from "@central-icons-react/round-outlined-radius-3-stroke-1.5/IconArrowUndoUp"
+import { IconArrowRedoDown } from "@central-icons-react/round-outlined-radius-3-stroke-1.5/IconArrowRedoDown"
+import { IconArrowRotateCounterClockwise } from "@central-icons-react/round-outlined-radius-3-stroke-1.5/IconArrowRotateCounterClockwise"
+import { IconCheckmark1 } from "@central-icons-react/round-outlined-radius-3-stroke-1.5/IconCheckmark1"
+import { IconLayoutDashboard } from "@central-icons-react/round-outlined-radius-3-stroke-1.5/IconLayoutDashboard"
+import { IconFileArrowRightIn } from "@central-icons-react/round-outlined-radius-3-stroke-1.5/IconFileArrowRightIn"
+import { IconFileArrowRightOut } from "@central-icons-react/round-outlined-radius-3-stroke-1.5/IconFileArrowRightOut"
+import { IconTrashCan } from "@central-icons-react/round-outlined-radius-3-stroke-1.5/IconTrashCan"
 import { IconText1 } from "@central-icons-react/round-filled-radius-3-stroke-1.5/IconText1"
 import { IconImages1 } from "@central-icons-react/round-filled-radius-3-stroke-1.5/IconImages1"
 import { IconTag } from "@central-icons-react/round-filled-radius-3-stroke-1.5/IconTag"
@@ -38,10 +46,15 @@ import { useSyncExternalStore } from "react"
 import { useBadgeMode } from "@/lib/use-badge-mode"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import { Toggle } from "@/components/ui/toggle"
-import { Separator } from "@/components/ui/separator"
+
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { ButtonGroup } from "@/components/ui/button-group"
+import { Separator } from "@/components/ui/separator"
+import {
+  DropdownMenu, DropdownMenuTrigger, DropdownMenuContent,
+  DropdownMenuItem, DropdownMenuCheckboxItem, DropdownMenuSeparator, DropdownMenuLabel,
+} from "@/components/ui/dropdown-menu"
 import { cn } from "@/lib/utils"
 import { BlockFrame } from "@/components/studio/canvas"
 import {
@@ -121,10 +134,79 @@ function blockSummary(block: Block): string {
 }
 
 // ---------------------------------------------------------------------------
+// Toolbar primitives
+// ---------------------------------------------------------------------------
+
+/* ────────────────────────────────────────────
+ * COPY-CONFIRM MICRO-INTERACTION
+ *
+ *     0ms   click → clipboard write, state flips to "copied"
+ *     0ms   clipboard glyph exits (scale 1 → 0.5, fades out)
+ *   spring  checkmark enters (scale 0.5 → 1, slight overshoot)
+ *  2000ms   reverts to the clipboard glyph
+ * ──────────────────────────────────────────── */
+const ICON_SPRING: Transition = { type: "spring", visualDuration: 0.22, bounce: 0.42 }
+
+/* ────────────────────────────────────────────
+ * DELETE DROPZONE STORYBOARD
+ *
+ *     0ms   user starts dragging an existing block
+ *   spring  a dashed trash panel springs in from the right edge (x 120% → 0)
+ *    hover  dragging over it reddens the panel; the trash icon swells (1 → 1.15)
+ *     drop  the dragged block is removed (undoable), panel springs back out
+ *   cancel  drop elsewhere → panel springs back out (x 0 → 120%)
+ * ──────────────────────────────────────────── */
+const PANEL_SPRING: Transition = { type: "spring", visualDuration: 0.34, bounce: 0.26 }
+const PANEL_HIDDEN = { x: "100%", opacity: 0 } as const
+const PANEL_SHOWN = { x: 0, opacity: 1 } as const
+
+/* ────────────────────────────────────────────
+ * BLOCK POOF STORYBOARD
+ *   add     new block pops in (scale 0.96 → 1, fade)
+ *   delete  block poofs away (scale → 0.6, blur 4px, fade) while the rest of
+ *           the list springs up to close the gap (layout)
+ * ──────────────────────────────────────────── */
+const POOF_TRANSITION: Transition = { type: "spring", visualDuration: 0.26, bounce: 0.15 }
+const POOF_GONE = { opacity: 0, scale: 0.6, filter: "blur(4px)" } as const
+
+/** Slides in from the right while a block is dragged; dropping on it deletes. */
+function DeleteDropzone({ onDelete, reduceMotion }: { onDelete: () => void; reduceMotion: boolean }) {
+  const [over, setOver] = useState(false)
+  // Anchored at the inspector's left edge (md:right-80). z-30 sits BELOW the
+  // inspector (z-40) so the panel is occluded while tucked behind it, then
+  // slides left out from behind the bar. On mobile it slides from the edge.
+  return (
+    <div className="pointer-events-none fixed inset-y-0 right-0 z-30 flex items-center md:right-80">
+      <motion.div
+        initial={reduceMotion ? PANEL_SHOWN : PANEL_HIDDEN}
+        animate={PANEL_SHOWN}
+        exit={reduceMotion ? { opacity: 0 } : PANEL_HIDDEN}
+        transition={PANEL_SPRING}
+        onDragOver={e => { e.preventDefault(); e.dataTransfer.dropEffect = "move"; if (!over) setOver(true) }}
+        onDragLeave={() => setOver(false)}
+        onDrop={e => { e.preventDefault(); e.stopPropagation(); setOver(false); onDelete() }}
+        className={cn(
+          "pointer-events-auto flex h-44 w-32 flex-col items-center justify-center gap-2 rounded-l-2xl border-2 border-r-0 border-dashed text-center shadow-lg backdrop-blur-sm transition-colors",
+          over
+            ? "border-destructive bg-destructive/20 text-destructive"
+            : "border-destructive/40 bg-destructive/10 text-destructive/80",
+        )}
+      >
+        <motion.div animate={{ scale: over ? 1.15 : 1 }} transition={ICON_SPRING}>
+          <IconTrashCan size={28} />
+        </motion.div>
+        <span className="px-2 text-xs font-medium leading-tight">{over ? "Release to delete" : "Drag here to delete"}</span>
+      </motion.div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Studio
 // ---------------------------------------------------------------------------
 
 export function Studio() {
+  const reduceMotion = useReducedMotion()
   const { mode } = useBadgeMode()
   const [blocks, setBlocks] = useState<Block[]>([])
   const [selectedId, setSelectedId] = useState<string | null>(null)
@@ -144,8 +226,21 @@ export function Studio() {
   }, [])
   const [themeAware, setThemeAware] = useState(false)
   const [mobileInspectorOpen, setMobileInspectorOpen] = useState(false)
+  // Reorder drag source (existing block) and palette drag source (new block).
   const [dragFrom, setDragFrom] = useState<number | null>(null)
+  const [dragNewType, setDragNewType] = useState<BlockType | null>(null)
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null)
+  const [dragOverEdge, setDragOverEdge] = useState<"top" | "bottom" | null>(null)
+  // Undo/redo history. Snapshots are recorded from a blocks-change effect with a
+  // skip guard so programmatic undo/redo writes don't re-enter the stack. Rapid
+  // edits within 500ms coalesce into a single entry so typing isn't per-keystroke.
+  const historyRef = useRef<{ past: Block[][]; future: Block[][] }>({ past: [], future: [] })
+  const prevBlocksRef = useRef<Block[]>([])
+  const skipHistoryRef = useRef(false)
+  const lastPushRef = useRef(0)
+  const [canUndo, setCanUndo] = useState(false)
+  const [canRedo, setCanRedo] = useState(false)
+  const dragging = dragFrom !== null || dragNewType !== null
 
   const baseUrl = useSyncExternalStore(
     () => () => {},
@@ -179,6 +274,29 @@ export function Studio() {
     if (!hydrated) return
     try { localStorage.setItem(SETTINGS_KEY, JSON.stringify({ themeAware })) } catch { /* ignore quota */ }
   }, [themeAware, hydrated])
+
+  // Record history whenever `blocks` changes from a user edit (skip on undo/redo).
+  useEffect(() => {
+    if (!hydrated) return
+    if (skipHistoryRef.current) {
+      skipHistoryRef.current = false
+      prevBlocksRef.current = blocks
+      return
+    }
+    const prev = prevBlocksRef.current
+    if (prev !== blocks && prev.length > 0) {
+      const now = Date.now()
+      if (now - lastPushRef.current > 500) {
+        historyRef.current.past.push(prev)
+        if (historyRef.current.past.length > 200) historyRef.current.past.shift()
+        lastPushRef.current = now
+      }
+      historyRef.current.future = []
+      setCanUndo(historyRef.current.past.length > 0)
+      setCanRedo(false)
+    }
+    prevBlocksRef.current = blocks
+  }, [hydrated, blocks])
 
   const selected = blocks.find(b => b.id === selectedId) ?? null
   const selectedIndex = blocks.findIndex(b => b.id === selectedId)
@@ -254,10 +372,118 @@ export function Studio() {
     })
   }, [])
 
+  // Insert a brand-new block at an absolute index (used by palette drag-to-drop).
+  const addBlockAt = useCallback((type: BlockType, index: number) => {
+    const block = makeBlock(type)
+    setBlocks(prev => {
+      const copy = [...prev]
+      const at = Math.min(Math.max(index, 0), copy.length)
+      copy.splice(at, 0, block)
+      return copy
+    })
+    setSelectedId(block.id)
+    setMobileInspectorOpen(true)
+  }, [])
+
+  // Move an existing block to land *before* `insertIndex` (pre-removal index).
+  const moveBlockToIndex = useCallback((from: number, insertIndex: number) => {
+    setBlocks(prev => {
+      if (from < 0 || from >= prev.length) return prev
+      const copy = [...prev]
+      const [moved] = copy.splice(from, 1)
+      let target = from < insertIndex ? insertIndex - 1 : insertIndex
+      target = Math.min(Math.max(target, 0), copy.length)
+      copy.splice(target, 0, moved)
+      return copy
+    })
+  }, [])
+
+  // --- drag (reorder + palette drop) ---------------------------------------
+
+  const clearDrag = useCallback(() => {
+    setDragFrom(null)
+    setDragNewType(null)
+    setDragOverIndex(null)
+    setDragOverEdge(null)
+  }, [])
+
+  const handleCanvasDrop = useCallback((i: number) => {
+    const edge = dragOverEdge ?? "bottom"
+    const insertIndex = edge === "top" ? i : i + 1
+    if (dragNewType) addBlockAt(dragNewType, insertIndex)
+    else if (dragFrom !== null) moveBlockToIndex(dragFrom, insertIndex)
+    clearDrag()
+  }, [dragOverEdge, dragNewType, dragFrom, addBlockAt, moveBlockToIndex, clearDrag])
+
+  const handleAppendDrop = useCallback(() => {
+    if (dragNewType) addBlockAt(dragNewType, blocks.length)
+    else if (dragFrom !== null) moveBlockToIndex(dragFrom, blocks.length)
+    clearDrag()
+  }, [dragNewType, dragFrom, blocks.length, addBlockAt, moveBlockToIndex, clearDrag])
+
+  // Drop the dragged block onto the delete zone → remove it (undoable via ⌘Z).
+  const deleteDraggedBlock = useCallback(() => {
+    const id = dragFrom !== null ? blocks[dragFrom]?.id : undefined
+    if (id) removeBlock(id)
+    clearDrag()
+  }, [dragFrom, blocks, removeBlock, clearDrag])
+
+  // --- undo / redo ---------------------------------------------------------
+
+  const undo = useCallback(() => {
+    const h = historyRef.current
+    if (h.past.length === 0) return
+    const prev = h.past.pop()!
+    h.future.push(prevBlocksRef.current)
+    skipHistoryRef.current = true
+    setBlocks(prev)
+    setSelectedId(id => (prev.some(b => b.id === id) ? id : prev[0]?.id ?? null))
+    setCanUndo(h.past.length > 0)
+    setCanRedo(true)
+  }, [])
+
+  const redo = useCallback(() => {
+    const h = historyRef.current
+    if (h.future.length === 0) return
+    const next = h.future.pop()!
+    h.past.push(prevBlocksRef.current)
+    skipHistoryRef.current = true
+    setBlocks(next)
+    setSelectedId(id => (next.some(b => b.id === id) ? id : next[0]?.id ?? null))
+    setCanUndo(true)
+    setCanRedo(h.future.length > 0)
+  }, [])
+
+  // Keyboard shortcuts: ⌘/Ctrl+Z undo, ⌘/Ctrl+Shift+Z or ⌘/Ctrl+Y redo. Never
+  // hijack the browser's native undo while the user is typing in a field/editor.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey)) return
+      const key = e.key.toLowerCase()
+      if (key !== "z" && key !== "y") return
+      const t = e.target as HTMLElement | null
+      if (t && (t.isContentEditable || t.tagName === "INPUT" || t.tagName === "TEXTAREA" || t.closest('[contenteditable="true"]'))) return
+      if (key === "y" || (key === "z" && e.shiftKey)) { e.preventDefault(); redo() }
+      else { e.preventDefault(); undo() }
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [undo, redo])
+
+  // Clicking the empty canvas background (not a block) clears the selection.
+  const deselect = useCallback((e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) setSelectedId(null)
+  }, [])
+
   const reset = useCallback(() => {
     const fresh = makeStarterDocument()
+    historyRef.current = { past: [], future: [] }
+    lastPushRef.current = 0
+    skipHistoryRef.current = true
     setBlocks(fresh)
     setSelectedId(fresh[0]?.id ?? null)
+    setCanUndo(false)
+    setCanRedo(false)
   }, [])
 
   // --- export --------------------------------------------------------------
@@ -295,6 +521,24 @@ export function Studio() {
     URL.revokeObjectURL(url)
   }, [shownMarkdown])
 
+  // Import a README.md file → parse to blocks. Flows through setBlocks, so the
+  // import lands in the undo history and ⌘Z reverts it (no confirm needed).
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const onImportFile = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    e.target.value = "" // reset so the same file can be re-imported
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = () => {
+      const text = typeof reader.result === "string" ? reader.result : ""
+      const next = markdownToDocument(text, baseUrl)
+      if (next.length === 0) return
+      setBlocks(next)
+      setSelectedId(next[0]?.id ?? null)
+    }
+    reader.readAsText(file)
+  }, [baseUrl])
+
   if (!hydrated) {
     return <div className="flex h-[60vh] items-center justify-center text-sm text-muted-foreground">Loading studio…</div>
   }
@@ -322,15 +566,25 @@ export function Studio() {
   return (
     <TooltipProvider delayDuration={200}>
     <div className="flex h-full flex-col">
-      {/* Toolbar */}
-      <div className="flex items-center justify-between gap-2 border-b border-border bg-background px-4 py-2.5">
-        <div className="flex items-center gap-2 min-w-0">
-          <span className="text-sm font-semibold tracking-tight">README Studio</span>
-          <Badge variant="secondary" className="h-5 rounded-full px-2 text-[10px] font-medium uppercase tracking-wide">Beta</Badge>
-          <span className="hidden truncate text-xs text-muted-foreground sm:inline">· {blocks.length} blocks</span>
+      {/* Toolbar — three intentional zones: identity (left), mode switch
+          (absolutely centered on md+), and grouped actions (right). */}
+      <div className="relative flex items-center justify-between gap-2 border-b border-border bg-background px-3 py-2 sm:px-4">
+        {/* Zone 1 — identity + document state */}
+        <div className="flex min-w-0 items-center gap-2.5">
+          <div className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary ring-1 ring-inset ring-primary/20">
+            <IconLayoutDashboard size={16} />
+          </div>
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="truncate text-sm font-semibold tracking-tight">README Studio</span>
+            <Badge variant="secondary" className="h-5 rounded-full px-2 text-[10px] font-medium uppercase tracking-wide">Beta</Badge>
+            <span className="hidden text-xs text-muted-foreground xl:inline">{blocks.length} blocks</span>
+          </div>
         </div>
-        <div className="flex items-center gap-1.5">
-          <div className="hidden md:flex">
+
+        {/* Zone 2 — mode switch, optically centered, overlay so the side zones
+            don't pull it off-center. Pointer-events gated to the control. */}
+        <div className="pointer-events-none absolute inset-x-0 top-1/2 hidden -translate-y-1/2 justify-center md:flex">
+          <div className="pointer-events-auto">
             <Tabs value={view} onValueChange={v => {
               const next = v as "design" | "code"
               if (next === "code") setCodeDraft(markdown)
@@ -343,37 +597,106 @@ export function Studio() {
               </TabsList>
             </Tabs>
           </div>
-          <Separator orientation="vertical" className="mx-1 hidden h-5 md:block" />
-          <Tip label={themeAware ? "Adaptive light/dark is ON — badges, headers & charts export as <picture> and follow the reader's GitHub theme" : "Make the whole README adaptive — export badges, headers & charts as <picture> that follow the reader's light/dark theme"}>
-            <span className="inline-flex">
-              <Toggle
-                size="sm"
-                variant="outline"
-                pressed={themeAware}
-                onPressedChange={setThemeAware}
-                aria-label="Adaptive light and dark mode for the whole README"
-                className="h-8 gap-1.5 data-[state=on]:border-primary data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:hover:bg-primary/90"
+        </div>
+
+        {/* Zone 3 — three legible tiers: Edit · Export · More */}
+        <div className="flex items-center gap-2">
+          {/* EDIT — undo/redo are universal, so icon-only is legible */}
+          <ButtonGroup aria-label="Edit history">
+            <Tip label="Undo (⌘Z)">
+              <Button variant="outline" size="icon" className="size-8 text-muted-foreground hover:text-foreground disabled:opacity-40" disabled={!canUndo} onClick={undo} aria-label="Undo">
+                <IconArrowUndoUp size={15} />
+              </Button>
+            </Tip>
+            <Tip label="Redo (⇧⌘Z)">
+              <Button variant="outline" size="icon" className="size-8 text-muted-foreground hover:text-foreground disabled:opacity-40" disabled={!canRedo} onClick={redo} aria-label="Redo">
+                <IconArrowRedoDown size={15} />
+              </Button>
+            </Tip>
+          </ButtonGroup>
+
+          <Separator orientation="vertical" className="mx-0.5 hidden h-5 sm:block" />
+
+          {/* IMPORT — bring a README.md file in (the one 'in' action) */}
+          <Tip label="Open a README.md file into the studio">
+            <Button variant="outline" size="sm" className="h-8 gap-1.5" onClick={() => fileInputRef.current?.click()}>
+              <IconFileArrowRightIn size={15} /> <span className="hidden lg:inline">Import</span>
+            </Button>
+          </Tip>
+
+          {/* EXPORT — primary; menu offers clipboard + file. The button face
+              flashes a spring "Copied" after a clipboard copy (the menu closes,
+              so the confirmation lives on the trigger). */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button size="sm" className="h-8 gap-1.5 shadow-sm" aria-label="Export README">
+                <span className="relative grid size-3.5 place-items-center">
+                  <AnimatePresence mode="popLayout" initial={false}>
+                    {copied ? (
+                      <motion.span key="done" initial={reduceMotion ? false : { scale: 0.5, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={reduceMotion ? { opacity: 0 } : { scale: 0.5, opacity: 0 }} transition={ICON_SPRING} className="absolute inset-0 grid place-items-center">
+                        <IconCheckmark1 size={15} />
+                      </motion.span>
+                    ) : (
+                      <motion.span key="exp" initial={reduceMotion ? false : { scale: 0.5, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={reduceMotion ? { opacity: 0 } : { scale: 0.5, opacity: 0 }} transition={ICON_SPRING} className="absolute inset-0 grid place-items-center">
+                        <IconFileArrowRightOut size={15} />
+                      </motion.span>
+                    )}
+                  </AnimatePresence>
+                </span>
+                <span>{copied ? "Copied" : "Export"}</span>
+                <ChevronDown className="size-3.5 opacity-60" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-52">
+              <DropdownMenuItem onSelect={copyMarkdown}>
+                <IconClipboard2 size={15} /> Copy to clipboard
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={downloadMarkdown}>
+                <IconFileDownload size={15} /> Download .md
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          <Separator orientation="vertical" className="mx-0.5 hidden h-5 sm:block" />
+
+          {/* MORE — low-frequency settings & destructive action, labeled in a menu */}
+          <DropdownMenu>
+            <Tip label="More options">
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" className="size-8 text-muted-foreground hover:text-foreground" aria-label="More options">
+                  <MoreHorizontal className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+            </Tip>
+            <DropdownMenuContent align="end" className="w-64">
+              <DropdownMenuLabel>Export options</DropdownMenuLabel>
+              <DropdownMenuCheckboxItem
+                checked={themeAware}
+                onCheckedChange={setThemeAware}
+                onSelect={e => e.preventDefault()}
               >
-                <IconAppearanceDarkMode size={14} /> <span className="hidden lg:inline">Adaptive</span>
-              </Toggle>
-            </span>
-          </Tip>
-          <Tip label="Copy README Markdown">
-            <Button variant="outline" size="sm" className="h-8 gap-1.5" onClick={copyMarkdown}>
-              {copied ? <Check className="size-3.5" /> : <IconClipboard2 size={14} />}
-              <span className="hidden sm:inline">{copied ? "Copied" : "Copy"}</span>
-            </Button>
-          </Tip>
-          <Tip label="Download README.md">
-            <Button variant="outline" size="sm" className="h-8 gap-1.5" onClick={downloadMarkdown}>
-              <IconFileDownload size={14} /> <span className="hidden sm:inline">Download</span>
-            </Button>
-          </Tip>
-          <Tip label="Reset to the starter document">
-            <Button variant="ghost" size="sm" className="h-8 gap-1.5 text-muted-foreground" onClick={reset}>
-              <RotateCcw className="size-3.5" /> <span className="hidden lg:inline">Reset</span>
-            </Button>
-          </Tip>
+                <span className="flex flex-col">
+                  <span>Adaptive light &amp; dark</span>
+                  <span className="text-xs text-muted-foreground">Export badges, headers &amp; charts as &lt;picture&gt; that follows the reader&apos;s theme</span>
+                </span>
+              </DropdownMenuCheckboxItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem variant="destructive" onSelect={reset}>
+                <IconArrowRotateCounterClockwise size={15} /> Reset to the starter document
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          {/* Hidden file picker driving Import */}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".md,.markdown,text/markdown,text/plain"
+            className="hidden"
+            onChange={onImportFile}
+            aria-hidden="true"
+            tabIndex={-1}
+          />
         </div>
       </div>
 
@@ -387,7 +710,17 @@ export function Studio() {
               {(["markdown", "header", "badges", "group", "chart", "table", "image", "sponsors"] as BlockType[]).map(type => {
                 const Icon = BLOCK_ICONS[type]
                 return (
-                  <Button key={type} variant="outline" size="sm" className="h-auto flex-col gap-1 py-2.5 text-xs" onClick={() => addBlock(type)}>
+                  <Button
+                    key={type}
+                    variant="outline"
+                    size="sm"
+                    className="h-auto flex-col gap-1 py-2.5 text-xs"
+                    onClick={() => addBlock(type)}
+                    draggable
+                    onDragStart={e => { setDragNewType(type); e.dataTransfer.effectAllowed = "copy"; e.dataTransfer.setData("text/plain", type) }}
+                    onDragEnd={clearDrag}
+                    title="Click to add, or drag into the canvas"
+                  >
                     <Icon className="size-4" />
                     {BLOCK_LABELS[type]}
                   </Button>
@@ -435,13 +768,25 @@ export function Studio() {
         </aside>
 
         {/* Center — canvas / markdown */}
-        <main className="min-w-0 flex-1 overflow-y-auto bg-muted/40">
+        {/* Clicking the bare editor surface (the gutters around the README card)
+            deselects. The guard inside `deselect` (target === currentTarget)
+            keeps bubbled clicks from blocks, buttons, and the card from firing. */}
+        <main className="min-w-0 flex-1 overflow-y-auto bg-muted/40" onClick={deselect}>
           {/* Mobile add bar */}
           <div className="flex items-center gap-1.5 overflow-x-auto border-b border-border bg-background px-3 py-2 lg:hidden">
             {(["markdown", "header", "badges", "group", "chart", "table", "image", "sponsors"] as BlockType[]).map(type => {
               const Icon = BLOCK_ICONS[type]
               return (
-                <Button key={type} variant="outline" size="sm" className="h-8 shrink-0 gap-1.5 text-xs" onClick={() => addBlock(type)}>
+                <Button
+                  key={type}
+                  variant="outline"
+                  size="sm"
+                  className="h-8 shrink-0 gap-1.5 text-xs"
+                  onClick={() => addBlock(type)}
+                  draggable
+                  onDragStart={e => { setDragNewType(type); e.dataTransfer.effectAllowed = "copy"; e.dataTransfer.setData("text/plain", type) }}
+                  onDragEnd={clearDrag}
+                >
                   <Plus className="size-3" /> <Icon className="size-3.5" /> {BLOCK_LABELS[type]}
                 </Button>
               )
@@ -461,10 +806,19 @@ export function Studio() {
               />
             </div>
           ) : (
-            <div className="mx-auto max-w-3xl p-4 sm:p-6">
-              <div className="rounded-xl border border-border bg-background p-4 shadow-sm sm:p-6">
+            <div className="mx-auto max-w-3xl p-4 sm:p-6" onClick={deselect}>
+              <div
+                className="rounded-xl border border-border bg-background p-4 shadow-sm sm:p-6"
+                onClick={deselect}
+                onDragOver={e => { if (dragging) e.preventDefault() }}
+                onDrop={e => { e.preventDefault(); handleAppendDrop() }}
+              >
                 {blocks.length === 0 ? (
-                  <div className="flex flex-col items-center gap-4 px-6 py-16 text-center">
+                  <div
+                    className="flex flex-col items-center gap-4 px-6 py-16 text-center"
+                    onDragOver={e => { if (dragging) e.preventDefault() }}
+                    onDrop={e => { e.preventDefault(); if (dragNewType) addBlockAt(dragNewType, 0); clearDrag() }}
+                  >
                     <div className="flex size-12 items-center justify-center rounded-xl border border-border bg-muted/40 text-muted-foreground">
                       <Type className="size-5" />
                     </div>
@@ -476,7 +830,16 @@ export function Studio() {
                       {(["markdown", "header", "badges", "group", "chart", "table", "image", "sponsors"] as BlockType[]).map(type => {
                         const Icon = BLOCK_ICONS[type]
                         return (
-                          <Button key={type} variant="outline" size="sm" className="gap-1.5" onClick={() => addBlock(type)}>
+                          <Button
+                            key={type}
+                            variant="outline"
+                            size="sm"
+                            className="gap-1.5"
+                            onClick={() => addBlock(type)}
+                            draggable
+                            onDragStart={e => { setDragNewType(type); e.dataTransfer.effectAllowed = "copy"; e.dataTransfer.setData("text/plain", type) }}
+                            onDragEnd={clearDrag}
+                          >
                             <Icon className="size-3.5" /> {BLOCK_LABELS[type]}
                           </Button>
                         )
@@ -484,28 +847,39 @@ export function Studio() {
                     </div>
                   </div>
                 ) : (
-                  <div className="space-y-1">
-                    {blocks.map((block, i) => (
-                      <BlockFrame
-                        key={block.id}
-                        block={block}
-                        index={i}
-                        siteMode={mode}
-                        themeAware={themeAware}
-                        selected={block.id === selectedId}
-                        isDragging={dragFrom === i}
-                        dropEdge={dragOverIndex === i && dragFrom !== null && dragFrom !== i ? (dragFrom > i ? "top" : "bottom") : null}
-                        onSelect={() => selectBlock(block.id)}
-                        onDelete={() => removeBlock(block.id)}
-                        onDuplicate={() => duplicateBlock(block.id)}
-                        onInsertBelow={type => insertBlockAfter(block.id, type)}
-                        onChange={updateBlock}
-                        onDragStart={() => setDragFrom(i)}
-                        onDragEnter={() => { if (dragOverIndex !== i) setDragOverIndex(i) }}
-                        onDrop={() => { if (dragFrom !== null) moveBlock(dragFrom, i); setDragFrom(null); setDragOverIndex(null) }}
-                        onDragEnd={() => { setDragFrom(null); setDragOverIndex(null) }}
-                      />
-                    ))}
+                  <div className="space-y-1" onClick={deselect}>
+                    <AnimatePresence mode="popLayout" initial={false}>
+                      {blocks.map((block, i) => (
+                        <motion.div
+                          key={block.id}
+                          layout
+                          initial={reduceMotion ? false : { opacity: 0, scale: 0.96 }}
+                          animate={{ opacity: 1, scale: 1, filter: "blur(0px)" }}
+                          exit={reduceMotion ? { opacity: 0 } : POOF_GONE}
+                          transition={POOF_TRANSITION}
+                        >
+                          <BlockFrame
+                            block={block}
+                            index={i}
+                            siteMode={mode}
+                            themeAware={themeAware}
+                            selected={block.id === selectedId}
+                            isDragging={dragFrom === i}
+                            dropEdge={dragOverIndex === i && dragging && dragFrom !== i ? dragOverEdge : null}
+                            dropVariant={dragNewType ? "add" : "move"}
+                            onSelect={() => selectBlock(block.id)}
+                            onDelete={() => removeBlock(block.id)}
+                            onDuplicate={() => duplicateBlock(block.id)}
+                            onInsertBelow={type => insertBlockAfter(block.id, type)}
+                            onChange={updateBlock}
+                            onDragStart={() => setDragFrom(i)}
+                            onDragEnter={edge => { setDragOverIndex(i); setDragOverEdge(edge) }}
+                            onDrop={() => handleCanvasDrop(i)}
+                            onDragEnd={clearDrag}
+                          />
+                        </motion.div>
+                      ))}
+                    </AnimatePresence>
                   </div>
                 )}
               </div>
@@ -514,7 +888,7 @@ export function Studio() {
         </main>
 
         {/* Right — inspector */}
-        <aside className="hidden w-80 shrink-0 flex-col border-l border-border bg-background md:flex">
+        <aside className="relative z-40 hidden w-80 shrink-0 flex-col border-l border-border bg-background md:flex">
           <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
             <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
               {selected ? `${BLOCK_LABELS[selected.type]} settings` : "Inspector"}
@@ -532,6 +906,14 @@ export function Studio() {
           </div>
         </aside>
       </div>
+
+      {/* Delete dropzone — slides in from the right while reordering an existing
+          block; drop on it to remove the block. Hidden when adding a new block. */}
+      <AnimatePresence>
+        {dragFrom !== null ? (
+          <DeleteDropzone onDelete={deleteDraggedBlock} reduceMotion={!!reduceMotion} />
+        ) : null}
+      </AnimatePresence>
 
       {/* Mobile inspector — bottom sheet (below md, where the side panel is hidden) */}
       {mobileInspectorOpen && selected ? (

--- a/packages/web/components/studio/toolbar-ui.tsx
+++ b/packages/web/components/studio/toolbar-ui.tsx
@@ -1,0 +1,96 @@
+/**
+ * shieldcn
+ * components/studio/toolbar-ui
+ *
+ * Shared "chambered tray" toolbar language used by both the top README Studio
+ * toolbar and the floating per-block toolbar, so they read as one system.
+ *
+ * Anatomy (mirrors a physical tray holding chips):
+ *   Tray     — the layered outer container (lighter fill + inset ring + depth)
+ *   Chamber  — a recessed darker compartment grouping tightly-related buttons
+ *   TrayButton — a uniform ghost icon button with crisp active / danger states
+ *
+ * Two-tone depth: the Tray sits a step lighter than its Chambers, which sit a
+ * step darker than the surface — the recess reads as inset. Active buttons pop
+ * back up as a lighter (or primary-tinted) chip with a hairline ring.
+ */
+
+"use client"
+
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+/** The outer tray. `floating` styles it for an elevated contextual popover. */
+export function Tray({
+  className, floating, ...props
+}: React.ComponentProps<"div"> & { floating?: boolean }) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-1 rounded-xl p-1",
+        floating
+          ? "bg-popover/95 shadow-lg ring-1 ring-border backdrop-blur-sm"
+          : "bg-muted/50 shadow-sm ring-1 ring-inset ring-border/60",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+/** A recessed compartment grouping tightly-related buttons inside a Tray. */
+export function Chamber({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-0.5 rounded-lg bg-background/60 p-0.5 ring-1 ring-inset ring-border/40",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+/** A uniform icon button for trays. Tooltip + disabled handled internally. */
+export function TrayButton({
+  label, onClick, active, danger, disabled, tone = "neutral", className, children,
+}: {
+  label: string
+  onClick: () => void
+  active?: boolean
+  danger?: boolean
+  disabled?: boolean
+  /** `primary` tints the active state with the brand color (e.g. a mode that
+      changes output); `neutral` uses a quiet lighter chip (e.g. alignment). */
+  tone?: "neutral" | "primary"
+  className?: string
+  children: React.ReactNode
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex">
+          <Button
+            variant="ghost"
+            size="icon"
+            disabled={disabled}
+            onClick={onClick}
+            aria-label={label}
+            aria-pressed={active}
+            className={cn(
+              "size-7 rounded-md text-muted-foreground transition-colors hover:text-foreground disabled:opacity-40",
+              active && tone === "primary" && "bg-primary/15 text-primary shadow-sm ring-1 ring-inset ring-primary/30 hover:text-primary",
+              active && tone === "neutral" && "bg-foreground/10 text-foreground shadow-sm ring-1 ring-inset ring-border/50",
+              danger && "hover:bg-destructive/10 hover:text-destructive",
+              className,
+            )}
+          >
+            {children}
+          </Button>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  )
+}

--- a/packages/web/components/ui/button-group.tsx
+++ b/packages/web/components/ui/button-group.tsx
@@ -1,0 +1,83 @@
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Separator } from "@/components/ui/separator"
+
+const buttonGroupVariants = cva(
+  "flex w-fit items-stretch has-[>[data-slot=button-group]]:gap-2 [&>*]:focus-visible:relative [&>*]:focus-visible:z-10 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
+  {
+    variants: {
+      orientation: {
+        horizontal:
+          "[&>*:not(:first-child)]:rounded-l-none [&>*:not(:first-child)]:border-l-0 [&>*:not(:last-child)]:rounded-r-none",
+        vertical:
+          "flex-col [&>*:not(:first-child)]:rounded-t-none [&>*:not(:first-child)]:border-t-0 [&>*:not(:last-child)]:rounded-b-none",
+      },
+    },
+    defaultVariants: {
+      orientation: "horizontal",
+    },
+  }
+)
+
+function ButtonGroup({
+  className,
+  orientation,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof buttonGroupVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="button-group"
+      data-orientation={orientation}
+      className={cn(buttonGroupVariants({ orientation }), className)}
+      {...props}
+    />
+  )
+}
+
+function ButtonGroupText({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> & {
+  asChild?: boolean
+}) {
+  const Comp = asChild ? Slot.Root : "div"
+
+  return (
+    <Comp
+      className={cn(
+        "flex items-center gap-2 rounded-md border bg-muted px-4 text-sm font-medium shadow-xs [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ButtonGroupSeparator({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="button-group-separator"
+      orientation={orientation}
+      className={cn(
+        "relative m-0! self-stretch bg-input data-[orientation=vertical]:h-auto",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  ButtonGroup,
+  ButtonGroupSeparator,
+  ButtonGroupText,
+  buttonGroupVariants,
+}

--- a/packages/web/components/ui/dropdown-menu.tsx
+++ b/packages/web/components/ui/dropdown-menu.tsx
@@ -1,0 +1,257 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  )
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[inset]:pl-8 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/packages/web/lib/badge-builder-shared.ts
+++ b/packages/web/lib/badge-builder-shared.ts
@@ -92,7 +92,8 @@ export function resolveDefaultLinkUrl(preset: BadgePreset, values: Record<string
   let url = preset.defaultLinkUrl
   for (const param of preset.params) {
     const val = values[param.key] || param.default
-    url = url.replace(`{${param.key}}`, val)
+    // split/join replaces *every* occurrence (templates can repeat a param).
+    url = url.split(`{${param.key}}`).join(val)
   }
   return url
 }
@@ -116,7 +117,8 @@ export function resolveTemplate(preset: BadgePreset, values: Record<string, stri
   let path = preset.template
   for (const param of preset.params) {
     const val = values[param.key] || param.default
-    path = path.replace(`{${param.key}}`, val)
+    // split/join replaces *every* occurrence (group templates repeat params).
+    path = path.split(`{${param.key}}`).join(val)
   }
   return path
 }

--- a/packages/web/lib/studio-shared.ts
+++ b/packages/web/lib/studio-shared.ts
@@ -498,15 +498,18 @@ export function blockToMarkdown(block: Block, baseUrl: string, themeAware = fals
     }
 
     case "header": {
+      // The banner's text alignment also drives the page-level wrapper so the
+      // exported <p align> follows the chosen alignment instead of always
+      // centering. (Header state only supports "left" | "center".)
+      const wrapAlign = block.state.align === "left" ? "left" : "center"
       if (adaptive) {
         const dark = buildHeaderUrl({ ...block.state, mode: "dark" }, baseUrl)
         const light = buildHeaderUrl({ ...block.state, mode: "light" }, baseUrl)
-        return `<p align="center">\n  ${picture(dark, light, block.alt)}\n</p>`
+        return `<p align="${wrapAlign}">\n  ${picture(dark, light, block.alt)}\n</p>`
       }
       const url = buildHeaderUrl(block.state, baseUrl)
       const img = `<img alt="${escapeAttr(block.alt)}" src="${escapeAttr(url)}" />`
-      // Headers are full-width banners — center them.
-      return `<p align="center">\n  ${img}\n</p>`
+      return `<p align="${wrapAlign}">\n  ${img}\n</p>`
     }
 
     case "badges": {


### PR DESCRIPTION
## What

A focused overhaul of the **README Studio** editor, plus a new project `README.md`.

**Studio editor**
- Toolbar restructured into three legible tiers — **Edit** (undo/redo) · **Export** (a single `Export ▾` dropdown for Copy / Download) · **More** (Adaptive + Reset) — using one uniform outlined Central Icons family.
- **Undo/redo** with a history stack + keyboard shortcuts (⌘Z / ⇧⌘Z).
- **Drag-to-add** blocks from the palette, **drag-to-reorder** from a block body, and **click-outside-to-deselect**.
- A chambered **floating per-block toolbar**, a slide-in **delete dropzone** (emerges from behind the inspector), and a **poof** delete animation.
- Insertion lines are now color-coded: **blue** = reorder, **green + plus** = add new.
- New **Import** action (open a local `.md` into the editor) alongside Download/Copy.

**Fixes**
- Badge **group preset editing**: `findPresetForPath` now escapes regex metacharacters (a literal `+` in group templates was acting as a quantifier and made the package/owner fields keep gaining a `+`), and `resolveTemplate`/`resolveDefaultLinkUrl` now replace *every* placeholder occurrence (repeated-param templates like the GitHub trio).
- Header banner `<p align>` now follows the in-banner text alignment.

**Docs**
- New minimal, theme-aware `README.md` (badge group, partner badges, star chart, sponsors), built in the Studio.

## Why

Editing in the Studio was hard to read and easy to misclick, and the badge-group fields were unusable (the runaway `+`). This makes the editor legible and direct, and ships a README that doubles as a live showcase.

Closes # N/A

## Type

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `docs` — Documentation
- [ ] `refactor` — Code restructuring
- [ ] `perf` — Performance improvement
- [ ] `style` — Visual / CSS changes
- [ ] `chore` — Maintenance / deps
- [ ] `ci` — CI/CD changes
- [ ] `test` — Tests

> Primarily `feat`; also bundles a badge-group `fix` and a new `docs` README.

## Checklist

- [x] Branch follows conventional naming (`feat/`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tested locally with `pnpm dev`
- [x] README image endpoints (header, group, badges, chart, sponsors) verified `200`
- [ ] Docs updated (no provider/query-param changes)

## Screenshots

Visual changes are in the Studio toolbar + canvas. Adds shadcn `button-group` and `dropdown-menu`. (Toolbar: Edit ┊ Import · Export ▾ ┊ ⋯; verified via live capture during development.)