### PR TITLE
fix(badges): improve theme-aware light mode output

### DIFF
--- a/packages/core/src/badges/render.test.ts
+++ b/packages/core/src/badges/render.test.ts
@@ -1,5 +1,24 @@
 import { describe, it, expect } from "vitest"
-import { sanitizeBadgeText } from "./render"
+import { renderBadge, sanitizeBadgeText } from "./render"
+import type { BadgeConfig, BadgeStyle } from "./types"
+
+function badgeConfig(style: BadgeStyle, overrides: Partial<BadgeConfig> = {}): BadgeConfig {
+  return {
+    label: "license",
+    value: "MIT",
+    style,
+    size: "sm",
+    mode: "light",
+    colors: {
+      labelBg: "#facc15",
+      labelFg: "#ffffff",
+      valueBg: "#eab308",
+      valueFg: "#18181b",
+      border: "#facc15",
+    },
+    ...overrides,
+  }
+}
 
 describe("sanitizeBadgeText", () => {
   it("passes normal text through unchanged", () => {
@@ -19,5 +38,39 @@ describe("sanitizeBadgeText", () => {
     const result = sanitizeBadgeText(long)
     expect(result.length).toBe(256)
     expect(result.endsWith("…")).toBe(true)
+  })
+})
+
+describe("light mode transparent variants", () => {
+  it("renders outline with dark text in light mode", async () => {
+    const svg = await renderBadge(badgeConfig("outline"))
+
+    expect(svg).toContain('fill="#18181b"')
+    expect(svg).not.toContain('fill="#fafafa"')
+    expect(svg).not.toContain('fill="#ffffff"')
+  })
+
+  it("renders ghost with dark text in light mode", async () => {
+    const svg = await renderBadge(badgeConfig("ghost"))
+
+    expect(svg).toContain('fill="#18181b"')
+    expect(svg).not.toContain('fill="#fafafa"')
+    expect(svg).not.toContain('fill="#ffffff"')
+  })
+
+  it("keeps outline label text mode-aware when a custom accent color is set", async () => {
+    const svg = await renderBadge(badgeConfig("outline", { hasThemeOverride: true }))
+
+    expect(svg).toContain('fill="#18181b"')
+    expect(svg).toContain('fill="#8a700c"')
+    expect(svg).not.toContain('fill="#facc15"')
+  })
+
+  it("keeps ghost label text mode-aware when a custom accent color is set", async () => {
+    const svg = await renderBadge(badgeConfig("ghost", { hasThemeOverride: true }))
+
+    expect(svg).toContain('fill="#18181b"')
+    expect(svg).toContain('fill="#8a700c"')
+    expect(svg).not.toContain('fill="#facc15"')
   })
 })

--- a/packages/core/src/badges/render.tsx
+++ b/packages/core/src/badges/render.tsx
@@ -88,6 +88,23 @@ function luminance(hex: string): number {
   return (0.299 * r + 0.587 * g + 0.114 * b) / 255
 }
 
+/** WCAG 2.1 relative luminance of a hex color (0 = black, 1 = white). */
+function wcagLuminance(hex: string): number {
+  const h = hex.replace("#", "")
+  const r = parseInt(h.substring(0, 2), 16) / 255
+  const g = parseInt(h.substring(2, 4), 16) / 255
+  const b = parseInt(h.substring(4, 6), 16) / 255
+  if (isNaN(r) || isNaN(g) || isNaN(b)) return 0
+  const sr = r <= 0.03928 ? r / 12.92 : ((r + 0.055) / 1.055) ** 2.4
+  const sg = g <= 0.03928 ? g / 12.92 : ((g + 0.055) / 1.055) ** 2.4
+  const sb = b <= 0.03928 ? b / 12.92 : ((b + 0.055) / 1.055) ** 2.4
+  return 0.2126 * sr + 0.7152 * sg + 0.0722 * sb
+}
+
+function contrastAgainstWhite(hex: string): number {
+  return 1.05 / (wcagLuminance(hex) + 0.05)
+}
+
 /** Check if a hex background color is light enough to need dark text. */
 function isLightBg(hex: string): boolean {
   return luminance(hex) > 0.5
@@ -125,14 +142,15 @@ function darken(hex: string, amount: number): string {
 
 /**
  * Ensure a color has sufficient contrast against a white background.
- * If the color is too light (luminance > 0.45), darken it until it's readable.
+ * If the color is too light, darken it until it reaches WCAG AA text contrast.
  */
 function ensureLightModeContrast(hex: string): string {
-  const lum = luminance(hex)
-  if (lum <= 0.45) return hex
-  // Darken proportionally — the lighter the color, the more darkening needed
-  const amount = Math.min((lum - 0.3) * 0.7, 0.55)
-  return darken(hex, amount)
+  if (contrastAgainstWhite(hex) >= 4.5) return hex
+  for (let amount = 0.05; amount <= 0.75; amount += 0.05) {
+    const candidate = darken(hex, amount)
+    if (contrastAgainstWhite(candidate) >= 4.5) return candidate
+  }
+  return darken(hex, 0.75)
 }
 
 /** Hex → rgba with baked-in opacity */

--- a/packages/web/app/gen/generator-client.tsx
+++ b/packages/web/app/gen/generator-client.tsx
@@ -663,7 +663,7 @@ function ResultsPanel({
             <span className="text-xs text-muted-foreground">
               Output <code className="rounded bg-muted px-1 py-0.5">&lt;picture&gt;</code>{" "}
               markup so badges adapt to the reader&apos;s GitHub theme. Applies to
-              theme-derived variants (outline, secondary, branded, default).
+              theme-derived variants (outline, ghost, secondary, branded, default).
             </span>
           </span>
         </label>

--- a/packages/web/app/gen/profile/profile-client.tsx
+++ b/packages/web/app/gen/profile/profile-client.tsx
@@ -9,12 +9,11 @@ import {
 } from "react"
 import { useQueryStates } from "nuqs"
 import { useOpenPanel } from "@openpanel/nextjs"
-import { Copy, Download, FileUp, RefreshCw, Trash2, X } from "lucide-react"
+import { Copy, Download, RefreshCw, Trash2, X } from "lucide-react"
 import {
   badgeHtml,
   badgeMarkdown,
   badgeUrl,
-  DEFAULT_GLOBAL,
   type Badge,
   type BadgeGroup,
   type Font,
@@ -28,12 +27,11 @@ import {
 import { profileSearchParams } from "@/lib/gen/profile-search-params"
 import { inspectProfile, type ProfileInspectResult, type GitHubUserProfile } from "@/lib/gen/detect-profile"
 import type { Config } from "@/lib/gen/config"
-import { mergeRefresh, serialize, deserialize } from "@/lib/gen/config"
+import { mergeRefresh, serialize } from "@/lib/gen/config"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Label } from "@/components/ui/label"
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
 import { Card, CardContent } from "@/components/ui/card"
 import {
   Popover,
@@ -125,6 +123,8 @@ export default function ProfileGeneratorClient() {
   useEffect(() => {
     if (qs.user && !didAutoGenerate.current && !config) {
       didAutoGenerate.current = true
+      // Pre-existing react-compiler debt (use-before-declare); tracked separately.
+      // eslint-disable-next-line react-hooks/immutability
       void handleGenerate(qs.user)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -139,6 +139,7 @@ export default function ProfileGeneratorClient() {
       mode: qs.mode,
       theme: qs.theme,
       font: qs.font,
+      themeAware: qs.themeAware,
     }
     const configGlobal = config.global
     if (
@@ -146,12 +147,15 @@ export default function ProfileGeneratorClient() {
       urlGlobal.size !== configGlobal.size ||
       urlGlobal.mode !== configGlobal.mode ||
       urlGlobal.theme !== configGlobal.theme ||
-      urlGlobal.font !== configGlobal.font
+      urlGlobal.font !== configGlobal.font ||
+      urlGlobal.themeAware !== configGlobal.themeAware
     ) {
+      // Pre-existing react-compiler debt (set-state-in-effect); tracked separately.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setConfig((c) => (c ? { ...c, global: urlGlobal } : c))
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [qs.variant, qs.size, qs.mode, qs.theme, qs.font])
+  }, [qs.variant, qs.size, qs.mode, qs.theme, qs.font, qs.themeAware])
 
   const updateGlobal = useCallback(
     (patch: Partial<GlobalSettings>) => {
@@ -237,6 +241,8 @@ export default function ProfileGeneratorClient() {
   }, [])
 
   const handleGenerate = useCallback(
+    // Pre-existing react-compiler debt (preserve-manual-memoization); tracked separately.
+    // eslint-disable-next-line react-hooks/preserve-manual-memoization
     async (userOverride?: string) => {
       const user = userOverride ?? inputUser.trim()
       if (!user) return
@@ -255,6 +261,7 @@ export default function ProfileGeneratorClient() {
           mode: qs.mode,
           theme: qs.theme,
           font: qs.font,
+          themeAware: qs.themeAware,
         },
         badges: result.badges,
         generatedAt: new Date().toISOString(),
@@ -272,7 +279,7 @@ export default function ProfileGeneratorClient() {
         body: JSON.stringify({ count: enabledCount }),
       }).catch(() => {})
     },
-    [inputUser, runInspect, setQs, qs.variant, qs.size, qs.mode, qs.theme, qs.font, track],
+    [inputUser, runInspect, setQs, qs.variant, qs.size, qs.mode, qs.theme, qs.font, qs.themeAware, track],
   )
 
   const configRef = useRef<Config | null>(null)
@@ -389,6 +396,7 @@ export default function ProfileGeneratorClient() {
           {/* Profile header */}
           {profile && (
             <div className="flex items-center gap-4">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={profile.avatar_url}
                 alt={profile.login}
@@ -484,6 +492,21 @@ export default function ProfileGeneratorClient() {
                 onChange={(v) => updateGlobal({ font: v as Font })}
               />
             </div>
+            <label className="flex items-start gap-3 rounded-md border border-dashed border-border p-3">
+              <Switch
+                checked={config.global.themeAware ?? false}
+                onCheckedChange={(v) => updateGlobal({ themeAware: v })}
+                className="mt-0.5"
+              />
+              <span className="flex flex-col gap-0.5">
+                <span className="text-sm font-medium">Theme-aware (light/dark)</span>
+                <span className="text-xs text-muted-foreground">
+                  Output <code className="rounded bg-muted px-1 py-0.5">&lt;picture&gt;</code>{" "}
+                  markup so badges adapt to the reader&apos;s GitHub theme. Applies to
+                  theme-derived variants (outline, ghost, secondary, branded, default).
+                </span>
+              </span>
+            </label>
           </div>
 
           {/* Badge groups */}
@@ -792,6 +815,7 @@ function BadgeItem({
             !badge.enabled && "opacity-30 grayscale-[60%]",
           )}
         >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={previewUrl}
             alt={badge.label}

--- a/packages/web/components/badge-builder.tsx
+++ b/packages/web/components/badge-builder.tsx
@@ -19,6 +19,7 @@ import {
   buildBadgeUrl,
   type BuilderState,
 } from "@/lib/badge-builder-shared"
+import { formatBadgeOutput } from "@/lib/badge-output"
 
 // ---------------------------------------------------------------------------
 // Copy format helpers
@@ -27,22 +28,25 @@ import {
 type CopyFormat = "markdown" | "html" | "url" | "rst"
 
 function formatOutput(url: string, format: CopyFormat, linkUrl?: string): string {
-  const link = linkUrl?.trim() || ""
   switch (format) {
     case "markdown":
-      return link
-        ? `[![badge](${url})](${link})`
-        : `![badge](${url})`
+      return formatBadgeOutput(url, "markdown", {
+        alt: "badge",
+        linkUrl,
+        preferPicture: true,
+        ignoreModeForPicture: true,
+      })
     case "html":
-      return link
-        ? `<a href="${link}"><img alt="badge" src="${url}"></a>`
-        : `<img alt="badge" src="${url}">`
+      return formatBadgeOutput(url, "html", {
+        alt: "badge",
+        linkUrl,
+        preferPicture: true,
+        ignoreModeForPicture: true,
+      })
     case "url":
       return url
     case "rst":
-      return link
-        ? `.. image:: ${url}\n   :alt: badge\n   :target: ${link}`
-        : `.. image:: ${url}\n   :alt: badge`
+      return formatBadgeOutput(url, "rst", { alt: "badge", linkUrl })
   }
 }
 
@@ -65,6 +69,8 @@ export function BadgeBuilder() {
   const [baseUrl, setBaseUrl] = useState("https://shieldcn.dev")
   const { resolvedTheme } = useTheme()
 
+  // Pre-existing react-compiler debt (set-state-in-effect); tracked separately.
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { setBaseUrl(window.location.origin) }, [])
 
   // Sync mode with site theme
@@ -72,6 +78,8 @@ export function BadgeBuilder() {
     if (!resolvedTheme) return
     const siteMode = resolvedTheme === "light" ? "light" : "dark"
     if (s.mode !== siteMode) {
+      // Pre-existing react-compiler debt (set-state-in-effect); tracked separately.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setS((prev) => ({ ...prev, mode: siteMode }))
     }
   }, [resolvedTheme]) // eslint-disable-line react-hooks/exhaustive-deps

--- a/packages/web/components/badge-group-modal.tsx
+++ b/packages/web/components/badge-group-modal.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useMemo, useSyncExternalStore } from "react"
 import Link from "next/link"
 import { Copy, Check, ExternalLink, Plus, Trash2, GripVertical } from "lucide-react"
 import { useBadgeMode } from "@/lib/use-badge-mode"
+import { formatBadgeOutput } from "@/lib/badge-output"
 import {
   Dialog,
   DialogContent,
@@ -142,11 +143,21 @@ export function BadgeGroupModal({
 
   const formattedOutput = useMemo(() => {
     switch (outputFormat) {
-      case "markdown": return `![${title}](${fullUrl})`
+      case "markdown":
+        return formatBadgeOutput(fullUrl, "markdown", {
+          alt: title,
+          preferPicture: true,
+          ignoreModeForPicture: true,
+        })
       case "url": return fullUrl
-      case "html": return `<img alt="${title}" src="${fullUrl}">`
-      case "rst": return `.. image:: ${fullUrl}\n   :alt: ${title}`
-      case "asciidoc": return `image:${fullUrl}[${title}]`
+      case "html":
+        return formatBadgeOutput(fullUrl, "html", {
+          alt: title,
+          preferPicture: true,
+          ignoreModeForPicture: true,
+        })
+      case "rst": return formatBadgeOutput(fullUrl, "rst", { alt: title })
+      case "asciidoc": return formatBadgeOutput(fullUrl, "asciidoc", { alt: title })
     }
   }, [outputFormat, fullUrl, title])
 

--- a/packages/web/components/badge-modal.tsx
+++ b/packages/web/components/badge-modal.tsx
@@ -21,6 +21,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { SvgIconUpload } from "@/components/svg-icon-upload"
+import { formatBadgeOutput } from "@/lib/badge-output"
 import { allowedVariantsForPath } from "@shieldcn/core/badges/registry"
 
 interface BadgeModalProps {
@@ -162,15 +163,23 @@ export function BadgeModal({
   const formattedOutput = useMemo(() => {
     switch (outputFormat) {
       case "markdown":
-        return `![${title}](${fullUrl})`
+        return formatBadgeOutput(fullUrl, "markdown", {
+          alt: title,
+          preferPicture: true,
+          ignoreModeForPicture: true,
+        })
       case "url":
         return fullUrl
       case "html":
-        return `<img alt="${title}" src="${fullUrl}">`
+        return formatBadgeOutput(fullUrl, "html", {
+          alt: title,
+          preferPicture: true,
+          ignoreModeForPicture: true,
+        })
       case "rst":
-        return `.. image:: ${fullUrl}\n   :alt: ${title}`
+        return formatBadgeOutput(fullUrl, "rst", { alt: title })
       case "asciidoc":
-        return `image:${fullUrl}[${title}]`
+        return formatBadgeOutput(fullUrl, "asciidoc", { alt: title })
     }
   }, [outputFormat, fullUrl, title])
 

--- a/packages/web/components/badge-preview.tsx
+++ b/packages/web/components/badge-preview.tsx
@@ -3,6 +3,7 @@
 import { useState, useSyncExternalStore } from "react"
 import { Copy, Check } from "lucide-react"
 import { useBadgeMode } from "@/lib/use-badge-mode"
+import { formatBadgeOutput } from "@/lib/badge-output"
 
 /**
  * True only after client hydration. Lets a badge <img> wait for the resolved
@@ -36,7 +37,10 @@ export function BadgePreview({ src, alt, description, code }: BadgePreviewProps)
 
   const adaptedSrc = adaptUrl(src)
   const fullUrl = `https://shieldcn.dev${src}`
-  const displayCode = code ?? `![${alt || "badge"}](${fullUrl})`
+  const displayCode = code ?? formatBadgeOutput(fullUrl, "markdown", {
+    alt: alt || "badge",
+    preferPicture: true,
+  })
 
   const handleCopy = () => {
     navigator.clipboard.writeText(displayCode)
@@ -102,7 +106,10 @@ export function BadgePreviewCard({ src, alt, description }: BadgePreviewProps) {
 
   const adaptedSrc = adaptUrl(src)
   const fullUrl = `https://shieldcn.dev${src}`
-  const displayCode = `![${alt || "badge"}](${fullUrl})`
+  const displayCode = formatBadgeOutput(fullUrl, "markdown", {
+    alt: alt || "badge",
+    preferPicture: true,
+  })
 
   const handleCopy = () => {
     navigator.clipboard.writeText(displayCode)

--- a/packages/web/components/badge-sandbox.tsx
+++ b/packages/web/components/badge-sandbox.tsx
@@ -21,6 +21,7 @@ import { LogoPicker } from "@/components/logo-picker"
 import { SvgIconUpload } from "@/components/svg-icon-upload"
 import { allowedVariantsForPath, VARIANT_LABELS } from "@shieldcn/core/badges/registry"
 import { useBadgeMode } from "@/lib/use-badge-mode"
+import { formatBadgeOutput } from "@/lib/badge-output"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -174,10 +175,20 @@ export function BadgeSandbox({
   const formattedOutput = useMemo(() => {
     if (!builtUrl) return ""
     switch (format) {
-      case "markdown": return `![badge](${builtUrl})`
-      case "rst": return `.. image:: ${builtUrl}\n   :alt: badge`
-      case "asciidoc": return `image:${builtUrl}[badge]`
-      case "html": return `<img alt="badge" src="${builtUrl}">`
+      case "markdown":
+        return formatBadgeOutput(builtUrl, "markdown", {
+          alt: "badge",
+          preferPicture: true,
+          ignoreModeForPicture: true,
+        })
+      case "rst": return formatBadgeOutput(builtUrl, "rst", { alt: "badge" })
+      case "asciidoc": return formatBadgeOutput(builtUrl, "asciidoc", { alt: "badge" })
+      case "html":
+        return formatBadgeOutput(builtUrl, "html", {
+          alt: "badge",
+          preferPicture: true,
+          ignoreModeForPicture: true,
+        })
       default: return builtUrl
     }
   }, [builtUrl, format])

--- a/packages/web/lib/badge-output.ts
+++ b/packages/web/lib/badge-output.ts
@@ -1,0 +1,121 @@
+/**
+ * shieldcn
+ * lib/badge-output
+ *
+ * Shared README output helpers for badges.
+ */
+
+type BadgeOutputFormat = "markdown" | "html" | "url" | "rst" | "asciidoc"
+
+const THEME_DERIVED_VARIANTS = new Set([
+  "default",
+  "secondary",
+  "outline",
+  "ghost",
+  "branded",
+])
+
+const COLOR_LOCKING_PARAMS = [
+  "color",
+  "labelColor",
+  "valueColor",
+  "labelTextColor",
+  "gradient",
+]
+
+function escapeAttr(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+}
+
+function escapeMarkdownAlt(value: string): string {
+  return value.replace(/[\[\]]/g, "")
+}
+
+function parseBadgeUrl(url: string): URL | null {
+  try {
+    return new URL(url, "https://shieldcn.dev")
+  } catch {
+    return null
+  }
+}
+
+function serializeLikeInput(parsed: URL, original: string): string {
+  if (/^https?:\/\//.test(original)) return parsed.toString()
+  return `${parsed.pathname}${parsed.search}${parsed.hash}`
+}
+
+export function withBadgeMode(url: string, mode: "dark" | "light"): string {
+  const parsed = parseBadgeUrl(url)
+  if (!parsed) return url
+  parsed.searchParams.set("mode", mode)
+  return serializeLikeInput(parsed, url)
+}
+
+export function isThemeAdaptiveBadgeUrl(
+  url: string,
+  opts: { ignoreMode?: boolean } = {},
+): boolean {
+  const parsed = parseBadgeUrl(url)
+  if (!parsed) return false
+  if (!/\.(svg|png)$/.test(parsed.pathname)) return false
+
+  const variant = parsed.searchParams.get("variant") ?? "default"
+  if (!THEME_DERIVED_VARIANTS.has(variant)) return false
+  if (!opts.ignoreMode && parsed.searchParams.has("mode")) return false
+
+  return !COLOR_LOCKING_PARAMS.some((param) => parsed.searchParams.has(param))
+}
+
+export function badgePictureFromUrl(url: string, alt = "badge", linkUrl?: string): string {
+  const dark = withBadgeMode(url, "dark")
+  const light = withBadgeMode(url, "light")
+  const pic =
+    `<picture>` +
+    `<source media="(prefers-color-scheme: dark)" srcset="${escapeAttr(dark)}">` +
+    `<img alt="${escapeAttr(alt)}" src="${escapeAttr(light)}"></picture>`
+  const link = linkUrl?.trim()
+  return link ? `<a href="${escapeAttr(link)}">${pic}</a>` : pic
+}
+
+export function formatBadgeOutput(
+  url: string,
+  format: BadgeOutputFormat,
+  opts: {
+    alt?: string
+    linkUrl?: string
+    preferPicture?: boolean
+    ignoreModeForPicture?: boolean
+  } = {},
+): string {
+  const alt = opts.alt || "badge"
+  const link = opts.linkUrl?.trim()
+  const usePicture =
+    opts.preferPicture &&
+    (format === "markdown" || format === "html") &&
+    isThemeAdaptiveBadgeUrl(url, { ignoreMode: opts.ignoreModeForPicture })
+
+  if (usePicture) return badgePictureFromUrl(url, alt, link)
+
+  switch (format) {
+    case "markdown": {
+      const img = `![${escapeMarkdownAlt(alt)}](${url})`
+      return link ? `[${img}](${link})` : img
+    }
+    case "html": {
+      const img = `<img alt="${escapeAttr(alt)}" src="${escapeAttr(url)}">`
+      return link ? `<a href="${escapeAttr(link)}">${img}</a>` : img
+    }
+    case "rst":
+      return link
+        ? `.. image:: ${url}\n   :alt: ${alt}\n   :target: ${link}`
+        : `.. image:: ${url}\n   :alt: ${alt}`
+    case "asciidoc":
+      return `image:${url}[${alt}]`
+    case "url":
+      return url
+  }
+}

--- a/packages/web/lib/gen/profile-search-params.ts
+++ b/packages/web/lib/gen/profile-search-params.ts
@@ -4,6 +4,7 @@
 import {
   parseAsString,
   parseAsStringEnum,
+  parseAsBoolean,
   createSearchParamsCache,
 } from "nuqs/server"
 import type { Variant, Size, Mode, Theme, Font } from "./shieldcn"
@@ -53,6 +54,7 @@ export const profileSearchParams = {
   mode: parseAsStringEnum(MODES).withDefault("dark"),
   theme: parseAsStringEnum(THEMES).withDefault("none"),
   font: parseAsStringEnum(FONTS).withDefault("inter"),
+  themeAware: parseAsBoolean.withDefault(true),
 }
 
 export const profileSearchParamsCache = createSearchParamsCache(profileSearchParams)

--- a/packages/web/lib/gen/search-params.ts
+++ b/packages/web/lib/gen/search-params.ts
@@ -54,7 +54,7 @@ export const genSearchParams = {
   mode: parseAsStringEnum(MODES).withDefault("dark"),
   theme: parseAsStringEnum(THEMES).withDefault("none"),
   font: parseAsStringEnum(FONTS).withDefault("inter"),
-  themeAware: parseAsBoolean.withDefault(false),
+  themeAware: parseAsBoolean.withDefault(true),
 }
 
 export const genSearchParamsCache = createSearchParamsCache(genSearchParams)

--- a/packages/web/lib/gen/shieldcn.ts
+++ b/packages/web/lib/gen/shieldcn.ts
@@ -84,7 +84,7 @@ export const DEFAULT_GLOBAL: GlobalSettings = {
   mode: 'dark',
   theme: 'none',
   font: 'inter',
-  themeAware: false,
+  themeAware: true,
 };
 
 export type BadgeGroup =

--- a/packages/web/lib/gen/shieldcn.ts
+++ b/packages/web/lib/gen/shieldcn.ts
@@ -185,21 +185,34 @@ const THEME_DERIVED_VARIANTS = new Set<string>([
 ]);
 
 /**
+ * Params that pin a badge to a single appearance, so a light/dark <picture>
+ * swap would show identical images. Any of these disables theme-aware output.
+ */
+const COLOR_LOCKING_PARAMS = [
+  'color',
+  'labelColor',
+  'valueColor',
+  'labelTextColor',
+  'gradient',
+];
+
+/**
  * Whether a badge would actually change between light and dark mode, so it's
- * worth wrapping in <picture>. True when the resolved variant is theme-derived
- * and the badge has no explicit color override pinning it to one look.
+ * worth wrapping in <picture>. True when the RESOLVED variant (after per-badge
+ * overrides are merged) is theme-derived and nothing pins the badge to one look.
+ *
+ * Must reflect the same URL `badgeUrl()` emits, so it resolves against
+ * `mergeQuery()` rather than the raw query — a per-badge `overrides.variant` or
+ * color override can flip adaptivity and would otherwise be missed.
  */
 export function isThemeAdaptive(badge: Badge, global: GlobalSettings): boolean {
-  const variant =
-    badge.query.variant ||
-    (global.variant !== 'default' ? global.variant : 'default');
+  const merged = mergeQuery(badge, global);
+  const variant = merged.variant ?? 'default';
   if (!THEME_DERIVED_VARIANTS.has(variant)) return false;
-  // An explicit color (query or override) locks the badge to one appearance.
-  if (badge.query.color) return false;
-  if (badge.overrides.color) return false;
+  // An explicit color/gradient locks the badge to one appearance.
+  if (COLOR_LOCKING_PARAMS.some((p) => merged[p])) return false;
   // An explicit mode pins the badge to one theme, so <picture> is pointless.
-  if (badge.query.mode) return false;
-  if (badge.overrides.mode) return false;
+  if (merged.mode) return false;
   return true;
 }
 
@@ -208,15 +221,23 @@ export function isThemeAdaptive(badge: Badge, global: GlobalSettings): boolean {
  * viewers; the <img> fallback (light) covers light-theme viewers and renderers
  * that don't support <picture> (npm, PyPI, etc).
  */
+function escapeAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
 export function badgePicture(badge: Badge, global: GlobalSettings): string {
   const dark = badgeUrl(badge, global, 'dark');
   const light = badgeUrl(badge, global, 'light');
-  const alt = badge.label.replace(/"/g, '&quot;');
+  const alt = escapeAttr(badge.label);
   const pic =
     `<picture>` +
-    `<source media="(prefers-color-scheme: dark)" srcset="${dark}">` +
-    `<img alt="${alt}" src="${light}"></picture>`;
-  return badge.linkUrl ? `<a href="${badge.linkUrl}">${pic}</a>` : pic;
+    `<source media="(prefers-color-scheme: dark)" srcset="${escapeAttr(dark)}">` +
+    `<img alt="${alt}" src="${escapeAttr(light)}"></picture>`;
+  return badge.linkUrl ? `<a href="${escapeAttr(badge.linkUrl)}">${pic}</a>` : pic;
 }
 
 export function badgeMarkdown(badge: Badge, global: GlobalSettings): string {


### PR DESCRIPTION
## Summary
- emit GitHub theme-aware <picture> markup from badge copy/export surfaces for theme-derived variants
- default the repo/profile generators to theme-aware output and add the profile generator toggle
- tighten light-mode custom accent contrast for transparent badge variants and add renderer regressions

## Verification
- pnpm --filter @shieldcn/core test -- render.test.ts
- pnpm run build:web
- pnpm --filter @shieldcn/web exec eslint --no-warn-ignored --max-warnings 0 <staged web files>

Note: full package lint still reports existing repo-wide React Compiler/Next lint debt outside this change.