### PR TITLE
fix(sponsor): read maintainer sponsors via PERSONAL_SPONSOR_TOKEN

### DIFF
--- a/packages/web/app/sponsor/page.tsx
+++ b/packages/web/app/sponsor/page.tsx
@@ -138,12 +138,19 @@ const SPONSOR_WORDMARK: Record<string, { dark: string; light: string }> = {
   usenotra: { dark: "/sponsors/notra-wordmark-dark.svg", light: "/sponsors/notra-wordmark.svg" },
 }
 
-// Active GitHub Sponsors of jal-co (the authenticated viewer), via GraphQL.
+// Active GitHub Sponsors of the maintainer (the authenticated viewer), via
+// GraphQL. The query resolves against `viewer`, so the token MUST belong to the
+// sponsored account. Use a dedicated PERSONAL_SPONSOR_TOKEN (a maintainer
+// read:user token) so this stays independent of:
+//   - GITHUB_TOKEN, which on a shared deployment may be a pooled / different
+//     account's token whose `viewer` has no sponsors, and
+//   - SPONSORS_GITHUB_TOKEN, which the badge engine uses for the /sponsors
+//     image list — kept separate so neither can break the other.
 // Requires a token; without one the section renders empty. Every active sponsor
 // is returned; the top *recurring* tier is flagged `featured` (one-time gifts
 // never count as the "top monthly" sponsor).
 async function getSponsors(): Promise<GhSponsor[]> {
-  const token = process.env.GITHUB_TOKEN
+  const token = process.env.PERSONAL_SPONSOR_TOKEN || process.env.GITHUB_TOKEN
   if (!token) return []
   try {
     const res = await fetch("https://api.github.com/graphql", {


### PR DESCRIPTION
## What

The `/sponsor` page now reads the maintainer's active GitHub Sponsors using a dedicated `PERSONAL_SPONSOR_TOKEN`, falling back to `GITHUB_TOKEN`.

## Why

`getSponsors()` queries `viewer { sponsorshipsAsMaintainer }`, which resolves against **the token owner**. On the deployed environment `GITHUB_TOKEN` belongs to a pooled / different account whose `viewer` has no sponsorships, so the Monthly sponsors / Supporters sections rendered empty in production (they work locally only because the local token is the maintainer's).

Verified directly: with the maintainer token the query returns the 4 active sponsors; the data path and scopes are correct — the only issue is which account the production token authenticates as.

## How

- `const token = process.env.PERSONAL_SPONSOR_TOKEN || process.env.GITHUB_TOKEN`
- Kept intentionally separate from `SPONSORS_GITHUB_TOKEN` (used by the badge engine's `/sponsors` image list) so the two tokens can't break each other.
- `getStargazers()` is unchanged — it reads a fixed public repo, not `viewer`.

## Deploy step

Set **`PERSONAL_SPONSOR_TOKEN`** on the deployment to a maintainer token with the **`read:user`** scope. Existing `GITHUB_TOKEN` is left as-is for the badge engine.

## Testing

- `tsc --noEmit` clean on `packages/web`; eslint clean (pre-commit hook passed).
- Confirmed the live GraphQL query returns the maintainer's sponsors with a `read:user` token.
