### PR TITLE
feat(contributors): add contributors image, generator, docs, and Studio block

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Drop a badge into any README and it renders as a real shadcn Button.
   <picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/sponsors/jal-co.svg?title=false&amp;preset=transparent&amp;size=80&amp;names=false&amp;special=usenotra&amp;separator=line&amp;mode=dark&amp;border=false" /><img alt="sponsors" src="https://shieldcn.dev/sponsors/jal-co.svg?title=false&amp;preset=transparent&amp;size=80&amp;names=true&amp;special=usenotra&amp;separator=line&amp;mode=light&amp;border=false" /></picture>
 </p>
 
+## Contributors
+
+<p align="center">
+  <a href="https://github.com/jal-co/shieldcn/graphs/contributors"><picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/contributors/jal-co/shieldcn.svg?title=false&amp;preset=transparent&amp;border=false&amp;mode=dark" /><img alt="contributors" src="https://shieldcn.dev/contributors/jal-co/shieldcn.svg?title=false&amp;preset=transparent&amp;border=false&amp;mode=light" /></picture></a>
+</p>
+
 <div align="center">
 
 [MIT](https://github.com/jal-co/shieldcn/blob/main/LICENSE) · Built by [Justin Levine](https://justinlevine.me) · [Contribute](https://github.com/jal-co/shieldcn)

--- a/packages/core/src/badges/contributors-route.test.ts
+++ b/packages/core/src/badges/contributors-route.test.ts
@@ -10,6 +10,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { handleBadgeGET } from "../route-handler"
+import { getGitHubContributorsList } from "../providers/github"
 
 // A 1x1 transparent PNG (smallest valid raster the inliner will accept).
 const PNG_1x1 = Buffer.from(
@@ -157,5 +158,34 @@ describe("handleBadgeGET /contributors", () => {
       ["contributors", "onlyowner.json"],
     )
     expect(res.status).toBe(400)
+  })
+})
+
+describe("getGitHubContributorsList — transient-failure handling", () => {
+  it("returns null (not an empty list) when page 1 body fails to parse", async () => {
+    // The repo resolves, the contributors fetch is HTTP 200, but the body is a
+    // truncated/malformed payload whose .json() throws. This must surface as a
+    // miss (null) so the route serves last-known-good, never an empty card.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (/^https:\/\/api\.github\.com\/repos\/[^/]+\/[^/?]+$/.test(url)) {
+          return new Response(JSON.stringify({ full_name: "acme/widgets" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          })
+        }
+        if (url.includes("/contributors?")) {
+          // Valid HTTP response, invalid JSON body → r.json() rejects.
+          return new Response("<<not json>>", {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          })
+        }
+        return new Response("not found", { status: 404 })
+      }),
+    )
+    const list = await getGitHubContributorsList("acme", "widgets")
+    expect(list).toBeNull()
   })
 })

--- a/packages/core/src/badges/contributors-route.test.ts
+++ b/packages/core/src/badges/contributors-route.test.ts
@@ -1,0 +1,161 @@
+/**
+ * shieldcn
+ * src/badges/contributors-route.test
+ *
+ * End-to-end: handleBadgeGET routes /contributors/{owner}/{repo} through the
+ * GitHub REST contributors provider (mocked) and renders the avatar-grid SVG.
+ * Avatar images are fetched and inlined as base64 data URIs (mocked, no
+ * network).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { handleBadgeGET } from "../route-handler"
+
+// A 1x1 transparent PNG (smallest valid raster the inliner will accept).
+const PNG_1x1 = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+  "base64",
+)
+
+function contributorNode(i: number, contributions: number, type = "User", login = `dev${i}`) {
+  return {
+    login,
+    avatar_url: `https://avatars.githubusercontent.com/u/${i}?v=4`,
+    html_url: `https://github.com/${login}`,
+    contributions,
+    type,
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string) => {
+      // repoData / resolveRepo — the canonical owner/repo lookup.
+      const repoMatch = url.match(/^https:\/\/api\.github\.com\/repos\/([^/]+)\/([^/?]+)$/)
+      if (repoMatch) {
+        const [, owner, repo] = repoMatch
+        if (owner === "missing") return new Response("not found", { status: 404 })
+        return new Response(JSON.stringify({ full_name: `${owner}/${repo}` }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      }
+      // Contributors list.
+      if (url.includes("/contributors?")) {
+        if (url.includes("/empty/")) {
+          return new Response(JSON.stringify([]), { status: 200, headers: { "content-type": "application/json" } })
+        }
+        return new Response(
+          JSON.stringify([
+            contributorNode(1, 500),
+            contributorNode(2, 300),
+            contributorNode(3, 100),
+            // A bot — excluded by default, included with ?bots=true.
+            contributorNode(4, 250, "Bot", "renovate[bot]"),
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } },
+        )
+      }
+      if (url.startsWith("https://avatars.githubusercontent.com/")) {
+        return new Response(PNG_1x1, { status: 200, headers: { "content-type": "image/png" } })
+      }
+      return new Response("not found", { status: 404 })
+    }),
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe("handleBadgeGET /contributors", () => {
+  it("returns contributor data as JSON, ordered by contributions, bots excluded", async () => {
+    const res = await handleBadgeGET(
+      new Request("https://x.dev/contributors/acme/widgets.json"),
+      ["contributors", "acme", "widgets.json"],
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      type: string
+      owner: string
+      repo: string
+      contributors: { login: string; contributions: number }[]
+    }
+    expect(body.type).toBe("contributors")
+    expect(body.owner).toBe("acme")
+    expect(body.repo).toBe("widgets")
+    // dev1, dev2, dev3 — the [bot] account is filtered out by default.
+    expect(body.contributors.map((c) => c.login)).toEqual(["dev1", "dev2", "dev3"])
+  })
+
+  it("includes bots with ?bots=true", async () => {
+    const res = await handleBadgeGET(
+      new Request("https://x.dev/contributors/acme/bots.json?bots=true"),
+      ["contributors", "acme", "bots.json"],
+    )
+    const body = (await res.json()) as { contributors: { login: string }[] }
+    expect(body.contributors.map((c) => c.login)).toContain("renovate[bot]")
+  })
+
+  it("filters by minimum contributions with ?min=", async () => {
+    const res = await handleBadgeGET(
+      new Request("https://x.dev/contributors/acme/min.json?min=200"),
+      ["contributors", "acme", "min.json"],
+    )
+    const body = (await res.json()) as { contributors: { login: string }[] }
+    // dev3 (100) drops out; dev1 (500) and dev2 (300) remain.
+    expect(body.contributors.map((c) => c.login)).toEqual(["dev1", "dev2"])
+  })
+
+  it("renders an SVG grid with inlined avatar images, each linked", async () => {
+    const res = await handleBadgeGET(
+      new Request("https://x.dev/contributors/acme/svg.svg"),
+      ["contributors", "acme", "svg.svg"],
+    )
+    expect(res.status).toBe(200)
+    expect(res.headers.get("Content-Type")).toBe("image/svg+xml")
+    const svg = await res.text()
+    expect(svg.startsWith("<svg")).toBe(true)
+    expect(svg).toContain("data:image/png;base64,")
+    expect(svg).not.toContain("https://avatars.githubusercontent.com/")
+    // Default title shown + a labelled aria-label.
+    expect(svg).toContain("Contributors")
+    expect(svg).toContain('aria-label="Contributors — GitHub contributors"')
+    // One <a> wrapper per rendered avatar (3 non-bot contributors).
+    expect((svg.match(/<a href=/g) || []).length).toBe(3)
+  })
+
+  it("renders a card-shaped fallback (not a red badge pill) for a missing repo", async () => {
+    const res = await handleBadgeGET(
+      new Request("https://x.dev/contributors/missing/repo.svg"),
+      ["contributors", "missing", "repo.svg"],
+    )
+    expect(res.headers.get("Content-Type")).toBe("image/svg+xml")
+    const svg = await res.text()
+    expect(svg.startsWith("<svg")).toBe(true)
+    expect(svg.toLowerCase()).not.toContain("#dc2626")
+    expect(svg).toContain("No contributors to show")
+    expect(svg).not.toContain("data:image/png")
+  })
+
+  it("renders an empty-state message when the repo has no contributors", async () => {
+    const res = await handleBadgeGET(
+      new Request("https://x.dev/contributors/acme/empty.svg"),
+      ["contributors", "acme", "empty.svg"],
+    )
+    expect(res.status).toBe(200)
+    const svg = await res.text()
+    expect(svg).toContain("No contributors")
+    expect(svg).not.toContain("<a href=")
+  })
+
+  it("returns 400 JSON when owner/repo is missing", async () => {
+    const res = await handleBadgeGET(
+      new Request("https://x.dev/contributors/onlyowner.json"),
+      ["contributors", "onlyowner.json"],
+    )
+    expect(res.status).toBe(400)
+  })
+})

--- a/packages/core/src/badges/render-sponsors.ts
+++ b/packages/core/src/badges/render-sponsors.ts
@@ -64,6 +64,8 @@ export interface SponsorsConfig {
   separatorColor?: string | null
   /** Message shown when there are no public sponsors. */
   emptyText?: string
+  /** Override the SVG `aria-label` (defaults to a sponsors-oriented label). */
+  ariaLabel?: string
 
   // --- Background (same premade system as headers) ---
   /** Named preset: surface | gradient | dots | grid | graph | glow | transparent. */
@@ -336,7 +338,9 @@ export function renderSponsors(cfg: SponsorsConfig): { svg: string; height: numb
       `</g>`
   }
 
-  const ariaLabel = esc(cfg.title ? `${cfg.title} — GitHub sponsors` : "GitHub sponsors")
+  const ariaLabel = esc(
+    cfg.ariaLabel ?? (cfg.title ? `${cfg.title} — GitHub sponsors` : "GitHub sponsors"),
+  )
   const cardClipId = "scCardClip"
 
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-label="${ariaLabel}">

--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -365,6 +365,86 @@ export async function getGitHubContributors(owner: string, repo: string): Promis
   return { label: "contributors", value: formatCount(count), link: link(owner, repo, "/graphs/contributors") }
 }
 
+export interface ContributorEntry {
+  login: string
+  /** GitHub-hosted avatar URL. */
+  avatarUrl: string
+  url: string
+  /** Number of contributions (commits) attributed to this account. */
+  contributions: number
+  /** "User" | "Bot" | "Anonymous". Bots are filtered out by default. */
+  type: "User" | "Bot" | "Anonymous"
+}
+
+/** Resolved contributor list for a repository, ordered by contributions desc. */
+export interface ContributorsList {
+  contributors: ContributorEntry[]
+}
+
+interface RawContributorNode {
+  login?: unknown
+  avatar_url?: unknown
+  html_url?: unknown
+  contributions?: unknown
+  type?: unknown
+}
+
+/**
+ * Fetch a repository's top contributors via the REST API, ordered by
+ * contributions (descending — GitHub's default order). Paginates up to
+ * {@link CONTRIBUTORS_PAGE_CAP} pages of 100 so very large repos stay bounded.
+ * Returns null on any failure so the route serves last-known-good instead of an
+ * error image. Bots are tagged via `type` and filtered downstream.
+ */
+const CONTRIBUTORS_PAGE_CAP = 3
+
+export async function getGitHubContributorsList(
+  owner: string,
+  repo: string,
+  max = 100,
+): Promise<ContributorsList | null> {
+  const resolved = await resolveRepo(owner, repo)
+  if (!resolved) return null
+  const contributors: ContributorEntry[] = []
+  let resolvedAny = false
+
+  for (let page = 1; page <= CONTRIBUTORS_PAGE_CAP; page++) {
+    const url = `https://api.github.com/repos/${encodeURIComponent(resolved.owner)}/${encodeURIComponent(resolved.repo)}/contributors?per_page=100&page=${page}`
+    const r = await githubFetch(url, 3600)
+    if (!r) {
+      // Transient failure mid-pagination: keep what we have, else miss.
+      if (!resolvedAny) return null
+      break
+    }
+    resolvedAny = true
+    let nodes: RawContributorNode[]
+    try {
+      const json = await r.json()
+      nodes = Array.isArray(json) ? (json as RawContributorNode[]) : []
+    } catch {
+      if (!resolvedAny) return null
+      break
+    }
+    for (const n of nodes) {
+      if (typeof n?.login !== "string" || typeof n?.avatar_url !== "string") continue
+      const rawType = typeof n.type === "string" ? n.type : "User"
+      const isBot = rawType === "Bot" || /\[bot\]$/i.test(n.login)
+      contributors.push({
+        login: n.login,
+        avatarUrl: n.avatar_url,
+        url: typeof n.html_url === "string" ? n.html_url : `https://github.com/${n.login}`,
+        contributions: typeof n.contributions === "number" ? n.contributions : 0,
+        type: isBot ? "Bot" : rawType === "Anonymous" ? "Anonymous" : "User",
+      })
+    }
+    if (nodes.length < 100) break
+    if (contributors.length >= max) break
+  }
+
+  if (!resolvedAny) return null
+  return { contributors }
+}
+
 // ---------------------------------------------------------------------------
 // CI / Checks
 // ---------------------------------------------------------------------------

--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -416,15 +416,20 @@ export async function getGitHubContributorsList(
       if (!resolvedAny) return null
       break
     }
-    resolvedAny = true
     let nodes: RawContributorNode[]
     try {
       const json = await r.json()
       nodes = Array.isArray(json) ? (json as RawContributorNode[]) : []
     } catch {
+      // A truncated/malformed body is a transient failure. On the first page
+      // (no good data yet) surface a miss so the route serves last-known-good;
+      // mid-pagination, keep the pages we already parsed.
       if (!resolvedAny) return null
       break
     }
+    // Only mark success once a page has actually parsed — otherwise a parse
+    // failure on page 1 would wrongly return an empty list instead of null.
+    resolvedAny = true
     for (const n of nodes) {
       if (typeof n?.login !== "string" || typeof n?.avatar_url !== "string") continue
       const rawType = typeof n.type === "string" ? n.type : "User"

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -117,6 +117,7 @@ import {
   getGitHubSponsors,
   getGitHubSponsorsList,
   getGitHubFeaturedSponsors,
+  getGitHubContributorsList,
   type SponsorEntry,
   githubRepoExists,
 } from "./providers/github"
@@ -2223,7 +2224,7 @@ async function inlineAvatar(rawUrl: string): Promise<string | undefined> {
 }
 
 /** Inline a batch of avatars with bounded concurrency. */
-async function inlineAvatars(entries: SponsorEntry[]): Promise<Map<string, string>> {
+async function inlineAvatars(entries: { login: string; avatarUrl: string }[]): Promise<Map<string, string>> {
   const out = new Map<string, string>()
   const CONCURRENCY = 8
   for (let i = 0; i < entries.length; i += CONCURRENCY) {
@@ -2249,6 +2250,183 @@ function parseLoginList(raw: string | null): string[] {
     }
   }
   return out
+}
+
+// ---------------------------------------------------------------------------
+// Contributors image (/contributors/{owner}/{repo}.svg) — a contrib.rocks-style
+// grid of a repository's top contributors' avatars. Reuses the sponsors grid
+// renderer (a single tier) and the same background/customization system.
+// ---------------------------------------------------------------------------
+
+/** Hard cap on how many contributor avatars a single image will inline. */
+const CONTRIBUTORS_RENDER_CAP = 100
+const CONTRIBUTORS_FRESH_TTL = 60 * 60 // 1 hour fresh copy
+const CONTRIBUTORS_STALE_TTL = 60 * 60 * 24 * 7 // 7 day last-known-good fallback
+
+async function handleContributors(
+  cleanSegments: string[],
+  searchParams: URLSearchParams,
+  format: Format,
+  options?: BadgeRequestOptions,
+): Promise<Response> {
+  const rest = cleanSegments.slice(1) // after "contributors"
+  const owner = (rest[0] ?? "").trim().replace(/^@/, "")
+  const repo = (rest[1] ?? "").trim()
+
+  const mode = (searchParams.get("mode") === "light" ? "light" : "dark") as "light" | "dark"
+  const width = clampNum(searchParams.get("width"), 320, 2000, 800)
+  const radius = clampNum(searchParams.get("radius"), 0, 80, 12)
+  const baseSize = clampNum(searchParams.get("size"), 24, 140, 64)
+  const limit = clampNum(searchParams.get("limit"), 1, CONTRIBUTORS_RENDER_CAP, 60)
+  const minContrib = clampNum(searchParams.get("min"), 0, 1_000_000, 0)
+  const fontFamily = resolveFontFamily(searchParams.get("font"))
+  const falsy = (v: string | null) => v === "false" || v === "0" || v === "none"
+  const border = !falsy(searchParams.get("border"))
+  const watermark = searchParams.get("watermark") === "true" || searchParams.get("watermark") === "1"
+  // Names default OFF for contributors (contrib.rocks shows a dense avatar grid).
+  const showNames = searchParams.get("names") === "true" || searchParams.get("names") === "1"
+  // Include bot accounts ([bot] / type:Bot) only when explicitly opted in.
+  const includeBots = searchParams.get("bots") === "true" || searchParams.get("bots") === "1"
+
+  // Title: defaults to "Contributors"; `title=false`/empty hides it.
+  const titleRaw = searchParams.get("title")
+  const title = titleRaw === null ? "Contributors" : falsy(titleRaw) ? undefined : titleRaw
+
+  const bgRaw = searchParams.get("bg") ?? searchParams.get("background")
+  const transparent = bgRaw === "transparent" || bgRaw === "none"
+  const imageDataUri = await resolveHeaderImage(searchParams.get("image") ?? searchParams.get("bgImage"))
+  const bgParams = {
+    preset: searchParams.get("preset"),
+    theme: searchParams.get("theme"),
+    bg: transparent ? null : resolveColor(bgRaw),
+    transparent,
+    gradient: searchParams.get("gradient"),
+    pattern: searchParams.get("pattern"),
+    glow: resolveColor(searchParams.get("glow")),
+    accent: resolveColor(searchParams.get("accent")),
+    imageDataUri,
+    overlay: searchParams.has("overlay") ? clampNum(searchParams.get("overlay"), 0, 1, 0.45) : undefined,
+    tint: resolveColor(searchParams.get("tint")),
+  }
+
+  const alignOf = (v: string | null, fallback: "left" | "center" | "right") =>
+    v === "left" || v === "center" || v === "right" ? v : fallback
+  const titleAlign = alignOf(searchParams.get("titleAlign"), "left")
+  const avatarAlign = alignOf(searchParams.get("align"), "center")
+
+  const imageResponse = async (svg: string, headers: Record<string, string>): Promise<Response> => {
+    if (format === "png") {
+      const png = await rasterizeToPng(svg)
+      return new Response(Buffer.from(png), { headers: { "Content-Type": "image/png", ...headers } })
+    }
+    return new Response(svg, { headers: { "Content-Type": "image/svg+xml", ...headers } })
+  }
+
+  const fallbackCard = (message: string): Promise<Response> => {
+    const { svg } = renderSponsors({
+      title,
+      tiers: [{ size: baseSize, avatars: [] }],
+      width,
+      mode,
+      radius,
+      fontFamily,
+      border,
+      watermark,
+      showNames,
+      titleAlign,
+      avatarAlign,
+      ...bgParams,
+      ariaLabel: title ? `${title} — GitHub contributors` : "GitHub contributors",
+      emptyText: message,
+    })
+    return imageResponse(svg, ERROR_CACHE_HEADERS)
+  }
+
+  if (!owner || !repo) {
+    if (format === "json") {
+      return Response.json({ error: "missing owner/repo" }, { status: 400, headers: ERROR_CACHE_HEADERS })
+    }
+    return fallbackCard("Provide a GitHub owner and repo")
+  }
+
+  let servedStale = false
+  const list = await cachedFetchStale(
+    "github",
+    `contributors-list/${owner.toLowerCase()}/${repo.toLowerCase()}`,
+    () => getGitHubContributorsList(owner, repo, CONTRIBUTORS_RENDER_CAP),
+    CONTRIBUTORS_FRESH_TTL,
+    CONTRIBUTORS_STALE_TTL,
+    { onStale: () => { servedStale = true } },
+  )
+
+  if (!list) {
+    if (format === "json") {
+      return Response.json({ error: "not found" }, { status: 404, headers: ERROR_CACHE_HEADERS })
+    }
+    return fallbackCard(`No contributors to show for ${owner}/${repo}`)
+  }
+
+  const cacheHeaders = servedStale ? ERROR_CACHE_HEADERS : CACHE_HEADERS
+
+  // Filter (bots / min contributions), then cap to the render budget.
+  const filtered = list.contributors.filter((c) => {
+    if (!includeBots && c.type === "Bot") return false
+    if (c.contributions < minContrib) return false
+    return true
+  })
+  const shown = filtered.slice(0, limit)
+
+  if (format === "json") {
+    return Response.json(
+      {
+        type: "contributors",
+        owner,
+        repo,
+        totalShown: shown.length,
+        contributors: shown.map((c) => ({
+          login: c.login,
+          url: c.url,
+          contributions: c.contributions,
+          type: c.type,
+        })),
+      },
+      { headers: cacheHeaders },
+    )
+  }
+
+  const avatarMap = await inlineAvatars(shown)
+  const avatars: SponsorAvatar[] = shown.map((c) => ({
+    login: c.login,
+    name: null,
+    url: c.url,
+    imageDataUri: avatarMap.get(c.login),
+  }))
+
+  const { svg } = renderSponsors({
+    title,
+    tiers: [{ size: baseSize, avatars }],
+    width,
+    mode,
+    radius,
+    fontFamily,
+    border,
+    watermark,
+    showNames,
+    titleAlign,
+    avatarAlign,
+    ...bgParams,
+    ariaLabel: title ? `${title} — GitHub contributors` : "GitHub contributors",
+    emptyText: `No contributors to show for ${owner}/${repo}`,
+  })
+
+  if (options?.onTrack) {
+    void options.onTrack({
+      name: "contributors_rendered",
+      data: { owner, repo, format, mode, shown: shown.length },
+    })
+  }
+
+  return imageResponse(svg, cacheHeaders)
 }
 
 async function handleSponsors(
@@ -2904,6 +3082,14 @@ async function handleBadgeGETInner(
   // ---------------------------------------------------------------------------
   if (cleanSegments[0] === "sponsors") {
     return handleSponsors(cleanSegments, searchParams, format, options)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Contributors grid: /contributors/{owner}/{repo}.svg
+  // Renders a contrib.rocks-style grid of a repository's top contributors.
+  // ---------------------------------------------------------------------------
+  if (cleanSegments[0] === "contributors") {
+    return handleContributors(cleanSegments, searchParams, format, options)
   }
 
   // Fetch badge data from provider

--- a/packages/web/app/contributors/page.tsx
+++ b/packages/web/app/contributors/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { SiteShell } from "@/components/site-shell"
+import { ContributorsBuilder } from "@/components/contributors-builder"
+import { pageMetadata } from "@/lib/metadata"
+
+export const metadata: Metadata = pageMetadata({
+  title: "GitHub Contributors Image Generator",
+  description:
+    "Free tool to generate a contributors grid image for your README: every contributor's avatar from one image URL, like contrib.rocks but shadcn-styled. Pick a repo, background, theme, and size. SVG and PNG, dark and light.",
+  path: "/contributors",
+})
+
+export default function ContributorsPage() {
+  return (
+    <SiteShell>
+      <main className="min-w-0 flex-1">
+        <div className="px-6 py-8 md:px-10 md:py-10">
+          <div className="mb-6 flex flex-wrap items-end justify-between gap-3">
+            <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">Contributors image</h1>
+            <Link
+              href="/docs/contributors"
+              className="text-sm font-medium text-muted-foreground underline underline-offset-4 hover:text-foreground"
+            >
+              Docs &amp; parameters
+            </Link>
+          </div>
+
+          <ContributorsBuilder />
+        </div>
+      </main>
+    </SiteShell>
+  )
+}

--- a/packages/web/components/animated-header.tsx
+++ b/packages/web/components/animated-header.tsx
@@ -105,6 +105,7 @@ const NAV = {
         { href: "/gen", label: "All badges" },
         { href: "/header", label: "Headers" },
         { href: "/sponsors", label: "Sponsors" },
+        { href: "/contributors", label: "Contributors" },
       ],
     },
     { href: "/migrate", label: "Migrate" },

--- a/packages/web/components/contributors-builder.tsx
+++ b/packages/web/components/contributors-builder.tsx
@@ -1,0 +1,373 @@
+/**
+ * shieldcn
+ * components/contributors-builder
+ *
+ * Interactive contributors-image generator. Pick a GitHub owner/repo, choose a
+ * background preset, theme, avatar size, and toggles; preview live; copy the
+ * URL as Markdown / HTML / plain URL. Everything resolves to a
+ * /contributors/{owner}/{repo}.svg image served from the server.
+ */
+
+"use client"
+
+import { useState, useCallback, useMemo, useSyncExternalStore } from "react"
+import { Copy, Check, Shuffle, AlignLeft, AlignCenter, AlignRight } from "lucide-react"
+import { useTheme } from "next-themes"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Checkbox as ShadcnCheckbox } from "@/components/ui/checkbox"
+import { cn } from "@/lib/utils"
+import {
+  CONTRIBUTORS_DEFAULTS,
+  CONTRIBUTORS_PRESETS,
+  CONTRIBUTORS_PRESET_LABELS,
+  CONTRIBUTORS_SIZES,
+  CONTRIBUTORS_SIZE_LABELS,
+  CONTRIBUTORS_FONTS,
+  CONTRIBUTORS_THEMES,
+  buildContributorsUrl,
+  randomUnsplashHeader,
+  type ContributorsState,
+} from "@/lib/contributors-builder-shared"
+
+type CopyFormat = "markdown" | "html" | "url"
+
+function formatOutput(url: string, format: CopyFormat, alt: string, link: string): string {
+  switch (format) {
+    case "markdown":
+      return `[![${alt}](${url})](${link})`
+    case "html":
+      return `<a href="${link}"><img alt="${alt}" src="${url}" /></a>`
+    case "url":
+      return url
+  }
+}
+
+const COPY_FORMATS: { value: CopyFormat; label: string }[] = [
+  { value: "markdown", label: "Markdown" },
+  { value: "html", label: "HTML" },
+  { value: "url", label: "URL" },
+]
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+  return <Label className="text-xs text-muted-foreground">{children}</Label>
+}
+
+type Align = "left" | "center" | "right"
+function AlignField({ label, value, onChange }: { label: string; value: Align; onChange: (v: Align) => void }) {
+  return (
+    <div className="space-y-1.5">
+      <FieldLabel>{label}</FieldLabel>
+      <ToggleGroup
+        type="single"
+        value={value}
+        onValueChange={(v) => v && onChange(v as Align)}
+        variant="outline"
+        size="sm"
+        className="w-full"
+      >
+        <ToggleGroupItem value="left" aria-label="Align left" className="flex-1"><AlignLeft className="size-3.5" /></ToggleGroupItem>
+        <ToggleGroupItem value="center" aria-label="Align center" className="flex-1"><AlignCenter className="size-3.5" /></ToggleGroupItem>
+        <ToggleGroupItem value="right" aria-label="Align right" className="flex-1"><AlignRight className="size-3.5" /></ToggleGroupItem>
+      </ToggleGroup>
+    </div>
+  )
+}
+
+export function ContributorsBuilder() {
+  const [s, setS] = useState<ContributorsState>(CONTRIBUTORS_DEFAULTS)
+  const [copied, setCopied] = useState(false)
+  const [copyError, setCopyError] = useState(false)
+  const [copyFormat, setCopyFormat] = useState<CopyFormat>("markdown")
+  const { resolvedTheme } = useTheme()
+
+  const baseUrl = useSyncExternalStore(
+    () => () => {},
+    () => window.location.origin,
+    () => "https://shieldcn.dev",
+  )
+  const mode: "dark" | "light" = resolvedTheme === "light" ? "light" : "dark"
+
+  const set = useCallback(<K extends keyof ContributorsState>(key: K, value: ContributorsState[K]) => {
+    setS((prev) => ({ ...prev, [key]: value }))
+  }, [])
+
+  const url = useMemo(() => buildContributorsUrl({ ...s, mode }, baseUrl), [s, mode, baseUrl])
+  const repoSlug = `${s.owner || "vercel"}/${s.repo || "next.js"}`
+  const altText = `${repoSlug} contributors`
+  const repoLink = `https://github.com/${repoSlug}/graphs/contributors`
+  const output = useMemo(() => formatOutput(url, copyFormat, altText, repoLink), [url, copyFormat, altText, repoLink])
+
+  const handleCopy = useCallback(() => {
+    if (!output) return
+    navigator.clipboard.writeText(output).then(
+      () => {
+        setCopied(true)
+        setTimeout(() => setCopied(false), 2000)
+      },
+      () => {
+        setCopyError(true)
+        setTimeout(() => setCopyError(false), 2000)
+      },
+    )
+  }, [output])
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[340px_minmax(0,1fr)]">
+      {/* ─── Preview + output (right on desktop, first on mobile) ─── */}
+      <div className="order-1 flex flex-col gap-4 lg:order-2">
+        <div
+          className="flex min-h-[300px] flex-1 items-center justify-center rounded-xl border border-border p-6 transition-colors md:p-10"
+          style={{
+            backgroundColor: mode === "light" ? "#f4f4f5" : "#0c0c0e",
+            backgroundImage:
+              mode === "light"
+                ? "radial-gradient(circle, #d4d4d8 1px, transparent 1px)"
+                : "radial-gradient(circle, #27272a 1px, transparent 1px)",
+            backgroundSize: "20px 20px",
+          }}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            key={url}
+            src={url}
+            alt="contributors preview"
+            className="w-full max-w-[760px] select-none"
+            draggable={false}
+          />
+        </div>
+
+        {/* Copy output */}
+        <div className="space-y-3">
+          <ToggleGroup
+            type="single"
+            value={copyFormat}
+            onValueChange={(v) => v && setCopyFormat(v as CopyFormat)}
+            variant="outline"
+            size="sm"
+            className="w-full max-w-md"
+          >
+            {COPY_FORMATS.map((f) => (
+              <ToggleGroupItem key={f.value} value={f.value} className="flex-1 text-xs">
+                {f.label}
+              </ToggleGroupItem>
+            ))}
+          </ToggleGroup>
+          <div className="flex items-start gap-2">
+            <code className="flex-1 rounded-lg border border-border bg-muted/30 px-3 py-2.5 text-[11px] font-mono break-all text-muted-foreground leading-relaxed min-h-[2.5rem]">
+              {output}
+            </code>
+            <Button variant="outline" size="sm" onClick={handleCopy} className="shrink-0 h-9">
+              {copied ? (
+                <>
+                  <Check className="size-3.5 text-success" /> Copied
+                </>
+              ) : copyError ? (
+                <>
+                  <Copy className="size-3.5 text-destructive" /> Failed
+                </>
+              ) : (
+                <>
+                  <Copy className="size-3.5" /> Copy
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* ─── Controls sidebar (left on desktop) ─── */}
+      <div className="order-2 lg:order-1 space-y-5 rounded-xl border border-border bg-card p-5">
+        {/* Owner + repo + title */}
+        <div className="space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <FieldLabel>Owner</FieldLabel>
+              <Input
+                value={s.owner}
+                onChange={(e) => set("owner", e.target.value)}
+                placeholder="vercel"
+                className="h-9 text-sm"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <FieldLabel>Repository</FieldLabel>
+              <Input
+                value={s.repo}
+                onChange={(e) => set("repo", e.target.value)}
+                placeholder="next.js"
+                className="h-9 text-sm"
+              />
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <FieldLabel>Title (empty to hide)</FieldLabel>
+            <Input
+              value={s.title}
+              onChange={(e) => set("title", e.target.value)}
+              placeholder="Contributors"
+              className="h-9 text-sm"
+            />
+          </div>
+        </div>
+
+        {/* Background preset */}
+        <div className="space-y-2">
+          <FieldLabel>Background</FieldLabel>
+          <div className="grid grid-cols-2 gap-1.5">
+            {CONTRIBUTORS_PRESETS.map((p) => (
+              <button
+                key={p}
+                onClick={() => set("preset", p)}
+                aria-pressed={s.preset === p}
+                className={cn(
+                  "rounded-lg px-1 py-2 text-xs transition-colors",
+                  s.preset === p
+                    ? "bg-primary/10 ring-1 ring-primary text-foreground"
+                    : "hover:bg-muted/60 text-muted-foreground",
+                )}
+              >
+                {CONTRIBUTORS_PRESET_LABELS[p]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Background image */}
+        <div className="space-y-2">
+          <FieldLabel>Background image</FieldLabel>
+          <div className="flex gap-2">
+            <Input
+              value={s.image}
+              onChange={(e) => set("image", e.target.value)}
+              placeholder="Unsplash or image URL"
+              className="text-xs"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className="size-9 shrink-0"
+              aria-label="Random Unsplash photo"
+              title="Random Unsplash photo"
+              onClick={() => set("image", randomUnsplashHeader(s.image))}
+            >
+              <Shuffle className="size-3.5" />
+            </Button>
+          </div>
+          {s.image ? (
+            <div className="space-y-1.5">
+              <FieldLabel>Overlay (0–1)</FieldLabel>
+              <Input value={s.overlay} onChange={(e) => set("overlay", e.target.value)} placeholder="0.45" className="h-9" />
+            </div>
+          ) : null}
+        </div>
+
+        {/* Selects */}
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1.5">
+            <FieldLabel>Avatar size</FieldLabel>
+            <Select value={s.size} onValueChange={(v) => set("size", v as ContributorsState["size"])}>
+              <SelectTrigger className="h-9 w-full text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {CONTRIBUTORS_SIZES.map((v) => (
+                  <SelectItem key={v} value={v}>
+                    {CONTRIBUTORS_SIZE_LABELS[v]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5">
+            <FieldLabel>Theme</FieldLabel>
+            <Select value={s.theme || "_none"} onValueChange={(v) => set("theme", v === "_none" ? "" : v)}>
+              <SelectTrigger className="h-9 w-full text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="_none">None</SelectItem>
+                {CONTRIBUTORS_THEMES.map((v) => (
+                  <SelectItem key={v} value={v}>
+                    {v}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5">
+            <FieldLabel>Limit</FieldLabel>
+            <Input
+              value={s.limit}
+              onChange={(e) => set("limit", e.target.value)}
+              placeholder="60"
+              inputMode="numeric"
+              className="h-9 text-sm"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <FieldLabel>Min contributions</FieldLabel>
+            <Input
+              value={s.min}
+              onChange={(e) => set("min", e.target.value)}
+              placeholder="0"
+              inputMode="numeric"
+              className="h-9 text-sm"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <FieldLabel>Font</FieldLabel>
+            <Select value={s.font} onValueChange={(v) => set("font", v)}>
+              <SelectTrigger className="h-9 w-full text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {CONTRIBUTORS_FONTS.map((v) => (
+                  <SelectItem key={v} value={v}>
+                    {v}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        {/* Alignment */}
+        <div className="grid grid-cols-2 gap-3">
+          <AlignField label="Title alignment" value={s.titleAlign} onChange={(v) => set("titleAlign", v)} />
+          <AlignField label="Avatar alignment" value={s.avatarAlign} onChange={(v) => set("avatarAlign", v)} />
+        </div>
+
+        {/* Toggles */}
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <ShadcnCheckbox checked={s.names} onCheckedChange={(v) => set("names", v === true)} />
+            <span className="text-xs">Names</span>
+          </label>
+          <label className="flex items-center gap-2 cursor-pointer">
+            <ShadcnCheckbox checked={s.bots} onCheckedChange={(v) => set("bots", v === true)} />
+            <span className="text-xs">Include bots</span>
+          </label>
+          <label className="flex items-center gap-2 cursor-pointer">
+            <ShadcnCheckbox checked={s.border} onCheckedChange={(v) => set("border", v === true)} />
+            <span className="text-xs">Border</span>
+          </label>
+          <label className="flex items-center gap-2 cursor-pointer">
+            <ShadcnCheckbox checked={s.watermark} onCheckedChange={(v) => set("watermark", v === true)} />
+            <span className="text-xs">Watermark</span>
+          </label>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/web/components/sidebar.tsx
+++ b/packages/web/components/sidebar.tsx
@@ -189,6 +189,14 @@ const docsNav: NavGroup[] = [
     ],
   },
   {
+    title: "Contributors",
+    alwaysOpen: true,
+    items: [
+      { title: "Overview", href: "/docs/contributors" },
+      { title: "Generator", href: "/contributors" },
+    ],
+  },
+  {
     title: "Registry",
     items: [
       { title: "Overview", href: "/docs/registry" },

--- a/packages/web/components/studio/canvas.tsx
+++ b/packages/web/components/studio/canvas.tsx
@@ -34,6 +34,7 @@ import { IconTrending5 } from "@central-icons-react/round-filled-radius-3-stroke
 import { IconLayoutGrid2 } from "@central-icons-react/round-filled-radius-3-stroke-1.5/IconLayoutGrid2"
 import { IconAddImage } from "@central-icons-react/round-filled-radius-3-stroke-1.5/IconAddImage"
 import { IconPeople } from "@central-icons-react/round-filled-radius-3-stroke-1.5/IconPeople"
+import { IconPeople2 } from "@central-icons-react/round-filled-radius-3-stroke-1.5/IconPeople2"
 import { IconAlignmentLeft } from "@central-icons-react/round-outlined-radius-3-stroke-1.5/IconAlignmentLeft"
 import { IconAlignmentCenter } from "@central-icons-react/round-outlined-radius-3-stroke-1.5/IconAlignmentCenter"
 import { IconAlignmentRight } from "@central-icons-react/round-outlined-radius-3-stroke-1.5/IconAlignmentRight"
@@ -55,6 +56,7 @@ import {
 import { buildBadgeUrl } from "@/lib/badge-builder-shared"
 import { buildHeaderUrl } from "@/lib/header-builder-shared"
 import { buildSponsorsUrl } from "@/lib/sponsors-builder-shared"
+import { buildContributorsUrl } from "@/lib/contributors-builder-shared"
 import {
   buildChartUrl,
   buildGroupUrl,
@@ -67,7 +69,7 @@ import {
   type MarkdownBlock,
 } from "@/lib/studio-shared"
 
-const BLOCK_TYPES: BlockType[] = ["markdown", "header", "badges", "group", "chart", "table", "image", "sponsors"]
+const BLOCK_TYPES: BlockType[] = ["markdown", "header", "badges", "group", "chart", "table", "image", "sponsors", "contributors"]
 
 const BLOCK_ICONS: Record<BlockType, React.ComponentType<{ className?: string }>> = {
   markdown: IconText1,
@@ -78,6 +80,7 @@ const BLOCK_ICONS: Record<BlockType, React.ComponentType<{ className?: string }>
   table: IconLayoutGrid2,
   image: IconAddImage,
   sponsors: IconPeople,
+  contributors: IconPeople2,
 }
 
 // Tiptap is heavy — keep it out of the initial Studio bundle until a text
@@ -306,6 +309,19 @@ function BlockContent({
       const mode = themeAware ? siteMode : block.state.mode
       if (!block.state.login.trim()) return <p className="text-sm text-muted-foreground italic">Enter a GitHub login in the inspector.</p>
       const url = buildSponsorsUrl({ ...block.state, mode }, "")
+      return (
+        <div className={cn("flex", ALIGN_CLASS[block.align])}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={url} alt={block.alt} draggable={false} className="max-w-full rounded-md" />
+        </div>
+      )
+    }
+
+    case "contributors": {
+      const mode = themeAware ? siteMode : block.state.mode
+      if (!block.state.owner.trim() || !block.state.repo.trim())
+        return <p className="text-sm text-muted-foreground italic">Enter a GitHub owner and repo in the inspector.</p>
+      const url = buildContributorsUrl({ ...block.state, mode }, "")
       return (
         <div className={cn("flex", ALIGN_CLASS[block.align])}>
           {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/packages/web/components/studio/inspectors.tsx
+++ b/packages/web/components/studio/inspectors.tsx
@@ -67,6 +67,15 @@ import {
   type SponsorsState,
 } from "@/lib/sponsors-builder-shared"
 import {
+  CONTRIBUTORS_PRESETS,
+  CONTRIBUTORS_PRESET_LABELS,
+  CONTRIBUTORS_SIZES,
+  CONTRIBUTORS_SIZE_LABELS,
+  CONTRIBUTORS_FONTS,
+  CONTRIBUTORS_THEMES,
+  type ContributorsState,
+} from "@/lib/contributors-builder-shared"
+import {
   CHART_THEMES,
   CHART_FONTS,
   makeBadgeItem,
@@ -82,6 +91,7 @@ import {
   type ImageBlock,
   type MarkdownBlock,
   type SponsorsBlock,
+  type ContributorsBlock,
   type TableBlock,
 } from "@/lib/studio-shared"
 
@@ -577,6 +587,115 @@ export function SponsorsInspector({ block, onChange }: { block: SponsorsBlock; o
       <Separator />
       <Field label="Alt text" htmlFor="sp-alt">
         <Input id="sp-alt" value={block.alt} onChange={e => onChange({ ...block, alt: e.target.value })} placeholder="sponsors" />
+      </Field>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Contributors inspector
+// ---------------------------------------------------------------------------
+
+export function ContributorsInspector({ block, onChange }: { block: ContributorsBlock; onChange: (b: ContributorsBlock) => void }) {
+  const s = block.state
+  const set = useCallback((patch: Partial<ContributorsState>) => onChange({ ...block, state: { ...block.state, ...patch } }), [block, onChange])
+
+  return (
+    <div className="space-y-4">
+      <Row>
+        <Field label="Owner" htmlFor="ct-owner">
+          <Input id="ct-owner" value={s.owner} onChange={e => set({ owner: e.target.value })} placeholder="vercel" />
+        </Field>
+        <Field label="Repository" htmlFor="ct-repo">
+          <Input id="ct-repo" value={s.repo} onChange={e => set({ repo: e.target.value })} placeholder="next.js" />
+        </Field>
+      </Row>
+      <Field label="Title (empty to hide)" htmlFor="ct-title">
+        <Input id="ct-title" value={s.title} onChange={e => set({ title: e.target.value })} placeholder="Contributors" />
+      </Field>
+
+      <Separator />
+      <Field label="Background">
+        <Select value={s.preset} onValueChange={v => set({ preset: v as ContributorsState["preset"] })}>
+          <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+          <SelectContent>
+            {CONTRIBUTORS_PRESETS.map(p => (
+              <SelectItem key={p} value={p}>{CONTRIBUTORS_PRESET_LABELS[p]}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </Field>
+
+      <Row>
+        <Field label="Avatar size">
+          <Select value={s.size} onValueChange={v => set({ size: v as ContributorsState["size"] })}>
+            <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {CONTRIBUTORS_SIZES.map(sz => <SelectItem key={sz} value={sz}>{CONTRIBUTORS_SIZE_LABELS[sz]}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </Field>
+        <Field label="Theme">
+          <Select value={s.theme || "_none"} onValueChange={v => set({ theme: v === "_none" ? "" : v })}>
+            <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="_none">Default</SelectItem>
+              {CONTRIBUTORS_THEMES.map(t => <SelectItem key={t} value={t}>{t}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </Field>
+      </Row>
+
+      <Row>
+        <Field label="Limit" htmlFor="ct-limit">
+          <Input id="ct-limit" value={s.limit} onChange={e => set({ limit: e.target.value })} placeholder="60" inputMode="numeric" />
+        </Field>
+        <Field label="Min contributions" htmlFor="ct-min">
+          <Input id="ct-min" value={s.min} onChange={e => set({ min: e.target.value })} placeholder="0" inputMode="numeric" />
+        </Field>
+      </Row>
+      <Field label="Font">
+        <Select value={s.font} onValueChange={v => set({ font: v })}>
+          <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+          <SelectContent>
+            {CONTRIBUTORS_FONTS.map(f => <SelectItem key={f} value={f}>{f}</SelectItem>)}
+          </SelectContent>
+        </Select>
+      </Field>
+
+      <Separator />
+      <Row>
+        <Field label="Title align">
+          <Select value={s.titleAlign} onValueChange={v => set({ titleAlign: v as ContributorsState["titleAlign"] })}>
+            <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="left">Left</SelectItem>
+              <SelectItem value="center">Center</SelectItem>
+              <SelectItem value="right">Right</SelectItem>
+            </SelectContent>
+          </Select>
+        </Field>
+        <Field label="Avatar align">
+          <Select value={s.avatarAlign} onValueChange={v => set({ avatarAlign: v as ContributorsState["avatarAlign"] })}>
+            <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="left">Left</SelectItem>
+              <SelectItem value="center">Center</SelectItem>
+              <SelectItem value="right">Right</SelectItem>
+            </SelectContent>
+          </Select>
+        </Field>
+      </Row>
+
+      <Separator />
+      <ToggleField label="Names" checked={s.names} onCheckedChange={v => set({ names: v })} />
+      <ToggleField label="Include bots" checked={s.bots} onCheckedChange={v => set({ bots: v })} />
+      <ToggleField label="Border" checked={s.border} onCheckedChange={v => set({ border: v })} />
+      <ToggleField label="Watermark" checked={s.watermark} onCheckedChange={v => set({ watermark: v })} />
+
+      <Separator />
+      <Field label="Alt text" htmlFor="ct-alt">
+        <Input id="ct-alt" value={block.alt} onChange={e => onChange({ ...block, alt: e.target.value })} placeholder="contributors" />
       </Field>
     </div>
   )

--- a/packages/web/components/studio/studio.tsx
+++ b/packages/web/components/studio/studio.tsx
@@ -42,6 +42,7 @@ import { IconTrending5 } from "@central-icons-react/round-filled-radius-3-stroke
 import { IconLayoutGrid2 } from "@central-icons-react/round-filled-radius-3-stroke-1.5/IconLayoutGrid2"
 import { IconAddImage } from "@central-icons-react/round-filled-radius-3-stroke-1.5/IconAddImage"
 import { IconPeople } from "@central-icons-react/round-filled-radius-3-stroke-1.5/IconPeople"
+import { IconPeople2 } from "@central-icons-react/round-filled-radius-3-stroke-1.5/IconPeople2"
 import { useSyncExternalStore } from "react"
 import { useBadgeMode } from "@/lib/use-badge-mode"
 import { Button } from "@/components/ui/button"
@@ -66,6 +67,7 @@ import {
   TableInspector,
   ImageInspector,
   SponsorsInspector,
+  ContributorsInspector,
   Tip,
 } from "@/components/studio/inspectors"
 import {
@@ -84,6 +86,7 @@ import {
   type TableBlock,
   type ImageBlock,
   type SponsorsBlock,
+  type ContributorsBlock,
 } from "@/lib/studio-shared"
 import { markdownToDocument } from "@/lib/studio-import"
 
@@ -99,6 +102,7 @@ const BLOCK_ICONS: Record<BlockType, React.ComponentType<{ className?: string }>
   table: IconLayoutGrid2,
   image: IconAddImage,
   sponsors: IconPeople,
+  contributors: IconPeople2,
 }
 
 // ---------------------------------------------------------------------------
@@ -130,6 +134,7 @@ function blockSummary(block: Block): string {
     case "table": return `${block.rows.length}×${block.headers.length} table`
     case "image": return block.alt || "image"
     case "sponsors": return block.state.login ? `@${block.state.login} sponsors` : "sponsors"
+    case "contributors": return block.state.owner && block.state.repo ? `${block.state.owner}/${block.state.repo} contributors` : "contributors"
   }
 }
 
@@ -559,6 +564,8 @@ export function Studio() {
     <ImageInspector block={selected as ImageBlock} onChange={updateBlock} />
   ) : selected.type === "sponsors" ? (
     <SponsorsInspector block={selected as SponsorsBlock} onChange={updateBlock} />
+  ) : selected.type === "contributors" ? (
+    <ContributorsInspector block={selected as ContributorsBlock} onChange={updateBlock} />
   ) : (
     <ChartInspector block={selected as ChartBlock} onChange={updateBlock} />
   )
@@ -707,7 +714,7 @@ export function Studio() {
           <div className="border-b border-border p-3">
             <p className="mb-2 px-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">Add block</p>
             <div className="grid grid-cols-2 gap-1.5">
-              {(["markdown", "header", "badges", "group", "chart", "table", "image", "sponsors"] as BlockType[]).map(type => {
+              {(["markdown", "header", "badges", "group", "chart", "table", "image", "sponsors", "contributors"] as BlockType[]).map(type => {
                 const Icon = BLOCK_ICONS[type]
                 return (
                   <Button
@@ -774,7 +781,7 @@ export function Studio() {
         <main className="min-w-0 flex-1 overflow-y-auto bg-muted/40" onClick={deselect}>
           {/* Mobile add bar */}
           <div className="flex items-center gap-1.5 overflow-x-auto border-b border-border bg-background px-3 py-2 lg:hidden">
-            {(["markdown", "header", "badges", "group", "chart", "table", "image", "sponsors"] as BlockType[]).map(type => {
+            {(["markdown", "header", "badges", "group", "chart", "table", "image", "sponsors", "contributors"] as BlockType[]).map(type => {
               const Icon = BLOCK_ICONS[type]
               return (
                 <Button
@@ -827,7 +834,7 @@ export function Studio() {
                       <p className="mx-auto max-w-xs text-sm text-muted-foreground">Add a block to begin. Mix text, headers, badges, charts, tables, and images, then export clean Markdown.</p>
                     </div>
                     <div className="flex flex-wrap justify-center gap-1.5">
-                      {(["markdown", "header", "badges", "group", "chart", "table", "image", "sponsors"] as BlockType[]).map(type => {
+                      {(["markdown", "header", "badges", "group", "chart", "table", "image", "sponsors", "contributors"] as BlockType[]).map(type => {
                         const Icon = BLOCK_ICONS[type]
                         return (
                           <Button

--- a/packages/web/content/docs/api-reference.mdx
+++ b/packages/web/content/docs/api-reference.mdx
@@ -167,6 +167,21 @@ logins with `special` and `backers` (comma-separated). Support `specialTitle`,
 `bg`, `accent`, `radius`, `border`, `watermark`, plus `mode` and `font`. See
 [Sponsors docs](/docs/sponsors).
 
+### Contributors
+
+| Endpoint | Description |
+|----------|-------------|
+| `/contributors/{owner}/{repo}.svg` | Repository contributors grid |
+| `/contributors/{owner}/{repo}.png` | PNG grid |
+| `/contributors/{owner}/{repo}.json` | Resolved contributor list |
+
+A contrib.rocks-style grid of a repository's top contributors, ordered by
+contributions. Bots are excluded by default (`bots=true` to include). Supports
+`title`, `limit`, `min`, `names`, `size`, `width`, `align`, `titleAlign`, the
+full header background system (`preset`, `theme`, `bg`, `gradient`, `pattern`,
+`glow`, `image`, `overlay`, `tint`, `accent`), `radius`, `border`, `watermark`,
+plus `mode` and `font`. See [Contributors docs](/docs/contributors).
+
 ## Query parameters
 
 <ApiRefTable

--- a/packages/web/content/docs/contributors/index.mdx
+++ b/packages/web/content/docs/contributors/index.mdx
@@ -1,0 +1,193 @@
+---
+title: Contributors
+description: A grid of your repository's contributors — every contributor's avatar, rendered as one portable image for your README. Like contrib.rocks, but shadcn-styled.
+---
+
+The contributors image renders a grid of a repository's **top contributors** —
+their avatars, linked to their GitHub profiles — as a single portable SVG (or
+PNG) served from shieldcn. It's a [contrib.rocks](https://contrib.rocks)-style
+image, but built from shadcn-styled chrome and the same background system as
+[headers](headers) and [sponsors](sponsors). Everything is encoded in the image
+URL, so it works anywhere a Markdown image does and never needs a build step or
+a CI job.
+
+<ContributorsPreview
+  src="/contributors/vercel/next.js.svg"
+  alt="next.js contributors"
+/>
+
+## Builder
+
+The fastest way to make a contributors image is the interactive generator.
+Enter an owner and repo, pick a background, theme, and size, then copy the
+Markdown.
+
+[Open the contributors generator](/contributors)
+
+## URL format
+
+```
+/contributors/{owner}/{repo}.svg     SVG grid
+/contributors/{owner}/{repo}.png     PNG grid
+/contributors/{owner}/{repo}.json    resolved contributor list (JSON)
+```
+
+`{owner}/{repo}` is any public GitHub repository. Drop it into your README with
+a linked Markdown image:
+
+```md
+[![Contributors](https://shieldcn.dev/contributors/vercel/next.js.svg)](https://github.com/vercel/next.js/graphs/contributors)
+```
+
+Or center it with an HTML block:
+
+```html
+<p align="center">
+  <a href="https://github.com/vercel/next.js/graphs/contributors">
+    <img src="https://shieldcn.dev/contributors/vercel/next.js.svg" alt="Contributors" />
+  </a>
+</p>
+```
+
+## Ordering and filtering
+
+Contributors are ordered by **number of contributions** (commits), descending —
+the same order as GitHub's contributors graph. Bots (accounts ending in
+`[bot]`, or of GitHub type `Bot`) are **excluded by default**; include them with
+`?bots=true`.
+
+- `limit` — cap how many avatars are shown (1–100, default 60).
+- `min` — only include contributors with at least this many contributions.
+- `bots` — set `true` to include bot accounts.
+
+```md
+[![Contributors](https://shieldcn.dev/contributors/vercel/next.js.svg?limit=30&min=5)](https://github.com/vercel/next.js/graphs/contributors)
+```
+
+<ContributorsPreview
+  src="/contributors/vercel/next.js.svg?limit=24&names=true"
+  alt="next.js contributors with names"
+  description="limit=24, names=true"
+/>
+
+## Sizing and layout
+
+The `size` parameter sets the avatar diameter; use `width` to set the canvas
+width — avatars wrap into as many rows as needed. Names are **off by default**
+for a dense avatar grid; turn them on with `names=true`.
+
+| Parameter | Values | Default |
+| --- | --- | --- |
+| `size` | 24–140 (px) | 64 |
+| `width` | 320–2000 (px) | 800 |
+| `limit` | 1–100 | 60 |
+| `min` | ≥ 0 | 0 |
+| `names` | `true`, `false` | `false` |
+| `bots` | `true`, `false` | `false` |
+| `titleAlign` | `left`, `center`, `right` | `left` |
+| `align` | `left`, `center`, `right` (avatars) | `center` |
+| `radius` | 0–80 (px) | 12 |
+| `border` | `true`, `false` | `true` |
+| `watermark` | `true`, `false` | `false` |
+
+```md
+![Contributors](https://shieldcn.dev/contributors/vercel/next.js.svg?size=48&limit=40)
+```
+
+## Title and colors
+
+The grid has a "Contributors" heading by default. Override it with `title=...`,
+or hide it with `title=false`. Color controls:
+
+- `bg` — a solid background color (hex without `#`), or `transparent` to blend
+  into the page.
+- `accent` — the color of the hairline rule under the title (hex without `#`).
+
+```md
+![Contributors](https://shieldcn.dev/contributors/vercel/next.js.svg?title=Built+by&bg=transparent)
+```
+
+## Backgrounds
+
+The card uses the **same premade background system as [headers](headers)** —
+so it's just as customizable. Set a preset with `?preset=`:
+
+| Preset | Description |
+| --- | --- |
+| `surface` | Clean flat zinc surface. The default. |
+| `gradient` | Subtle neutral vertical gradient. |
+| `dots` | Dot grid over the surface. |
+| `grid` | Line grid over the surface. |
+| `graph` | Fine and coarse graph paper. |
+| `glow` | Soft themed spotlight from the top. |
+| `transparent` | No surface fill — blends into the page. |
+
+<ContributorsPreview
+  src="/contributors/vercel/next.js.svg?preset=glow&theme=blue"
+  alt="contributors with the glow preset and blue theme"
+  description="glow preset, blue theme"
+/>
+
+For full control, override the background directly:
+
+- `theme` — tints the glow/accent: `zinc`, `slate`, `blue`, `green`, `rose`,
+  `orange`, `violet`, `purple`, `cyan`, `emerald`.
+- `gradient` — comma-separated hex stops with an optional trailing angle, e.g.
+  `gradient=7c2d12,9f1239,86198f,135`.
+- `pattern` — `dots`, `grid`, `graph`, or `none`.
+- `glow` — the spotlight color (hex without `#`).
+- `bg` — a solid color (hex without `#`), or `transparent`.
+- `image` — a background photo (Unsplash or any image URL), inlined behind an
+  auto scrim; tune it with `overlay` (0–1) and `tint`.
+
+```md
+![Contributors](https://shieldcn.dev/contributors/vercel/next.js.svg?gradient=7c2d12,9f1239,86198f,135)
+```
+
+## Light and dark mode
+
+The grid reads correctly in both modes. Pass `mode=light` or `mode=dark`, or
+pair two images in a `<picture>` element so it follows the reader's GitHub
+theme. See [Light & Dark Mode](customization/light-dark-mode).
+
+## Parameters
+
+In addition to the shared `mode` and `font` parameters from the
+[API reference](api-reference):
+
+| Parameter | Values | Default |
+| --- | --- | --- |
+| `title` | string, or `false` | `Contributors` |
+| `limit` | 1–100 | 60 |
+| `min` | ≥ 0 | 0 |
+| `names` | `true`, `false` | `false` |
+| `bots` | `true`, `false` | `false` |
+| `titleAlign` | `left`, `center`, `right` | `left` |
+| `align` | `left`, `center`, `right` (avatars) | `center` |
+| `size` | 24–140 (px) | 64 |
+| `width` | 320–2000 (px) | 800 |
+| `preset` | `surface`, `gradient`, `dots`, `grid`, `graph`, `glow`, `transparent` | `surface` |
+| `theme` | `zinc`, `slate`, `blue`, `green`, `rose`, `orange`, `violet`, `purple`, `cyan`, `emerald` | — |
+| `bg` | hex without `#`, or `transparent` | card surface |
+| `gradient` | comma-separated hex stops, optional trailing angle | — |
+| `pattern` | `dots`, `grid`, `graph`, `none` | preset |
+| `glow` | hex without `#` | per preset |
+| `image` | Unsplash / image URL, or `data:` URI | — |
+| `overlay` | 0–1 | 0.45 |
+| `tint` | hex without `#` | `000000` |
+| `accent` | hex without `#` | — |
+| `radius` | 0–80 (px) | 12 |
+| `border` | `true`, `false` | `true` |
+| `watermark` | `true`, `false` | `false` |
+| `mode` | `dark`, `light` | `dark` |
+
+## Data source
+
+Contributor data comes from the GitHub REST
+[contributors API](https://docs.github.com/en/rest/repos/repos#list-repository-contributors)
+(`/repos/{owner}/{repo}/contributors`), ordered by contributions descending.
+Avatars are fetched once and inlined into the image, and the list is cached for
+an hour (serving the last-known-good list during any GitHub outage). The image
+renders the top contributors up to `limit`; very large repositories are capped
+at 100. A repository that doesn't exist or has no contributors renders an
+empty-state message.

--- a/packages/web/content/docs/contributors/meta.json
+++ b/packages/web/content/docs/contributors/meta.json
@@ -1,0 +1,6 @@
+{
+  "title": "Contributors",
+  "pages": [
+    "index"
+  ]
+}

--- a/packages/web/content/docs/meta.json
+++ b/packages/web/content/docs/meta.json
@@ -17,6 +17,8 @@
     "...headers",
     "---Sponsors---",
     "...sponsors",
+    "---Contributors---",
+    "...contributors",
     "---Registry---",
     "...registry",
     "---Reference---",

--- a/packages/web/lib/contributors-builder-shared.ts
+++ b/packages/web/lib/contributors-builder-shared.ts
@@ -1,0 +1,119 @@
+/**
+ * shieldcn
+ * lib/contributors-builder-shared
+ *
+ * Shared state + URL builder for the contributors-image generator UI.
+ * Mirrors sponsors-builder-shared but for /contributors/{owner}/{repo}.svg —
+ * a contrib.rocks-style grid of a repository's top contributors.
+ */
+
+import {
+  HEADER_PRESETS,
+  HEADER_PRESET_LABELS,
+  HEADER_FONTS,
+  HEADER_THEMES,
+  randomUnsplashHeader,
+  type HeaderPreset,
+} from "./header-builder-shared"
+
+// The contributors card reuses the exact background system as headers.
+export const CONTRIBUTORS_PRESETS = HEADER_PRESETS
+export const CONTRIBUTORS_PRESET_LABELS = HEADER_PRESET_LABELS
+export const CONTRIBUTORS_FONTS = HEADER_FONTS
+export const CONTRIBUTORS_THEMES = HEADER_THEMES
+export { randomUnsplashHeader }
+export type ContributorsPreset = HeaderPreset
+
+export const CONTRIBUTORS_SIZES = ["40", "48", "64", "80"] as const
+export type ContributorsSize = (typeof CONTRIBUTORS_SIZES)[number]
+export const CONTRIBUTORS_SIZE_LABELS: Record<ContributorsSize, string> = {
+  "40": "Compact",
+  "48": "Small",
+  "64": "Medium",
+  "80": "Large",
+}
+
+export interface ContributorsState {
+  /** GitHub repository owner (user or org). */
+  owner: string
+  /** GitHub repository name. */
+  repo: string
+  /** Card heading. Empty hides it (title=false). */
+  title: string
+  preset: ContributorsPreset
+  theme: string
+  /** Avatar diameter (px) as a string. */
+  size: ContributorsSize
+  /** Show a login caption under each avatar. */
+  names: boolean
+  /** Include bot accounts ([bot] / type:Bot). */
+  bots: boolean
+  /** Alignment of the card title. */
+  titleAlign: "left" | "center" | "right"
+  /** Alignment of the avatar rows. */
+  avatarAlign: "left" | "center" | "right"
+  /** Max avatars rendered (string for the input). */
+  limit: string
+  /** Minimum contributions to include (string for the input). */
+  min: string
+  mode: "dark" | "light"
+  font: string
+  border: boolean
+  watermark: boolean
+  /** Background photo URL (Unsplash or any image). Fetched + inlined server-side. */
+  image: string
+  /** Scrim strength over the photo, "0"–"1". Blank = default (0.45). */
+  overlay: string
+}
+
+export const CONTRIBUTORS_DEFAULTS: ContributorsState = {
+  owner: "vercel",
+  repo: "next.js",
+  title: "Contributors",
+  preset: "surface",
+  theme: "",
+  size: "64",
+  names: false,
+  bots: false,
+  titleAlign: "left",
+  avatarAlign: "center",
+  limit: "",
+  min: "",
+  mode: "dark",
+  font: "inter",
+  border: true,
+  watermark: false,
+  image: "",
+  overlay: "",
+}
+
+/** Build the `/contributors/{owner}/{repo}.svg?...` URL from builder state. */
+export function buildContributorsUrl(s: ContributorsState, baseUrl: string): string {
+  const owner = s.owner.trim().replace(/^@/, "") || "vercel"
+  const repo = s.repo.trim() || "next.js"
+  const params = new URLSearchParams()
+
+  // Title: default is "Contributors". An empty title hides the heading.
+  if (s.title.trim() === "") params.set("title", "false")
+  else if (s.title !== "Contributors") params.set("title", s.title)
+
+  if (s.preset && s.preset !== "surface") params.set("preset", s.preset)
+  if (s.theme) params.set("theme", s.theme)
+  if (s.size && s.size !== "64") params.set("size", s.size)
+  if (s.names) params.set("names", "true")
+  if (s.bots) params.set("bots", "true")
+  if (s.titleAlign && s.titleAlign !== "left") params.set("titleAlign", s.titleAlign)
+  if (s.avatarAlign && s.avatarAlign !== "center") params.set("align", s.avatarAlign)
+  if (s.limit.trim()) params.set("limit", s.limit.trim())
+  if (s.min.trim()) params.set("min", s.min.trim())
+  // Always include mode so the URL changes with the site theme (cache-safe).
+  params.set("mode", s.mode)
+  if (s.font && s.font !== "inter") params.set("font", s.font)
+  if (s.watermark) params.set("watermark", "true")
+  if (!s.border) params.set("border", "false")
+  if (s.image) params.set("image", s.image)
+  if (s.image && s.overlay) params.set("overlay", s.overlay)
+
+  const qs = params.toString()
+  return `${baseUrl}/contributors/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}.svg${qs ? `?${qs}` : ""}`
+}

--- a/packages/web/lib/studio-import.ts
+++ b/packages/web/lib/studio-import.ts
@@ -32,6 +32,7 @@ import {
 import { BUILDER_DEFAULTS, type BuilderState } from "@/lib/badge-builder-shared"
 import { HEADER_DEFAULTS, type HeaderPreset, type HeaderSize, type HeaderState } from "@/lib/header-builder-shared"
 import { SPONSORS_DEFAULTS, type SponsorsPreset, type SponsorsSize, type SponsorsState } from "@/lib/sponsors-builder-shared"
+import { CONTRIBUTORS_DEFAULTS, type ContributorsPreset, type ContributorsSize, type ContributorsState } from "@/lib/contributors-builder-shared"
 
 // Minimal mdast shape — only the fields this parser reads.
 interface MdNode {
@@ -44,7 +45,7 @@ interface MdNode {
   position?: { start: { offset: number }; end: { offset: number } }
 }
 
-type ImgKind = "header" | "group" | "chart" | "badge" | "image" | "sponsors"
+type ImgKind = "header" | "group" | "chart" | "badge" | "image" | "sponsors" | "contributors"
 
 interface ImgRef {
   src: string
@@ -84,6 +85,7 @@ function classifyUrl(src: string, baseUrl: string): ImgKind {
   if (first === "group") return "group"
   if (first === "chart") return "chart"
   if (first === "sponsors") return "sponsors"
+  if (first === "contributors") return "contributors"
   if (first === "badge") return "badge"
   const base = originOf(baseUrl)
   const relative = !/^https?:\/\//i.test(src)
@@ -254,6 +256,36 @@ function sponsorsStateFromUrl(u: URL): SponsorsState {
   }
 }
 
+/** Reverse a `/contributors/{owner}/{repo}.svg?...` URL into a ContributorsState. */
+function contributorsStateFromUrl(u: URL): ContributorsState {
+  const q = u.searchParams
+  const segs = u.pathname.split("/").filter(Boolean) // ["contributors", "{owner}", "{repo}.svg"]
+  const owner = decodeURIComponent(segs[1] || "")
+  const repo = decodeURIComponent((segs[2] || "").replace(/\.(svg|png)$/i, ""))
+  const titleParam = q.get("title")
+  return {
+    ...CONTRIBUTORS_DEFAULTS,
+    owner: owner || CONTRIBUTORS_DEFAULTS.owner,
+    repo: repo || CONTRIBUTORS_DEFAULTS.repo,
+    title: titleParam === null ? "Contributors" : titleParam === "false" ? "" : titleParam,
+    preset: ((q.get("preset") || "surface") as ContributorsPreset),
+    theme: q.get("theme") || "",
+    size: ((q.get("size") as ContributorsSize) || "64"),
+    names: q.get("names") === "true",
+    bots: q.get("bots") === "true",
+    titleAlign: ((v) => (v === "center" || v === "right" ? v : "left"))(q.get("titleAlign")),
+    avatarAlign: ((v) => (v === "left" || v === "right" ? v : "center"))(q.get("align")),
+    limit: q.get("limit") || "",
+    min: q.get("min") || "",
+    mode: (q.get("mode") as "dark" | "light") || "dark",
+    font: q.get("font") || "inter",
+    border: q.get("border") !== "false",
+    watermark: q.get("watermark") === "true",
+    image: q.get("image") || "",
+    overlay: q.get("overlay") || "",
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Image refs → blocks (groups adjacent badges into one Badges block)
 // ---------------------------------------------------------------------------
@@ -287,6 +319,8 @@ function blocksFromImageRefs(refs: ImgRef[], align: Alignment, baseUrl: string):
       out.push({ id: newId("chart"), type: "chart", alt: ref.alt, align, themeAware: ref.themeAware || undefined, state: chartStateFromUrl(u) })
     } else if (kind === "sponsors" && u) {
       out.push({ id: newId("sponsors"), type: "sponsors", alt: ref.alt, align, themeAware: ref.themeAware || undefined, state: sponsorsStateFromUrl(u) })
+    } else if (kind === "contributors" && u) {
+      out.push({ id: newId("contributors"), type: "contributors", alt: ref.alt, align, themeAware: ref.themeAware || undefined, state: contributorsStateFromUrl(u) })
     } else {
       out.push({ id: newId("img"), type: "image", src: ref.src, alt: ref.alt, align, width: ref.width, link: ref.link })
     }

--- a/packages/web/lib/studio-shared.ts
+++ b/packages/web/lib/studio-shared.ts
@@ -25,6 +25,11 @@ import {
   buildSponsorsUrl,
   type SponsorsState,
 } from "@/lib/sponsors-builder-shared"
+import {
+  CONTRIBUTORS_DEFAULTS,
+  buildContributorsUrl,
+  type ContributorsState,
+} from "@/lib/contributors-builder-shared"
 
 // ---------------------------------------------------------------------------
 // Chart state (the chart sandbox keeps state inline; the Studio needs it as a
@@ -135,7 +140,7 @@ export function buildChartUrl(s: ChartState, baseUrl: string): string | null {
 // Block model
 // ---------------------------------------------------------------------------
 
-export type BlockType = "markdown" | "header" | "badges" | "group" | "chart" | "table" | "image" | "sponsors"
+export type BlockType = "markdown" | "header" | "badges" | "group" | "chart" | "table" | "image" | "sponsors" | "contributors"
 
 /** Default placeholder image source. */
 export const PLACEHOLDER_IMAGE = "https://placeholdpicsum.dev/photo/600/400"
@@ -235,6 +240,15 @@ export interface SponsorsBlock extends BaseBlock {
   state: SponsorsState
 }
 
+export interface ContributorsBlock extends BaseBlock {
+  type: "contributors"
+  alt: string
+  align: Alignment
+  /** Emit a GitHub <picture> that swaps dark/light with the reader's theme. */
+  themeAware?: boolean
+  state: ContributorsState
+}
+
 export interface ImageBlock extends BaseBlock {
   type: "image"
   /** Image URL or absolute/relative path. */
@@ -259,7 +273,7 @@ export interface TableBlock extends BaseBlock {
   align?: Alignment
 }
 
-export type Block = MarkdownBlock | HeaderBlock | BadgesBlock | GroupBlock | ChartBlock | TableBlock | ImageBlock | SponsorsBlock
+export type Block = MarkdownBlock | HeaderBlock | BadgesBlock | GroupBlock | ChartBlock | TableBlock | ImageBlock | SponsorsBlock | ContributorsBlock
 
 export const BLOCK_LABELS: Record<BlockType, string> = {
   markdown: "Text",
@@ -270,6 +284,7 @@ export const BLOCK_LABELS: Record<BlockType, string> = {
   table: "Table",
   image: "Image",
   sponsors: "Sponsors",
+  contributors: "Contributors",
 }
 
 // ---------------------------------------------------------------------------
@@ -392,6 +407,16 @@ export function makeSponsorsBlock(): SponsorsBlock {
   }
 }
 
+export function makeContributorsBlock(): ContributorsBlock {
+  return {
+    id: newId("contributors"),
+    type: "contributors",
+    alt: "contributors",
+    align: "center",
+    state: { ...CONTRIBUTORS_DEFAULTS },
+  }
+}
+
 export function makeTableBlock(): TableBlock {
   return {
     id: newId("table"),
@@ -444,6 +469,7 @@ export function makeBlock(type: BlockType): Block {
     case "table": return makeTableBlock()
     case "image": return makeImageBlock()
     case "sponsors": return makeSponsorsBlock()
+    case "contributors": return makeContributorsBlock()
   }
 }
 
@@ -578,6 +604,20 @@ export function blockToMarkdown(block: Block, baseUrl: string, themeAware = fals
       const url = buildSponsorsUrl(block.state, baseUrl)
       if (block.align === "left") return `![${block.alt}](${url})`
       return alignWrap(block.align, `<img alt="${escapeAttr(block.alt)}" src="${escapeAttr(url)}" />`)
+    }
+
+    case "contributors": {
+      const link = `https://github.com/${block.state.owner || "vercel"}/${block.state.repo || "next.js"}/graphs/contributors`
+      if (adaptive) {
+        const dark = buildContributorsUrl({ ...block.state, mode: "dark" }, baseUrl)
+        const light = buildContributorsUrl({ ...block.state, mode: "light" }, baseUrl)
+        const pic = picture(dark, light, block.alt, link)
+        return block.align === "left" ? pic : `<p align="${block.align}">\n  ${pic}\n</p>`
+      }
+      const url = buildContributorsUrl(block.state, baseUrl)
+      const img = `<img alt="${escapeAttr(block.alt)}" src="${escapeAttr(url)}" />`
+      const linked = `<a href="${escapeAttr(link)}">${img}</a>`
+      return block.align === "left" ? linked : `<p align="${block.align}">\n  ${linked}\n</p>`
     }
 
     case "table": {

--- a/packages/web/mdx-components.tsx
+++ b/packages/web/mdx-components.tsx
@@ -25,6 +25,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     // Headers and sponsors reuse the generic full-width image preview.
     HeaderPreview: ChartPreview,
     SponsorsPreview: ChartPreview,
+    ContributorsPreview: ChartPreview,
 
     // jalco-ui registry components
     CodeBlock,


### PR DESCRIPTION
## What

Adds a contrib.rocks-style **contributors image** — a grid of a repository's top contributors served from a single URL, styled with shadcn chrome and the same background system as headers and sponsors.

- **Core engine** — `getGitHubContributorsList()` provider (REST contributors API, paginated, ordered by contributions, bot tagging) and `handleContributors()` route for `/contributors/{owner}/{repo}.svg|png|json`. Reuses the avatar-grid renderer (added an `ariaLabel` override). Supports `limit`, `min`, `bots`, `names`, `size`, `width`, presets, themes, gradients, photo backgrounds; inlines avatars as base64, links each to its profile, and degrades to a calm card fallback (never a red error pill) with stale-cache fallback.
- **Generator** — `/contributors` page + builder with live preview and copy-as-Markdown/HTML/URL. Added to the nav **Generator** dropdown.
- **Studio** — `Contributors` block: model, factory, inspector, live canvas render, adaptive `<picture>` linked-image markdown serialization, and URL→state import round-trip.
- **Docs** — `/docs/contributors` provider page, sidebar entry, API reference section, and README Contributors section.

## Why

shieldcn already offers headers and sponsors images; contributors is the natural companion and a frequently requested contrib.rocks alternative.

## How

- New `handleContributors()` reuses the existing `renderSponsors()` grid via a single tier, keeping one render pipeline.
- The generator/Studio mirror the sponsors pattern (`*-builder-shared.ts`, inspector, canvas, import).

## Testing

- New `packages/core/src/badges/contributors-route.test.ts` — 7 cases (JSON ordering, bot exclude/include, `min` filter, inlined linked avatars + aria-label, missing-repo and empty-repo fallbacks, missing-args 400).
- Full core suite: **144 tests pass**.
- `tsc --noEmit` clean on `packages/core` and `packages/web`; eslint clean.
- Manually verified live: SVG (dark + light), PNG, and JSON endpoints; `/contributors` and `/docs/contributors` return 200; rendered image inspected visually in both modes with and without names.
