### PR TITLE
feat(charts): add GitHub commit-history charts

### DIFF
--- a/packages/core/src/badges/chart-route.test.ts
+++ b/packages/core/src/badges/chart-route.test.ts
@@ -28,6 +28,28 @@ function ghStub() {
   })
 }
 
+/**
+ * Stub the GitHub GraphQL API for commit-history charts: the first query asks
+ * for `createdAt`, subsequent batched queries alias monthly
+ * `contributionsCollection` windows (each gets a fixed count).
+ */
+function commitStub(createdAt: string, perWindow = 5) {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input)
+    if (url === "https://api.github.com/graphql" && init?.method === "POST") {
+      const query = JSON.parse(String(init.body)).query as string
+      if (query.includes("contributionsCollection")) {
+        const aliases = [...query.matchAll(/(w\d+):\s*contributionsCollection/g)].map((m) => m[1])
+        const user: Record<string, unknown> = {}
+        for (const a of aliases) user[a] = { totalCommitContributions: perWindow }
+        return new Response(JSON.stringify({ data: { user } }), { status: 200 })
+      }
+      return new Response(JSON.stringify({ data: { user: { createdAt } } }), { status: 200 })
+    }
+    return new Response("{}", { status: 200 })
+  })
+}
+
 describe("handleBadgeGET /chart", () => {
   const realFetch = globalThis.fetch
   beforeEach(() => { globalThis.fetch = ghStub() as unknown as typeof fetch })
@@ -75,5 +97,52 @@ describe("handleBadgeGET /chart", () => {
     const res = await handleBadgeGET(req, ["chart", "json.json"])
     const data = await res.json()
     expect(data.points.map((p: { value: number }) => p.value)).toEqual([5, 10, 15])
+  })
+
+  it("renders a lifetime commit-history SVG for one user", async () => {
+    globalThis.fetch = commitStub("2024-01-01T00:00:00Z") as unknown as typeof fetch
+    const req = new Request("https://x.dev/chart/github/commits/torvalds.svg?theme=green")
+    const res = await handleBadgeGET(req, ["chart", "github", "commits", "torvalds.svg"])
+    expect(res.status).toBe(200)
+    expect(res.headers.get("Content-Type")).toBe("image/svg+xml")
+    const svg = await res.text()
+    expect(svg.startsWith("<svg")).toBe(true)
+    expect(svg).toContain("torvalds")
+    expect(svg).toContain("commits")
+    expect(svg).not.toContain("NaN")
+  })
+
+  it("returns a cumulative commit series for .json", async () => {
+    globalThis.fetch = commitStub("2024-01-01T00:00:00Z") as unknown as typeof fetch
+    const req = new Request("https://x.dev/chart/github/commits/octocat.json")
+    const res = await handleBadgeGET(req, ["chart", "github", "commits", "octocat.json"])
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.login).toBe("octocat")
+    expect(data.total).toBeGreaterThan(0)
+    expect(Array.isArray(data.points)).toBe(true)
+    // Cumulative: the last point is the grand total, the first is the birth (0).
+    expect(data.points[0].value).toBe(0)
+    expect(data.points[data.points.length - 1].value).toBe(data.total)
+  })
+
+  it("compares several users on one chart", async () => {
+    globalThis.fetch = commitStub("2024-06-01T00:00:00Z") as unknown as typeof fetch
+    const req = new Request("https://x.dev/chart/github/commits/torvalds,gaearon.svg")
+    const res = await handleBadgeGET(req, ["chart", "github", "commits", "torvalds,gaearon.svg"])
+    expect(res.status).toBe(200)
+    const svg = await res.text()
+    expect(svg).toContain("torvalds")
+    expect(svg).toContain("gaearon")
+  })
+
+  it("supports aligned mode", async () => {
+    globalThis.fetch = commitStub("2024-01-01T00:00:00Z") as unknown as typeof fetch
+    const req = new Request("https://x.dev/chart/github/commits/sindresorhus.svg?align=true")
+    const res = await handleBadgeGET(req, ["chart", "github", "commits", "sindresorhus.svg"])
+    expect(res.status).toBe(200)
+    const svg = await res.text()
+    expect(svg).toContain("aligned")
+    expect(svg).not.toContain("NaN")
   })
 })

--- a/packages/core/src/providers/commit-history.ts
+++ b/packages/core/src/providers/commit-history.ts
@@ -1,0 +1,154 @@
+/**
+ * shieldcn
+ * src/providers/commit-history
+ *
+ * GitHub lifetime commit-history data provider. Builds a cumulative time series
+ * of a user's public commit contributions across their whole account lifetime —
+ * one satisfying, rising curve, the same data as the green contribution graph.
+ *
+ * A homage to (and directly inspired by) Peet von Zweigbergk's
+ * **commit-history** — "a star-history, but for commits":
+ *   https://github.com/peetzweg/commit-history
+ *
+ * Like that project, the numbers come from GitHub's GraphQL
+ * `user.contributionsCollection.totalCommitContributions`. A single collection
+ * spans at most a year, so a lifetime is sliced into monthly windows and the
+ * counts are accumulated. Windows are batched (a year of months per GraphQL
+ * query, aliased) to keep the request count low, distributed across the shared
+ * token pool, and cached with a last-known-good fallback — exactly like the
+ * star-history provider.
+ */
+
+import { githubGraphQL } from "./github"
+import { cachedFetchStale } from "../cache"
+
+/** A single point on a cumulative commit curve. */
+export interface CommitPoint {
+  /** ISO-8601 timestamp (window end). */
+  date: string
+  /** Cumulative public commits up to that moment. */
+  value: number
+}
+
+/** Resolved cumulative commit series for a user. */
+export interface CommitHistory {
+  login: string
+  /** Total public commits over the account's lifetime. */
+  total: number
+  /** ISO-8601 account creation timestamp. */
+  createdAt: string
+  /** Time-ordered cumulative points (first → last). */
+  points: CommitPoint[]
+}
+
+/** Hard cap on monthly windows (~25 years) — GitHub predates 2008 by nobody. */
+const MAX_WINDOWS = 300
+/** Monthly windows aliased into a single GraphQL query. */
+const WINDOW_BATCH = 12
+
+/** UTC month-start for a date. */
+function monthStart(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1))
+}
+
+/** Add `n` months to a UTC month-start date. */
+function addMonths(d: Date, n: number): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + n, 1))
+}
+
+/** Build the inclusive list of [from, to) monthly windows from birth → now. */
+function monthlyWindows(createdAt: Date, now: Date): Array<{ from: string; to: string }> {
+  const windows: Array<{ from: string; to: string }> = []
+  let cursor = monthStart(createdAt)
+  while (cursor.getTime() < now.getTime() && windows.length < MAX_WINDOWS) {
+    const next = addMonths(cursor, 1)
+    const to = next.getTime() < now.getTime() ? next : now
+    windows.push({ from: cursor.toISOString(), to: to.toISOString() })
+    cursor = next
+  }
+  return windows
+}
+
+/** Fetch the account creation timestamp, or null if the user doesn't exist. */
+async function fetchCreatedAt(login: string): Promise<string | null> {
+  const data = await githubGraphQL(
+    "query($login:String!){ user(login:$login){ createdAt } }",
+    { login },
+    60 * 60 * 24, // creation date is immutable — cache a day
+  )
+  const user = data?.user as { createdAt?: string } | null | undefined
+  return typeof user?.createdAt === "string" ? user.createdAt : null
+}
+
+/**
+ * Fetch totalCommitContributions for a batch of monthly windows in one query.
+ * Returns the per-window counts in order (0 for any window GitHub omits).
+ */
+async function fetchWindowBatch(
+  login: string,
+  windows: Array<{ from: string; to: string }>,
+): Promise<number[] | null> {
+  const fields = windows
+    .map(
+      (w, i) =>
+        `w${i}: contributionsCollection(from:"${w.from}",to:"${w.to}"){ totalCommitContributions }`,
+    )
+    .join("\n")
+  const query = `query($login:String!){ user(login:$login){ ${fields} } }`
+  const data = await githubGraphQL(query, { login }, 60 * 60 * 6)
+  const user = data?.user as Record<string, unknown> | null | undefined
+  if (!user) return null
+  return windows.map((_, i) => {
+    const node = user[`w${i}`] as { totalCommitContributions?: number } | undefined
+    return typeof node?.totalCommitContributions === "number" ? node.totalCommitContributions : 0
+  })
+}
+
+/** Uncached builder — see {@link getCommitHistory} for the cached entrypoint. */
+async function buildCommitHistory(login: string): Promise<CommitHistory | null> {
+  const createdAt = await fetchCreatedAt(login)
+  if (!createdAt) return null
+
+  const now = new Date()
+  const windows = monthlyWindows(new Date(createdAt), now)
+
+  // Brand-new account with no full month yet — flat baseline at zero.
+  if (windows.length === 0) {
+    return { login, total: 0, createdAt, points: [{ date: createdAt, value: 0 }] }
+  }
+
+  // Batch the monthly windows (a year per query) and fetch in parallel.
+  const batches: Array<Array<{ from: string; to: string }>> = []
+  for (let i = 0; i < windows.length; i += WINDOW_BATCH) {
+    batches.push(windows.slice(i, i + WINDOW_BATCH))
+  }
+  const results = await Promise.all(batches.map((b) => fetchWindowBatch(login, b)))
+  if (results.some((r) => r === null)) return null
+
+  const counts = results.flat() as number[]
+
+  // Accumulate. Start the curve at account birth (value 0), then a cumulative
+  // point at each window end.
+  const points: CommitPoint[] = [{ date: createdAt, value: 0 }]
+  let cumulative = 0
+  windows.forEach((w, i) => {
+    cumulative += counts[i] ?? 0
+    points.push({ date: w.to, value: cumulative })
+  })
+
+  return { login, total: cumulative, createdAt, points }
+}
+
+/**
+ * Cached lifetime commit-history series with last-known-good fallback. Returns
+ * null when the user can't be resolved and there's no prior good value.
+ */
+export async function getCommitHistory(login: string): Promise<CommitHistory | null> {
+  return cachedFetchStale(
+    "github",
+    `commithistory/${login}`,
+    () => buildCommitHistory(login),
+    60 * 60 * 6, // fresh 6h — past months are immutable, only the trailing month moves
+    60 * 60 * 24 * 30, // 30-day last-known-good
+  )
+}

--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -94,7 +94,7 @@ async function githubJson(url: string, revalidate?: number): Promise<Record<stri
  * which arrive as HTTP 200 with an `errors` array) so callers fall back to the
  * last-known-good cache instead of rendering a red badge.
  */
-async function githubGraphQL(
+export async function githubGraphQL(
   query: string,
   variables: Record<string, unknown>,
   revalidate: number = 3600,

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -12,6 +12,7 @@ import { renderHeader, type HeaderLogoInput } from "./badges/render-header"
 import { renderSponsors, type SponsorAvatar, type SponsorTier } from "./badges/render-sponsors"
 import { resolveHeaderBackground } from "./badges/header-backgrounds"
 import { getStarHistory, getIssueHistory } from "./providers/starhistory"
+import { getCommitHistory, type CommitHistory } from "./providers/commit-history"
 import { getNpmDownloadSeries } from "./providers/npm"
 import { formatCount } from "./format"
 import { JSONPath } from "jsonpath-plus"
@@ -1870,7 +1871,6 @@ async function handleChart(
   const width = clampNum(searchParams.get("width"), 200, 2000, 800)
   const height = clampNum(searchParams.get("height"), 120, 1200, 400)
   const areaParam = searchParams.get("area")
-  const area = areaParam !== "false" && areaParam !== "0"
   const accent = resolveAccent(searchParams.get("theme"), searchParams.get("color"))
   const fillParam = resolveColor(searchParams.get("fill"))
   const fill = fillParam ? `#${fillParam}` : undefined
@@ -1957,9 +1957,20 @@ async function handleChart(
   }
   const titleIconColor = iconColorParam ? `#${iconColorParam}` : undefined
 
-  const series: ChartSeries[] = [
-    { label: resolved.seriesLabel, points: resolved.points, color: accent, fill },
-  ]
+  // Area fill defaults on for a single line, off when comparing multiple
+  // series (overlapping fills get muddy) — an explicit ?area= always wins.
+  const isCompare = !!(resolved.multiSeries && resolved.multiSeries.length > 1)
+  const area = areaParam !== null ? areaParam !== "false" && areaParam !== "0" : !isCompare
+
+  const series: ChartSeries[] =
+    resolved.multiSeries && resolved.multiSeries.length
+      ? resolved.multiSeries.map((s, i) => ({
+          label: s.label,
+          points: s.points,
+          color: i === 0 ? accent : COMPARE_PALETTE[(i - 1) % COMPARE_PALETTE.length],
+          fill: i === 0 ? fill : undefined,
+        }))
+      : [{ label: resolved.seriesLabel, points: resolved.points, color: accent, fill }]
   const svg = renderChart({
     title: searchParams.get("title") || resolved.title,
     subtitle: resolved.subtitle,
@@ -2867,6 +2878,38 @@ interface ChartOk {
   link?: string
   points: ChartPoint[]
   json: unknown
+  /**
+   * Optional multi-series payload (e.g. comparing several users' commit
+   * histories on one chart). When present, `handleChart` renders one line per
+   * entry with palette colors; `points` carries the first series for callers
+   * (like the .json output) that only read a single series.
+   */
+  multiSeries?: Array<{ label: string; points: ChartPoint[] }>
+}
+
+/**
+ * Distinct accent colors for multi-series charts (the first series still uses
+ * the resolved `theme`/`color` accent; the rest cycle through this palette).
+ */
+const COMPARE_PALETTE = [
+  "#f59e0b", // amber-500
+  "#10b981", // emerald-500
+  "#ec4899", // pink-500
+  "#8b5cf6", // violet-500
+  "#06b6d4", // cyan-500
+  "#ef4444", // red-500
+  "#84cc16", // lime-500
+  "#f97316", // orange-500
+]
+
+/**
+ * Re-index a series onto a "month zero" axis: strip dates so the chart uses an
+ * evenly spaced index axis, and label each point by its month offset. Used by
+ * the commit-history `align` mode so users who joined at different times line
+ * up at their own account birth (a homage to commit-history's Aligned view).
+ */
+function alignByIndex(points: ChartPoint[]): ChartPoint[] {
+  return points.map((p, i) => ({ value: p.value, label: String(i) }))
 }
 type ChartResolved = ChartOk | { ok: false; status: number; msg: string }
 
@@ -2895,6 +2938,62 @@ async function resolveChartData(
   searchParams: URLSearchParams,
 ): Promise<ChartResolved> {
   const provider = rest[0]
+
+  // --- GitHub lifetime commit history (homage to peetzweg/commit-history) ---
+  if (provider === "commits" || (provider === "github" && rest[1] === "commits")) {
+    const raw = provider === "commits" ? rest[1] : rest[2]
+    if (!raw) {
+      return { ok: false, status: 400, msg: "usage: /chart/github/commits/{user}.svg" }
+    }
+    // Comma-separated logins → compare several users on one chart.
+    const logins = decodeURIComponent(raw)
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .slice(0, 6)
+    if (logins.length === 0) {
+      return { ok: false, status: 400, msg: "usage: /chart/github/commits/{user}.svg" }
+    }
+    const align = ["1", "true", "yes"].includes((searchParams.get("align") || "").toLowerCase())
+
+    const histories = await Promise.all(logins.map((l) => getCommitHistory(l)))
+    const ok = histories.filter((h): h is CommitHistory => h !== null)
+    if (ok.length === 0) {
+      return { ok: false, status: 404, msg: `could not load commit history for ${logins.join(", ")}` }
+    }
+
+    const toPoints = (h: CommitHistory): ChartPoint[] =>
+      align ? alignByIndex(h.points) : h.points.map((p) => ({ value: p.value, date: p.date }))
+
+    // Single user → single series with a title, subtitle, and repo link.
+    if (ok.length === 1) {
+      const h = ok[0]
+      return {
+        ok: true,
+        provider: "github",
+        kind: "commits",
+        title: h.login,
+        subtitle: `${formatCountSafe(h.total)} commits${align ? " · aligned" : ""}`,
+        seriesLabel: h.login,
+        link: `https://github.com/${h.login}`,
+        points: toPoints(h),
+        json: h,
+      }
+    }
+
+    // Multiple users → one line each (the legend shows the names).
+    const multiSeries = ok.map((h) => ({ label: h.login, points: toPoints(h) }))
+    return {
+      ok: true,
+      provider: "github",
+      kind: "commits",
+      title: align ? "Commits since account creation" : "Commit history",
+      seriesLabel: ok[0].login,
+      points: multiSeries[0].points,
+      multiSeries,
+      json: { aligned: align, users: ok },
+    }
+  }
 
   // --- GitHub stars / issues over time ---
   if (provider === "github" || provider === "stars" || provider === "issues") {
@@ -3095,8 +3194,9 @@ async function handleBadgeGETInner(
   }
 
   // ---------------------------------------------------------------------------
-  // Charts: /chart/github/stars/{owner}/{repo}.svg
-  // Renders a shadcn-styled star-history line/area chart.
+  // Charts: /chart/github/{stars|issues}/{owner}/{repo}.svg,
+  // /chart/github/commits/{user}.svg, /chart/npm/{package}.svg, /chart/json.svg
+  // Renders a shadcn-styled line/area chart.
   // ---------------------------------------------------------------------------
   if (cleanSegments[0] === "chart") {
     return handleChart(cleanSegments, searchParams, format, options)

--- a/packages/web/components/chart-sandbox.tsx
+++ b/packages/web/components/chart-sandbox.tsx
@@ -23,7 +23,7 @@ import { LogoPicker } from "@/components/logo-picker"
 // Types
 // ---------------------------------------------------------------------------
 
-type ChartKind = "stars" | "issues" | "npm" | "json"
+type ChartKind = "stars" | "issues" | "commits" | "npm" | "json"
 
 interface ChartSandboxProps {
   /** Initial chart kind. */
@@ -47,6 +47,8 @@ export function ChartSandbox({ kind: initialKind = "stars", defaults = {} }: Cha
   // Data inputs (interpretation depends on kind).
   const [owner, setOwner] = useState(defaults.owner ?? "vercel")
   const [repo, setRepo] = useState(defaults.repo ?? "next.js")
+  const [user, setUser] = useState(defaults.user ?? "torvalds")
+  const [aligned, setAligned] = useState(false)
   const [pkg, setPkg] = useState(defaults.package ?? "zod")
   const [values, setValues] = useState(defaults.values ?? "10,25,40,30,60,55,80")
   const [dataLabel, setDataLabel] = useState(defaults.label ?? "")
@@ -94,6 +96,7 @@ export function ChartSandbox({ kind: initialKind = "stars", defaults = {} }: Cha
     switch (kind) {
       case "stars": return "/chart/github/stars/:owner/:repo.svg"
       case "issues": return "/chart/github/issues/:owner/:repo.svg"
+      case "commits": return "/chart/github/commits/:user.svg"
       case "npm": return "/chart/npm/:package.svg"
       case "json": return "/chart/json.svg?values=…"
     }
@@ -105,6 +108,10 @@ export function ChartSandbox({ kind: initialKind = "stars", defaults = {} }: Cha
     if (kind === "stars" || kind === "issues") {
       if (!owner || !repo) return null
       path = `/chart/github/${kind}/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}${ext}`
+    } else if (kind === "commits") {
+      const users = user.split(",").map(u => u.trim()).filter(Boolean)
+      if (users.length === 0) return null
+      path = `/chart/github/commits/${users.map(encodeURIComponent).join(",")}${ext}`
     } else if (kind === "npm") {
       if (!pkg) return null
       // Scoped packages keep their slash.
@@ -121,6 +128,7 @@ export function ChartSandbox({ kind: initialKind = "stars", defaults = {} }: Cha
       qp.set("values", cleaned)
       if (dataLabel) qp.set("label", dataLabel)
     }
+    if (kind === "commits" && aligned) qp.set("align", "true")
     if (kind === "npm" && days && days !== "365") qp.set("days", days)
     if (mode !== "dark") qp.set("mode", mode)
     if (theme && theme !== "_none") qp.set("theme", theme)
@@ -143,7 +151,7 @@ export function ChartSandbox({ kind: initialKind = "stars", defaults = {} }: Cha
 
     const qs = qp.toString()
     return `${baseUrl}${path}${qs ? `?${qs}` : ""}`
-  }, [kind, imageFormat, owner, repo, pkg, values, dataLabel, days, mode, theme, font, color, fill, area, transparent, border, logo, width, height, title, icon, yScale, yMin, yMax, yTicks, xTicks, baseUrl])
+  }, [kind, imageFormat, owner, repo, user, aligned, pkg, values, dataLabel, days, mode, theme, font, color, fill, area, transparent, border, logo, width, height, title, icon, yScale, yMin, yMax, yTicks, xTicks, baseUrl])
 
   const formattedOutput = useMemo(() => {
     if (!builtUrl) return ""
@@ -181,6 +189,7 @@ export function ChartSandbox({ kind: initialKind = "stars", defaults = {} }: Cha
               <SelectContent>
                 <SelectItem value="stars">GitHub stars</SelectItem>
                 <SelectItem value="issues">GitHub issues</SelectItem>
+                <SelectItem value="commits">GitHub commits</SelectItem>
                 <SelectItem value="npm">npm downloads</SelectItem>
                 <SelectItem value="json">Inline JSON</SelectItem>
               </SelectContent>
@@ -194,6 +203,20 @@ export function ChartSandbox({ kind: initialKind = "stars", defaults = {} }: Cha
               </SField>
               <SField label="repo">
                 <Input id={`${id}-repo`} value={repo} onChange={e => setRepo(e.target.value)} placeholder="next.js" />
+              </SField>
+            </>
+          )}
+
+          {kind === "commits" && (
+            <>
+              <SField label="user">
+                <Input id={`${id}-user`} value={user} onChange={e => setUser(e.target.value)} placeholder="torvalds or torvalds,gaearon" />
+              </SField>
+              <SField label="aligned">
+                <label className="flex items-center gap-1.5 text-xs cursor-pointer pt-2.5">
+                  <Checkbox aria-label="Align users at account birth" checked={aligned} onCheckedChange={v => setAligned(v === true)} />
+                  <span className="font-mono text-muted-foreground">line up at month zero</span>
+                </label>
               </SField>
             </>
           )}

--- a/packages/web/components/home-charts.tsx
+++ b/packages/web/components/home-charts.tsx
@@ -12,7 +12,7 @@ function useHydrated() {
 
 const CHARTS: { src: string; alt: string }[] = [
   { src: "/chart/github/stars/vercel/next.js.svg?theme=blue", alt: "GitHub star history" },
-  { src: "/chart/npm/zod.svg?theme=emerald", alt: "npm weekly downloads" },
+  { src: "/chart/github/commits/torvalds.svg?theme=green", alt: "GitHub lifetime commit history" },
 ]
 
 export function HomeCharts() {
@@ -25,8 +25,8 @@ export function HomeCharts() {
         <div className="max-w-lg">
           <h2 className="text-2xl font-bold tracking-tight sm:text-3xl">Charts, too</h2>
           <p className="mt-3 text-pretty text-muted-foreground">
-            Shadcn-styled star history, issues over time, npm downloads, and your own JSON
-            data — portable SVGs, no JavaScript.
+            Shadcn-styled star history, lifetime commit history, issues over time, npm
+            downloads, and your own JSON data — portable SVGs, no JavaScript.
           </p>
         </div>
         <Link

--- a/packages/web/components/studio/inspectors.tsx
+++ b/packages/web/components/studio/inspectors.tsx
@@ -1127,6 +1127,7 @@ export function ChartInspector({ block, onChange }: { block: ChartBlock; onChang
           <SelectContent>
             <SelectItem value="stars">GitHub stars</SelectItem>
             <SelectItem value="issues">GitHub issues</SelectItem>
+            <SelectItem value="commits">GitHub commits</SelectItem>
             <SelectItem value="npm">npm downloads</SelectItem>
             <SelectItem value="json">Inline JSON</SelectItem>
           </SelectContent>
@@ -1138,6 +1139,13 @@ export function ChartInspector({ block, onChange }: { block: ChartBlock; onChang
           <Field label="Owner"><Input value={s.owner} onChange={e => set({ owner: e.target.value })} placeholder="vercel" /></Field>
           <Field label="Repo"><Input value={s.repo} onChange={e => set({ repo: e.target.value })} placeholder="next.js" /></Field>
         </Row>
+      ) : null}
+
+      {s.kind === "commits" ? (
+        <>
+          <Field label="User(s)"><Input value={s.user} onChange={e => set({ user: e.target.value })} placeholder="torvalds or torvalds,gaearon" /></Field>
+          <ToggleField label="Aligned (line up at account birth)" checked={s.aligned} onCheckedChange={v => set({ aligned: v })} />
+        </>
       ) : null}
 
       {s.kind === "npm" ? (

--- a/packages/web/content/docs/charts/index.mdx
+++ b/packages/web/content/docs/charts/index.mdx
@@ -1,12 +1,14 @@
 ---
 title: Charts
-description: Shadcn-styled graphs for GitHub stars, GitHub issues, npm downloads, and your own JSON data — rendered as portable SVGs.
+description: Shadcn-styled graphs for GitHub stars, GitHub issues, lifetime commit history, npm downloads, and your own JSON data — rendered as portable SVGs.
 ---
 
 Shadcn-styled line/area charts you can drop in a README, docs site, or anywhere
-an image works — plain SVG, no JavaScript, no iframe. Four kinds: GitHub star
+an image works — plain SVG, no JavaScript, no iframe. Five kinds: GitHub star
 history (like [starcharts](https://github.com/caarlos0/starcharts)), GitHub
-issues over time, npm downloads, and arbitrary JSON.
+issues over time, lifetime commit history (a homage to
+[commit-history](https://github.com/peetzweg/commit-history)), npm downloads,
+and arbitrary JSON.
 
 <ChartPreview
   src="/chart/github/stars/vercel/next.js.svg"
@@ -24,6 +26,8 @@ Pick a chart kind, tweak the styling, and copy the URL or markdown.
 ```
 /chart/github/stars/{owner}/{repo}.svg     → GitHub star history
 /chart/github/issues/{owner}/{repo}.svg    → GitHub issues over time
+/chart/github/commits/{user}.svg            → lifetime commit history
+/chart/github/commits/{user1},{user2}.svg   → compare users
 /chart/npm/{package}.svg                    → npm weekly downloads
 /chart/json.svg?values=1,2,3                → inline JSON data
 /chart/json.svg?url=...&query=...           → remote JSON data
@@ -70,6 +74,49 @@ excluded).
   src="/chart/github/issues/honojs/hono.svg?theme=rose"
   alt="honojs/hono issues over time"
   description="Issues opened over time"
+/>
+
+## GitHub commits over time
+
+A whole coding career as one rising curve — every public commit since the
+account was born, accumulated month by month (the same data as the green
+contribution graph, not the noisy issues/PRs calendar). This is a loving homage
+to [**commit-history**](https://github.com/peetzweg/commit-history) by
+[Peet von Zweigbergk](https://github.com/peetzweg) — "a
+[star-history](https://www.star-history.com), but for commits".
+
+```
+/chart/github/commits/{user}.svg
+```
+
+<ChartPreview
+  src="/chart/github/commits/torvalds.svg?theme=green"
+  alt="torvalds lifetime commit history"
+  description="Lifetime public commits, accumulated month by month"
+/>
+
+### Compare users
+
+Pass comma-separated logins to race several trajectories on one chart.
+
+```
+/chart/github/commits/{user1},{user2},{user3}.svg
+```
+
+<ChartPreview
+  src="/chart/github/commits/gaearon,sindresorhus.svg"
+  alt="gaearon vs sindresorhus commit history"
+  description="Comma-separated logins compare users on one chart"
+/>
+
+Add `?align=true` for **aligned** mode — every user lines up at "month zero"
+(their own account birth) regardless of when they actually joined, so you're
+comparing trajectories rather than calendar dates.
+
+<ChartPreview
+  src="/chart/github/commits/gaearon,sindresorhus.svg?align=true&theme=violet"
+  alt="aligned commit history comparison"
+  description="Aligned mode — everyone starts at their own month zero"
 />
 
 ## npm downloads
@@ -136,6 +183,7 @@ selects the value array; optional `dateQuery` selects a parallel date array.
 | `width` | 200–2000 | `800` | Chart width in px |
 | `height` | 120–1200 | `400` | Chart height in px |
 | `title` | string | per kind | Override the chart title |
+| `align` | `true`, `false` | `false` | Commit charts: line users up at their account birth (month zero) |
 | `days` | 30–540 | `365` | npm download window |
 | `values` | comma numbers | — | Inline JSON data points |
 | `dates` | comma dates | — | Inline JSON x-axis dates |
@@ -162,12 +210,24 @@ Requests are distributed across the donated [token pool](/token-pool) and
 cached with a 6-hour fresh window plus a 30-day last-known-good fallback, so a
 transient rate limit never collapses the chart.
 
+## How commit history works
+
+The commit curve is a homage to [commit-history](https://github.com/peetzweg/commit-history),
+and works the same way it does. GitHub's GraphQL
+`user.contributionsCollection.totalCommitContributions` returns the public
+commit count for a window of at most a year, so a lifetime is sliced into
+**monthly windows** — batched a year at a time into aliased queries — then the
+counts are accumulated into the rising curve. Only public commits are counted.
+Like the star data, requests go through the donated [token pool](/token-pool)
+with a 6-hour fresh window and a 30-day last-known-good fallback.
+
 ## Data sources
 
 | Chart | Source | Cache |
 |-------|--------|-------|
 | Stars | [GitHub Stargazers API](https://docs.github.com/en/rest/activity/starring) | 6h fresh · 30d last-known-good |
 | Issues | [GitHub Search API](https://docs.github.com/en/rest/search) (`type:issue`) | 6h fresh · 30d last-known-good |
+| Commits | [GitHub GraphQL API](https://docs.github.com/en/graphql) (`contributionsCollection`) | 6h fresh · 30d last-known-good |
 | npm | [npm downloads API](https://github.com/npm/registry/blob/main/docs/download-counts.md) | 1h |
 | JSON | inline, or your `url` | 5m (remote) |
 

--- a/packages/web/lib/studio-import.ts
+++ b/packages/web/lib/studio-import.ts
@@ -164,6 +164,11 @@ function chartStateFromUrl(u: URL): ChartState {
     s.kind = rest[1]
     s.owner = decodeURIComponent(rest[2] || "")
     s.repo = decodeURIComponent((rest[3] || "").replace(/\.(svg|png)$/i, ""))
+  } else if ((rest[0] === "github" && rest[1] === "commits") || rest[0] === "commits") {
+    s.kind = "commits"
+    const raw = (rest[0] === "commits" ? rest[1] : rest[2]) || ""
+    s.user = decodeURIComponent(raw.replace(/\.(svg|png)$/i, ""))
+    s.aligned = ["1", "true", "yes"].includes((q.get("align") || "").toLowerCase())
   } else if (rest[0] === "npm") {
     s.kind = "npm"
     s.package = decodeURIComponent(rest.slice(1).join("/").replace(/\.(svg|png)$/i, ""))

--- a/packages/web/lib/studio-shared.ts
+++ b/packages/web/lib/studio-shared.ts
@@ -36,12 +36,16 @@ import {
 // serializable object, so we model it here and mirror the sandbox URL builder).
 // ---------------------------------------------------------------------------
 
-export type ChartKind = "stars" | "issues" | "npm" | "json"
+export type ChartKind = "stars" | "issues" | "commits" | "npm" | "json"
 
 export interface ChartState {
   kind: ChartKind
   owner: string
   repo: string
+  /** GitHub user(s) for commit history — comma-separated to compare. */
+  user: string
+  /** Commit-history aligned mode: line users up at their account birth. */
+  aligned: boolean
   package: string
   values: string
   dataLabel: string
@@ -66,6 +70,8 @@ export const CHART_DEFAULTS: ChartState = {
   kind: "stars",
   owner: "vercel",
   repo: "next.js",
+  user: "torvalds",
+  aligned: false,
   package: "zod",
   values: "10,25,40,30,60,55,80",
   dataLabel: "",
@@ -102,6 +108,10 @@ export function buildChartUrl(s: ChartState, baseUrl: string): string | null {
   if (s.kind === "stars" || s.kind === "issues") {
     if (!s.owner || !s.repo) return null
     path = `/chart/github/${s.kind}/${encodeURIComponent(s.owner)}/${encodeURIComponent(s.repo)}${ext}`
+  } else if (s.kind === "commits") {
+    const users = s.user.split(",").map(u => u.trim()).filter(Boolean)
+    if (users.length === 0) return null
+    path = `/chart/github/commits/${users.map(encodeURIComponent).join(",")}${ext}`
   } else if (s.kind === "npm") {
     if (!s.package) return null
     const encoded = s.package.split("/").map(encodeURIComponent).join("/")
@@ -117,6 +127,7 @@ export function buildChartUrl(s: ChartState, baseUrl: string): string | null {
     qp.set("values", cleaned)
     if (s.dataLabel) qp.set("label", s.dataLabel)
   }
+  if (s.kind === "commits" && s.aligned) qp.set("align", "true")
   if (s.kind === "npm" && s.days && s.days !== "365") qp.set("days", s.days)
   if (s.mode !== "dark") qp.set("mode", s.mode)
   if (s.theme && s.theme !== "_none") qp.set("theme", s.theme)


### PR DESCRIPTION
## What

Adds a new `commits` chart kind — a user's **lifetime public commit curve**, accumulated month by month — consolidated into the existing chart engine as a graph type (not a separate renderer).

```
/chart/github/commits/{user}.svg              → single lifetime curve
/chart/github/commits/{user1},{user2}.svg     → compare users on one chart
/chart/github/commits/{users}.svg?align=true  → aligned mode (everyone at month zero)
```

Serves `.svg`, `.png`, and `.json`, and honors every existing chart param (`theme`, `color`, `mode`, `font`, `width`, `bg`, …).

A loving homage to **[peetzweg/commit-history](https://github.com/peetzweg/commit-history)** — "a star-history, but for commits" — credited in the provider header, the docs page, and this PR.

## Why

The chart engine already did stars / issues / npm / JSON. Commit history is the natural next graph type, and folding it into the same `resolve() → render` pipeline keeps one code path instead of a bespoke renderer.

## How

- **`providers/commit-history.ts`** (new) — fetches `user.contributionsCollection.totalCommitContributions` over monthly windows (batched a year per GraphQL query, aliased), accumulates into a rising curve. Token-pool distributed, 6h fresh + 30d last-known-good cache.
- **`route-handler.ts`** — `commits` resolver; multi-series support added to `ChartOk`/`handleChart`; compare color palette; `alignByIndex()` month-zero transform; area-fill defaults off when comparing.
- **`providers/github.ts`** — exported the existing `githubGraphQL` helper for reuse.
- Web: chart sandbox, studio inspector, studio URL import, docs charts page, and the landing showcase all updated.

## Testing

- 4 new core tests (single / `.json` / compare / aligned) — **all 154 core tests pass**.
- `tsc --noEmit` clean for `@shieldcn/core` and `@shieldcn/web`; eslint clean (pre-commit hooks passed).
- Smoke-tested live against real GitHub data via `pnpm dev:web`:
  - `octocat.json` → born 2011-01-25, 187 monthly points, cumulative `0 → 16`, last point == `total` ✅
  - compare renders both legend names; dark + `mode=light` both 200.

## Screenshots (if UI change)

Live SVGs rendered from real data during testing — single-user (`torvalds`, green), compare (`gaearon,sindresorhus`), and aligned mode all return valid `image/svg+xml`. New "GitHub commits" option appears in the docs chart builder, the studio chart inspector, and the landing "Charts, too" showcase.
