### PR TITLE
fix(turbo): expose build-time env vars under strict env mode

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,25 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalEnv": [
+    "PERSONAL_SPONSOR_TOKEN",
+    "GITHUB_TOKEN",
+    "SPONSORS_GITHUB_TOKEN",
+    "DATABASE_URL",
+    "DATABASE_URL_UNPOOLED",
+    "POSTGRES_URL",
+    "POSTGRES_URL_NON_POOLING",
+    "POSTGRES_USER",
+    "POSTGRES_HOST",
+    "POSTGRES_PASSWORD",
+    "POSTGRES_DATABASE",
+    "PGUSER",
+    "PGPASSWORD",
+    "PGHOST",
+    "PGDATABASE",
+    "NEON_PROJECT_ID",
+    "UPSTASH_REDIS_REST_URL",
+    "UPSTASH_REDIS_REST_TOKEN"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## What

Declare server-side environment variables in `turbo.json` `globalEnv` so they're available during `turbo build`.

## Why

Turborepo 2.x defaults to **strict env mode**, which strips any undeclared variable from `process.env` for build tasks. The `/sponsor` page is statically prerendered and calls `getSponsors()` at **build time**, reading `PERSONAL_SPONSOR_TOKEN`. Because the var wasn't declared, it was `undefined` during prerender, so the page baked in an **empty sponsor list** in production — the "Monthly sponsors" section and the featured org sponsor never rendered.

Runtime serverless functions (badge engine, token pool) receive the full Vercel env regardless, which is why they were unaffected and masked the problem.

Vercel's build log surfaced this directly:
```
Warning - the following environment variables are set on your Vercel project,
but missing from "turbo.json" ... WILL NOT be available to your application
  - PERSONAL_SPONSOR_TOKEN
  - SPONSORS_GITHUB_TOKEN
  - POSTGRES_URL ...
```

## How

Add a `globalEnv` array covering the sponsor tokens, Postgres/Neon connection vars, and Upstash Redis vars used by server components and build-time data fetching.

## Testing

- Validated `turbo.json` parses.
- Deployed to Production and confirmed `/sponsor` now renders the "Monthly sponsors" section, the featured **usenotra** org wordmark, and all one-time supporter chips. Before this change the same deployment (with the token correctly set in Vercel) rendered an empty sponsors list.
