### PR TITLE
docs(skill): improve agent skill guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ Drop a badge into any README and it renders as a real shadcn Button.
 ![views](https://shieldcn.dev/views/repo/shieldcn/shieldcn.svg)
 ```
 
+## Agent skill
+
+Install the `shieldcn-badges` skill from [skills.sh](https://skills.sh) so your
+coding agent can add shieldcn badges, charts, and headers to READMEs:
+
+```bash
+npx skills add jal-co/shieldcn -a claude-code # installs to Claude Code
+npx skills add jal-co/shieldcn -a cursor # installs to Cursor
+```
+
+See [`skills/shieldcn-badges/SKILL.md`](skills/shieldcn-badges/SKILL.md) for
+prompt examples and options.
+
 ## Star History
 
 <p align="center">

--- a/packages/web/components/code-block.tsx
+++ b/packages/web/components/code-block.tsx
@@ -71,6 +71,8 @@ interface CodeBlockProps extends Omit<React.ComponentProps<"div">, "children"> {
   muted?: boolean
   /** Hide the header bar. Copy button floats inside the code area. */
   compact?: boolean
+  /** Wrap long lines instead of horizontally scrolling. */
+  wrap?: boolean
   /** Shiki theme name for single-theme rendering (e.g. "dracula", "nord"). */
   theme?: string
   className?: string
@@ -85,6 +87,7 @@ export async function CodeBlock({
   maxHeight,
   muted = false,
   compact = false,
+  wrap = false,
   theme,
   className,
   ...props
@@ -157,7 +160,8 @@ export async function CodeBlock({
       <CodeBlockWrapper overflow={overflow} maxHeight={maxHeight} muted={muted}>
         <div
           className={cn(
-            "relative overflow-x-auto",
+            "relative",
+            wrap ? "overflow-x-hidden" : "overflow-x-auto",
             !muted && !theme && "bg-[var(--shiki-light-bg)] dark:bg-[var(--shiki-dark-bg)]"
           )}
         >
@@ -168,7 +172,11 @@ export async function CodeBlock({
           )}
           <div
             className={cn(
-              "code-block [&_code]:font-mono [&_code]:text-[13px] [&_pre]:m-0 [&_pre]:overflow-x-auto [&_pre]:p-4 [&_pre]:sm:p-5",
+              "code-block [&_code]:font-mono [&_code]:text-[13px] [&_pre]:m-0 [&_pre]:p-4 [&_pre]:sm:p-5",
+              compact && "[&_pre]:pr-14 [&_pre]:sm:pr-14",
+              wrap
+                ? "[&_code]:break-words [&_code]:whitespace-pre-wrap [&_pre]:break-words [&_pre]:whitespace-pre-wrap [&_pre]:overflow-x-hidden"
+                : "[&_pre]:overflow-x-auto",
               theme
                 ? "[&_pre]:rounded-b-xl"
                 : "[&_pre]:bg-transparent",

--- a/packages/web/components/code-line.tsx
+++ b/packages/web/components/code-line.tsx
@@ -36,8 +36,9 @@ async function CodeLine({
     <div
       data-slot="code-line"
       className={cn(
-        "inline-flex w-full items-center gap-2 overflow-hidden rounded-lg border border-border/60 shadow-xs",
-        !theme && "bg-muted/30",
+        "inline-flex w-full items-center gap-2 overflow-hidden rounded-xl border border-border/60 shadow-sm",
+        "[&_.shiki]:!bg-transparent [&_.shiki_span]:!bg-transparent",
+        !theme && "bg-white dark:bg-[#101010]",
         className
       )}
       style={themeBg ? { backgroundColor: themeBg } : undefined}

--- a/packages/web/components/sidebar.tsx
+++ b/packages/web/components/sidebar.tsx
@@ -23,6 +23,7 @@ import { Kbd } from "@/components/ui/kbd"
 interface NavItem {
   title: string
   href: string
+  highlight?: boolean
   children?: NavItem[]
 }
 
@@ -53,7 +54,7 @@ const docsNav: NavGroup[] = [
       { title: "Introduction", href: "/docs" },
       { title: "README Studio", href: "/docs/studio" },
       { title: "CLI", href: "/docs/cli" },
-      { title: "Agent Skill", href: "/docs/skill" },
+      { title: "Agent Skill", href: "/docs/skill", highlight: true },
       { title: "Self-Hosting", href: "/docs/self-hosting" },
       { title: "API Reference", href: "/docs/api-reference" },
       { title: "Token Pool", href: "/token-pool" },
@@ -231,11 +232,13 @@ const ITEM_SPRING: Transition = { type: "spring", stiffness: 500, damping: 38 }
 function NavLink({
   href,
   title,
+  highlight,
   isActive,
   reduce,
 }: {
   href: string
   title: string
+  highlight?: boolean
   isActive: boolean
   reduce: boolean | null
 }) {
@@ -244,11 +247,14 @@ function NavLink({
       href={href}
       data-sidebar-active={isActive ? "true" : undefined}
       className={cn(
-        "group/navlink relative flex items-center rounded-md py-1.5 pl-3 pr-2 text-sm leading-5 outline-none transition-colors",
+        "group/navlink relative flex items-center rounded-md border py-1.5 pl-3 pr-2 text-sm leading-5 outline-none transition-colors",
         "focus-visible:ring-2 focus-visible:ring-ring/50",
         isActive
-          ? "font-medium text-foreground"
+          ? "border-transparent font-medium text-foreground"
           : "text-muted-foreground hover:text-foreground",
+        highlight && !isActive
+          ? "border-primary/20 bg-primary/5 text-foreground shadow-sm shadow-primary/5 hover:border-primary/30 hover:bg-primary/10 dark:bg-primary/10"
+          : "border-transparent",
       )}
     >
       {/* hover wash (sits behind text, only when not active) */}
@@ -274,12 +280,17 @@ function NavLink({
 
       <span
         className={cn(
-          "relative z-10 truncate transition-transform duration-150",
+          "relative z-10 flex-1 truncate transition-transform duration-150",
           !isActive && "group-hover/navlink:translate-x-0.5",
         )}
       >
         {title}
       </span>
+      {highlight && (
+        <span className="relative z-10 ml-2 shrink-0 rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium leading-none text-primary">
+          New
+        </span>
+      )}
     </Link>
   )
 }
@@ -310,14 +321,14 @@ function CollapsibleNavItem({
   }, [pathname, isRelevant])
 
   if (!hasChildren) {
-    return <NavLink href={item.href} title={item.title} isActive={isActive} reduce={reduce} />
+    return <NavLink href={item.href} title={item.title} highlight={item.highlight} isActive={isActive} reduce={reduce} />
   }
 
   return (
     <div className="flex flex-col">
       <div className="flex items-center">
         <div className="flex-1">
-          <NavLink href={item.href} title={item.title} isActive={isActive} reduce={reduce} />
+          <NavLink href={item.href} title={item.title} highlight={item.highlight} isActive={isActive} reduce={reduce} />
         </div>
         <button
           type="button"

--- a/packages/web/content/docs/skill.mdx
+++ b/packages/web/content/docs/skill.mdx
@@ -27,10 +27,17 @@ This installs the `shieldcn-badges` skill to your coding agent.
 
 Once installed, ask your coding agent to add badges. The skill triggers automatically for requests like:
 
-- _"Add npm and GitHub badges to the README"_
-- _"Add a CI status badge for this repo"_
-- _"Add shieldcn badges to the docs"_
-- _"Set up a badge row with stars, license, and version"_
+<div className="not-prose my-6 space-y-3">
+  <CodeBlock compact wrap language="text" code={`Add npm and GitHub badges to the README.
+Use size xs, the ghost variant, and make them work in both light and dark mode.`} />
+  <CodeBlock compact wrap language="text" code={`Migrate the existing Shields.io badges in this README to shieldcn.
+Undo any split-style/two-tone badges: use single-surface badges and remove split=true, labelColor, and split-label styling unless explicitly needed.`} />
+  <CodeBlock compact wrap language="text" code={`Add a shieldcn star-history chart for this repo below the intro.
+Make it transparent, link it to the stargazers page, and keep it readable in both light and dark mode.`} />
+  <CodeBlock compact wrap language="text" code="Add a CI status badge for this repo" />
+  <CodeBlock compact wrap language="text" code="Add shieldcn badges to the docs" />
+  <CodeBlock compact wrap language="text" code="Set up a badge row with stars, license, and version" />
+</div>
 
 The agent knows all shieldcn providers, URL patterns, variants, and query parameters — no manual lookup needed.
 

--- a/skills/shieldcn-badges/SKILL.md
+++ b/skills/shieldcn-badges/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shieldcn-badges
-description: Add beautiful shadcn/ui-styled README badges, charts, and header banners to projects using shieldcn, and build entire READMEs with the visual README Studio. Use when adding badges, shields, status indicators, star-history/download charts, or header banners to README files, docs, or markdown, or when building/generating a README. Triggers include "add badges", "add shields", "readme badges", "npm badge", "GitHub stars badge", "CI badge", "star history chart", "readme header", "readme banner", "build a readme", "readme builder", "readme generator", "github readme tool", "shieldcn", or any request to add project status badges, charts, or headers to documentation.
+description: Create polished shieldcn README badges, badge groups, charts, headers, sponsors grids, and full README hero sections. Use when a user wants shadcn/ui-styled badges, Shields.io replacement, npm/GitHub/CI/status badges, star-history or download charts, README header banners, contributor/sponsor images, or README Studio guidance. Triggers include "add badges", "add shields", "README badges", "npm badge", "GitHub stars badge", "CI badge", "star history chart", "download chart", "README header", "README banner", "contributors grid", "sponsors grid", "build a README", "README Studio", "shieldcn", and requests to make a project README look better.
 metadata:
   author: jal-co
   version: "1.0.0"
@@ -8,63 +8,177 @@ metadata:
 
 # shieldcn Badges
 
-Add beautiful [shadcn/ui](https://ui.shadcn.com)-styled badges to READMEs and docs using [shieldcn](https://shieldcn.dev) — a free, open-source shields.io alternative.
+Use [shieldcn](https://shieldcn.dev) to add beautiful shadcn/ui-styled badges,
+badge groups, charts, headers, sponsors grids, and contributor images to READMEs
+and docs.
 
 Base URL: `https://shieldcn.dev`
 
-## Badge URL format
+## Install this skill
 
-```
-https://shieldcn.dev/{provider}/{...params}.svg     → SVG (default, for READMEs)
-https://shieldcn.dev/{provider}/{...params}.png     → PNG
-https://shieldcn.dev/{provider}/{...params}.json    → raw data
+Install from the shieldcn repository with the Skills CLI:
+
+```bash
+npx skills add jal-co/shieldcn
 ```
 
-## Markdown pattern
+Useful variants:
+
+```bash
+# Install globally instead of only the current project
+npx skills add jal-co/shieldcn --global
+
+# Install for a specific agent supported by the Skills CLI
+npx skills add jal-co/shieldcn --agent AGENT_NAME
+
+# Use once without installing
+npx skills use jal-co/shieldcn@shieldcn-badges
+```
+
+Verify installation:
+
+```bash
+npx skills list
+```
+
+## What to ask your agent
+
+Copy one of these prompts after installing the skill. Replace bracketed values
+with the real project details.
+
+### Great badge rows
+
+```text
+Add a polished shieldcn badge row to my README for [owner/repo]. Include npm
+version/downloads if this package is published as [package], GitHub stars,
+license, CI status, and last commit. Center the row, make badges clickable, and
+use a subtle shadcn style that works on GitHub light and dark themes.
+```
+
+```text
+Replace the existing Shields.io badges in this README with shieldcn equivalents.
+Keep the same links where possible, remove stale or duplicate badges, and keep
+the final row to 3-6 high-signal badges.
+```
+
+```text
+Migrate the existing Shields.io badges in this README to shieldcn, but undo any
+split-style/two-tone badges. Use single-surface shieldcn badges instead: remove
+split=true, labelColor, and other split-label styling unless a split badge is
+explicitly needed for readability.
+```
+
+```text
+Create a compact shieldcn badge group for [owner/repo] with stars, license,
+contributors, and last commit. Use one grouped image when that is cleaner than
+separate badges.
+```
+
+```text
+Add release-quality README badges for a TypeScript library named [package]. I
+want npm version, monthly downloads, license, types, GitHub stars, CI, and a
+small branded static badge if it improves the visual hierarchy.
+```
+
+### Headers and hero sections
+
+```text
+Design the top of my README using shieldcn: add an adaptive header banner for
+[project name], a one-sentence tagline, and a centered badge row. Use GitHub
+<picture> markup so the header and badges adapt to light/dark mode.
+```
+
+```text
+Add a left-aligned shieldcn header to my README with title [title], subtitle
+[subtitle], logo [simple-icons slug], and a graph/grid style that fits a
+technical open-source project.
+```
+
+### Charts and visual proof
+
+```text
+Add a shieldcn star-history chart for [owner/repo] below the intro. Make it
+transparent so it blends into GitHub, and link it to the repository stargazers.
+```
+
+```text
+Add a shieldcn npm download chart for [package] to the README. Use a concise
+caption and choose chart dimensions that work well on GitHub mobile.
+```
+
+```text
+Add a shieldcn lifetime commit chart for [github username]. If multiple users
+are listed, compare them in one chart and explain what the chart shows.
+```
+
+### Bigger README work
+
+```text
+Improve this README's above-the-fold impression with shieldcn. Keep the content
+accurate, add a header, badges, and one chart only where they help, and avoid
+visual clutter.
+```
+
+```text
+I want to generate a whole README visually. Point me to shieldcn README Studio
+and explain which blocks I should use for this project.
+```
+
+## Agent workflow
+
+When this skill is loaded for a README/docs task:
+
+1. Inspect the existing README and package metadata before editing.
+2. Identify the project type: library, app, CLI, docs site, template, or skill.
+3. Choose only high-signal badges. Default to 3-6 badges above the fold.
+4. Use real values for `owner`, `repo`, package names, workflow names, and links.
+5. Prefer SVG for Markdown images. Use PNG only when the target host blocks SVG.
+6. Make badges clickable with `<a>` wrappers when they represent an external page.
+7. Use `<p align="center">` for centered rows in GitHub READMEs.
+8. Use GitHub `<picture>` markup when a header/chart/badge needs explicit light
+   and dark URLs.
+9. Avoid leaving placeholders in the user's README. Placeholders are fine only in
+   examples or drafts.
+10. If the user wants a full README rather than a few assets, suggest README
+    Studio at `https://shieldcn.dev/studio`.
+
+## URL basics
+
+```text
+https://shieldcn.dev/{provider}/{...params}.svg          SVG badge/image
+https://shieldcn.dev/{provider}/{...params}.png          PNG badge/image
+https://shieldcn.dev/{provider}/{...params}.json         raw resolved data
+https://shieldcn.dev/{provider}/{...params}/shields.json Shields.io-compatible JSON
+```
+
+Markdown patterns:
 
 ```md
 [![alt](https://shieldcn.dev/{provider}/{params}.svg)](https://link)
 
-<!-- or without link -->
 ![alt](https://shieldcn.dev/{provider}/{params}.svg)
 ```
 
-## Providers & endpoints
+Adaptive GitHub pattern:
 
-### Package registries
+```md
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/header/graph.svg?title=Acme&subtitle=Build+faster&logo=react&mode=dark" />
+    <img alt="Acme" src="https://shieldcn.dev/header/graph.svg?title=Acme&subtitle=Build+faster&logo=react&mode=light" />
+  </picture>
+</p>
+```
 
-| Provider | Endpoint | Example |
-|----------|----------|---------|
-| npm version | `/npm/{package}` | `/npm/react` |
-| npm version (tag) | `/npm/v/{package}/{tag}` | `/npm/v/next/canary` |
-| npm downloads/wk | `/npm/dw/{package}` | `/npm/dw/react` |
-| npm downloads/mo | `/npm/dm/{package}` | `/npm/dm/react` |
-| npm downloads/yr | `/npm/dy/{package}` | `/npm/dy/react` |
-| npm total downloads | `/npm/dt/{package}` | `/npm/dt/react` |
-| npm license | `/npm/license/{package}` | `/npm/license/react` |
-| npm types | `/npm/types/{package}` | `/npm/types/react` |
-| npm dependents | `/npm/dependents/{package}` | `/npm/dependents/react` |
-| npm scoped | `/npm/v/@scope/pkg` | `/npm/v/@types/node` |
-| PyPI version | `/pypi/{package}` | `/pypi/flask` |
-| PyPI downloads/mo | `/pypi/dm/{package}` | `/pypi/dm/flask` |
-| Crates.io version | `/crates/{crate}` | `/crates/serde` |
-| Docker Hub pulls | `/docker/pulls/{image}` | `/docker/pulls/library/nginx` |
-| JSR version | `/jsr/{@scope}/{name}` | `/jsr/@std/path` |
-| Bundlephobia minzip | `/bundlephobia/minzip/{package}` | `/bundlephobia/minzip/react` |
-| Homebrew version | `/homebrew/{formula}` | `/homebrew/node` |
-| Maven version | `/maven/{groupId}/{artifactId}` | `/maven/org.apache.maven/maven-core` |
-| Packagist version | `/packagist/v/{vendor}/{package}` | `/packagist/v/laravel/framework` |
-| RubyGems version | `/rubygems/{gem}` | `/rubygems/rails` |
-| NuGet version | `/nuget/{package}` | `/nuget/Newtonsoft.Json` |
-| Pub.dev version | `/pub/{package}` | `/pub/flutter` |
-| CocoaPods version | `/cocoapods/{pod}` | `/cocoapods/Alamofire` |
+## Common badge endpoints
 
 ### GitHub
 
-Both formats work: `/github/{topic}/{owner}/{repo}` or `/github/{owner}/{repo}/{topic}`
+Both route styles work: `/github/{topic}/{owner}/{repo}` and
+`/github/{owner}/{repo}/{topic}`.
 
 | Badge | Endpoint | Example |
-|-------|----------|---------|
+|---|---|---|
 | Stars | `/github/stars/{owner}/{repo}` | `/github/stars/vercel/next.js` |
 | Forks | `/github/forks/{owner}/{repo}` | `/github/forks/vercel/next.js` |
 | License | `/github/license/{owner}/{repo}` | `/github/license/vercel/next.js` |
@@ -78,174 +192,208 @@ Both formats work: `/github/{topic}/{owner}/{repo}` or `/github/{owner}/{repo}/{
 | Downloads | `/github/dt/{owner}/{repo}` | `/github/dt/vercel/next.js` |
 | Dependabot | `/github/dependabot/{owner}/{repo}` | `/github/dependabot/vercel/next.js` |
 
-CI supports `?workflow=name&branch=main` query params.
+CI supports `?workflow=name&branch=main`.
 
-### Social
+### Package registries
 
-| Provider | Endpoint | Example |
-|----------|----------|---------|
+| Badge | Endpoint | Example |
+|---|---|---|
+| npm version | `/npm/{package}` | `/npm/react` |
+| npm version tag | `/npm/v/{package}/{tag}` | `/npm/v/next/canary` |
+| npm weekly downloads | `/npm/dw/{package}` | `/npm/dw/react` |
+| npm monthly downloads | `/npm/dm/{package}` | `/npm/dm/react` |
+| npm yearly downloads | `/npm/dy/{package}` | `/npm/dy/react` |
+| npm total downloads | `/npm/dt/{package}` | `/npm/dt/react` |
+| npm license | `/npm/license/{package}` | `/npm/license/react` |
+| npm types | `/npm/types/{package}` | `/npm/types/react` |
+| npm dependents | `/npm/dependents/{package}` | `/npm/dependents/react` |
+| PyPI version | `/pypi/{package}` | `/pypi/flask` |
+| PyPI monthly downloads | `/pypi/dm/{package}` | `/pypi/dm/flask` |
+| Crates.io version | `/crates/{crate}` | `/crates/serde` |
+| Docker Hub pulls | `/docker/pulls/{image}` | `/docker/pulls/library/nginx` |
+| JSR version | `/jsr/{@scope}/{name}` | `/jsr/@std/path` |
+| Bundlephobia minzip | `/bundlephobia/minzip/{package}` | `/bundlephobia/minzip/react` |
+| Homebrew version | `/homebrew/{formula}` | `/homebrew/node` |
+| Maven version | `/maven/{groupId}/{artifactId}` | `/maven/org.apache.maven/maven-core` |
+| Packagist version | `/packagist/v/{vendor}/{package}` | `/packagist/v/laravel/framework` |
+| RubyGems version | `/rubygems/{gem}` | `/rubygems/rails` |
+| NuGet version | `/nuget/{package}` | `/nuget/Newtonsoft.Json` |
+| Pub.dev version | `/pub/{package}` | `/pub/flutter` |
+| CocoaPods version | `/cocoapods/{pod}` | `/cocoapods/Alamofire` |
+
+For npm scoped packages, keep the full scope: `/npm/v/@scope/package`.
+
+### Social, quality, and skills
+
+| Badge | Endpoint | Example |
+|---|---|---|
 | Discord online | `/discord/{serverId}` | `/discord/1316199667142496307` |
-| Discord by invite | `/discord/members/{inviteCode}` | `/discord/members/nextjs` |
+| Discord members by invite | `/discord/members/{inviteCode}` | `/discord/members/nextjs` |
 | Reddit subscribers | `/reddit/subscribers/r/{subreddit}` | `/reddit/subscribers/r/reactjs` |
 | Bluesky followers | `/bluesky/followers/{handle}` | `/bluesky/followers/bsky.app` |
-| YouTube subs | `/youtube/subscribers/{channelId}` | `/youtube/subscribers/UCxxxxxx` |
+| YouTube subscribers | `/youtube/subscribers/{channelId}` | `/youtube/subscribers/UCxxxxxx` |
 | Mastodon followers | `/mastodon/followers/{instance}/{acct}` | `/mastodon/followers/mastodon.social/Gargron` |
 | Hacker News karma | `/hackernews/{userId}` | `/hackernews/pg` |
-
-### Code quality
-
-| Provider | Endpoint | Example |
-|----------|----------|---------|
 | Codecov | `/codecov/{service}/{owner}/{repo}` | `/codecov/gh/vercel/next.js` |
 | VS Code installs | `/vscode/installs/{publisher}/{ext}` | `/vscode/installs/esbenp/prettier-vscode` |
 | WakaTime | `/wakatime/{username}` | `/wakatime/@user` |
-
-### Agent skills (skills.sh)
-
-Addressed as `{owner}/{repo}/{skill}` — the GitHub repo (skills.sh `source`) plus the skill slug.
-
-| Badge | Endpoint | Example |
-|-------|----------|---------|
 | Skill installs | `/skills/installs/{owner}/{repo}/{skill}` | `/skills/installs/vercel-labs/agent-skills/vercel-react-best-practices` |
 | Skill rank | `/skills/rank/{owner}/{repo}/{skill}` | `/skills/rank/vercel-labs/agent-skills/vercel-react-best-practices` |
-| Trending rank | `/skills/trending/{owner}/{repo}/{skill}` | `/skills/trending/vercel-labs/agent-skills/vercel-react-best-practices` |
-| Hot rank | `/skills/hot/{owner}/{repo}/{skill}` | `/skills/hot/vercel-labs/agent-skills/vercel-react-best-practices` |
+| Trending skill rank | `/skills/trending/{owner}/{repo}/{skill}` | `/skills/trending/vercel-labs/agent-skills/vercel-react-best-practices` |
+| Hot skill rank | `/skills/hot/{owner}/{repo}/{skill}` | `/skills/hot/vercel-labs/agent-skills/vercel-react-best-practices` |
 
-### Custom badges
+### Custom and grouped badges
 
 | Type | Endpoint | Example |
-|------|----------|---------|
+|---|---|---|
 | Static | `/badge/{label}-{message}-{color}` | `/badge/build-passing-brightgreen` |
 | Dynamic JSON | `/badge/dynamic/json?url=...&query=...` | Fetch any JSON API |
-| HTTPS endpoint | `/https/{hostname}/{path}` | Proxy any JSON endpoint |
+| HTTPS endpoint | `/https/{hostname}/{path}` | Proxy a JSON endpoint |
+| Badge group | `/group/{badge1}+{badge2}.svg` | `/group/github/vercel/next.js/stars+github/vercel/next.js/license.svg` |
 
-## Query parameters
+Badge groups render several badges as one joined shadcn ButtonGroup-style image.
+Use them when a README row is visually busy or when the badges share one link.
 
-Append to any badge URL as `?key=value&key2=value2`.
+## Badge styling options
+
+Append query params as `?key=value&key2=value2`.
 
 | Param | Values | Default | Notes |
-|-------|--------|---------|-------|
+|---|---|---|---|
 | `variant` | `default`, `secondary`, `outline`, `ghost`, `destructive`, `branded` | `default` | shadcn Button variant |
 | `size` | `xs`, `sm`, `default`, `lg` | `sm` | Badge size |
-| `mode` | `dark`, `light` | `dark` | Color mode |
-| `split` | `true`, `false` | `false` | Two-tone label/value split |
-| `logo` | SimpleIcons slug, `ri:Name`, `false` | auto | Icon source |
-| `logoColor` | hex (no `#`) | auto | Icon color |
+| `mode` | `dark`, `light` | `dark` | Explicit color mode |
+| `theme` | `zinc`, `slate`, `blue`, `green`, `rose`, `orange`, `violet`, `purple`, `cyan`, `emerald` | — | Theme accent |
+| `font` | `inter`, `geist`, `geist-mono`, `jetbrains-mono`, `fira-code`, `roboto`, `space-grotesk` | `inter` | Font family |
+| `split` | `true`, `false` | `false` | Two-tone label/value badge |
+| `logo` | SimpleIcons slug, `ri:Name`, `data:image/svg+xml;base64,...`, `false` | auto | Icon source |
+| `logoColor` | hex without `#` | auto | Icon color |
 | `label` | string | auto | Override label text |
-| `color` | hex (no `#`) | — | Background color |
-| `labelColor` | hex (no `#`) | — | Label side bg (split mode) |
-| `theme` | `zinc`, `slate`, `blue`, `green`, `rose`, `orange`, `violet` | — | Color theme |
-| `font` | `inter`, `geist`, `geist-mono` | `inter` | Font family |
-| `statusDot` | `true`, `false` | auto for CI | Show status indicator dot |
+| `color` | hex without `#` | — | Main badge color |
+| `labelColor` | hex without `#` | — | Split label background |
+| `valueColor` | hex without `#` | — | Value text color |
+| `labelTextColor` | hex without `#` | — | Label text color |
+| `labelOpacity` | `0`-`1` | `0.7` | Label opacity in split badges |
+| `gradient` | comma-separated hex stops, optional angle | — | Example `ff6b6b,4ecdc4,135` |
+| `statusDot` | `true`, `false` | auto for CI | Show a status dot |
+| `animate` | `pulse`, `glow`, `shimmer`, `none` | `none` | SVG-only animation |
+| `height`, `fontSize`, `radius`, `padX`, `iconSize`, `gap`, `labelGap` | number | per size | Fine tuning |
 
-## Common recipes
+Style recommendations:
 
-### Typical README badge row
-
-```md
-<p align="center">
-  <a href="https://www.npmjs.com/package/{pkg}"><img src="https://shieldcn.dev/npm/{pkg}.svg" alt="npm" /></a>
-  <a href="https://github.com/{owner}/{repo}/stargazers"><img src="https://shieldcn.dev/github/stars/{owner}/{repo}.svg" alt="stars" /></a>
-  <a href="https://github.com/{owner}/{repo}"><img src="https://shieldcn.dev/github/license/{owner}/{repo}.svg" alt="license" /></a>
-  <a href="https://github.com/{owner}/{repo}/actions"><img src="https://shieldcn.dev/github/ci/{owner}/{repo}.svg" alt="CI" /></a>
-</p>
-```
-
-### Secondary variant (lighter)
-
-```md
-![badge](https://shieldcn.dev/npm/react.svg?variant=secondary)
-```
-
-### Branded variant (brand-colored bg)
-
-```md
-![badge](https://shieldcn.dev/npm/react.svg?variant=branded)
-```
-
-### Split badge (two-tone)
-
-```md
-![badge](https://shieldcn.dev/npm/react.svg?split=true)
-```
-
-### Light mode
-
-```md
-![badge](https://shieldcn.dev/npm/react.svg?mode=light)
-```
-
-### Custom icon
-
-```md
-![badge](https://shieldcn.dev/npm/react.svg?logo=typescript)
-![badge](https://shieldcn.dev/github/stars/owner/repo.svg?logo=ri:GoStarFill)
-```
-
-### No icon
-
-```md
-![badge](https://shieldcn.dev/npm/react.svg?logo=false)
-```
+- `variant=secondary` is the safest default for quiet, professional README rows.
+- `variant=branded` is best for one or two brand badges, not every badge.
+- `split=true` works well for status/data pairs where label and value should be
+  distinct.
+- `mode=light`/`mode=dark` is useful inside `<picture>` for adaptive GitHub
+  READMEs.
+- `gradient=` and `animate=` should be used sparingly; they are accents, not the
+  default look.
 
 ## Charts
 
-shieldcn also renders line charts (inlined SVG/PNG, styled like the badges). Use them for star history, issues over time, or download trends.
+Charts render as portable SVG/PNG images styled like shadcn cards.
 
+```text
+/chart/github/stars/{owner}/{repo}.svg       star history
+/chart/github/issues/{owner}/{repo}.svg      issues over time
+/chart/github/commits/{user}.svg             lifetime contribution commits
+/chart/npm/{package}.svg                     npm download history
+/chart/json.svg?values=10,25,40,30,60        inline values
+/chart/json.svg?url=...&query=...            remote JSON values
 ```
-https://shieldcn.dev/chart/github/stars/{owner}/{repo}.svg    → star-history chart
-https://shieldcn.dev/chart/github/issues/{owner}/{repo}.svg   → issues over time
-https://shieldcn.dev/chart/npm/{package}.svg                  → npm downloads
-https://shieldcn.dev/chart/json.svg?values=10,25,40,30,60     → inline JSON data
+
+Markdown example:
+
+```md
+[![Star history](https://shieldcn.dev/chart/github/stars/vercel/next.js.svg?bg=transparent&border=false)](https://github.com/vercel/next.js/stargazers)
 ```
 
-Markdown: `![stars](https://shieldcn.dev/chart/github/stars/vercel/next.js.svg)`
+Chart params: `theme`, `font`, `color`, `fill`, `area`, `width`, `height`,
+`title`, `icon`, `iconColor`, `mode`, `bg`/`background`, `border`, `yScale`,
+`yMin`, `yMax`, `yTicks`, `xTicks`, and for npm charts `days`.
 
-Query params: `theme`, `font`, `color`, `fill`, `area`, `width`, `height`, `title`, `icon`, `mode`.
+Use charts when they tell a story: adoption over time, download trend, issue
+load, or contribution history. Avoid adding charts purely as decoration.
 
 ## Headers
 
-Repository header banners (logo + title + tagline) from a single image URL — great at the top of a README.
+Headers render repository banners from one URL.
 
+```text
+/header/{preset}.svg?title=Acme&subtitle=A+delightful+toolkit
+/header/{preset}.png?title=Acme&subtitle=A+delightful+toolkit
+/header/{preset}.json?title=Acme&subtitle=A+delightful+toolkit
 ```
-https://shieldcn.dev/header/{preset}.svg?title=Acme&subtitle=A%20delightful%20toolkit
-```
 
-Presets: `surface`, `gradient`, `dots`, `grid`, `graph`, `glow`, `transparent`. Query params: `logo`, `theme`, `size`, `align`, `font`, `border`, and `image=<url>` for a photo background (any image or Unsplash URL, fetched and inlined, with an auto scrim tunable via `overlay`/`tint`).
+Presets: `surface`, `gradient`, `dots`, `grid`, `graph`, `glow`, `transparent`.
 
-Center a header at the top of a README:
+Common params: `title`, `subtitle`, `logo`, `logoColor`, `theme`, `size`,
+`width`, `height`, `align`, `font`, `border`, `radius`, `bg`, `gradient`,
+`pattern`, `glow`, `accent`, `titleColor`, `subtitleColor`, `image`, `overlay`,
+`tint`, and `watermark`.
+
+Centered header example:
 
 ```md
 <p align="center">
-  <img src="https://shieldcn.dev/header/gradient.svg?title=Acme&subtitle=A%20delightful%20toolkit" alt="Acme" />
+  <img src="https://shieldcn.dev/header/gradient.svg?title=Acme&subtitle=A+delightful+toolkit&logo=react" alt="Acme" />
 </p>
 ```
 
-## README Studio (visual builder)
+Use `align=left` for technical/product README hero banners and `align=center`
+for logos, frameworks, or portfolio-style projects. Use `bg=transparent` when
+embedding into an already styled page.
 
-For building an entire README visually (not just one badge), point the user to the free README Studio: https://shieldcn.dev/studio
+## Sponsors and contributors images
 
-It is a Figma-style editor — a document of reorderable blocks (Text/Markdown, Header, Badges, Chart, Table, Image), a live preview, and a property inspector — that exports clean GitHub-flavored Markdown. It has an "Adaptive" toggle that exports badges/headers/charts as GitHub `<picture>` elements that follow the reader's light/dark theme. Suggest it when the user wants to compose, redesign, or generate a whole README rather than add a single badge.
+```text
+/sponsors/{login}.svg
+/contributors/{owner}/{repo}.svg
+```
 
-## Rules
+Both support SVG/PNG plus the same card background system used by headers:
+`preset`, `theme`, `bg`, `gradient`, `pattern`, `glow`, `image`, `overlay`,
+`tint`, `accent`, `radius`, `border`, and `watermark`. Contributors also support
+controls like `limit`, `min`, and `names`.
 
-1. Always use `.svg` for markdown images (best quality, smallest size)
-2. Use `<a>` wrapper to make badges clickable links
-3. Use `<p align="center">` to center badge rows in GitHub READMEs
-4. Replace `{owner}`, `{repo}`, `{package}` with actual values — never leave placeholders
-5. Default variant (`default`) works on both light and dark GitHub themes
-6. Icons are auto-resolved per provider — only set `?logo=` to override
-7. For npm scoped packages, use the full scope: `/npm/v/@scope/package`
-8. Prefer `variant=secondary` for subtle badge rows
-9. Keep badge rows to 3–6 badges for readability
-10. Link each badge to its relevant page (npm registry, GitHub stars page, etc.)
+Use these below the main intro or near community sections, not in the top badge
+row.
+
+## README Studio
+
+For building or redesigning an entire README visually, point the user to
+README Studio: `https://shieldcn.dev/studio`.
+
+README Studio is a Figma-style editor with reorderable blocks: Text/Markdown,
+Header, Badges, Chart, Table, and Image. It exports clean GitHub-flavored
+Markdown and has an Adaptive toggle that exports badges, headers, and charts as
+GitHub `<picture>` elements that follow the reader's light/dark theme.
+
+Suggest Studio when the user asks for a full README, a visual editor, a README
+generator, or broad redesign rather than a few specific badge/image edits.
+
+## Quality rules
+
+1. Use `.svg` for Markdown images unless the target host requires PNG.
+2. Keep top badge rows to 3-6 high-signal badges.
+3. Link badges to their relevant destinations.
+4. Prefer `variant=secondary` for calm rows; use `branded` selectively.
+5. Use `mode=light`/`mode=dark` with `<picture>` when visual parity matters.
+6. Use provider auto-icons unless a custom logo materially improves clarity.
+7. Keep alt text human-readable: `npm version`, `GitHub stars`, `CI status`.
+8. Test generated URLs in a browser or with `curl -I` when editing real docs.
+9. Do not hardcode private tokens or secrets in badge URLs.
+10. Do not leave example placeholders in final README output.
 
 ## Docs
 
-Full documentation: https://shieldcn.dev/docs
-API reference: https://shieldcn.dev/docs/api-reference
-Badge builder: https://shieldcn.dev (interactive UI)
-README Studio (visual README builder): https://shieldcn.dev/studio
-Studio docs: https://shieldcn.dev/docs/studio
-Charts docs: https://shieldcn.dev/docs/charts
-Headers docs: https://shieldcn.dev/docs/headers
+- Full docs: https://shieldcn.dev/docs
+- API reference: https://shieldcn.dev/docs/api-reference
+- Badge builder: https://shieldcn.dev
+- README Studio: https://shieldcn.dev/studio
+- Studio docs: https://shieldcn.dev/docs/studio
+- Charts docs: https://shieldcn.dev/docs/charts
+- Headers docs: https://shieldcn.dev/docs/headers
+- Sponsors docs: https://shieldcn.dev/docs/sponsors
+- Contributors docs: https://shieldcn.dev/docs/contributors


### PR DESCRIPTION
## What

- Expand the `shieldcn-badges` skill docs with install guidance, prompt examples, chart/header options, and README Studio guidance.
- Add a brief Agent Skill install section to the README.
- Highlight the Agent Skill docs sidebar item with a `New` pill.
- Make docs prompt examples consistent with compact wrapping code blocks.

## Why

This makes the agent skill easier to discover, install, and use for high-quality README badges, migrations from Shields.io, and star-history charts.

Closes N/A

## Type

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `docs` — Documentation
- [ ] `refactor` — Code restructuring
- [ ] `perf` — Performance improvement
- [x] `style` — Visual / CSS changes
- [ ] `chore` — Maintenance / deps
- [ ] `ci` — CI/CD changes
- [ ] `test` — Tests

## Checklist

- [x] Branch follows conventional naming (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tested locally with `pnpm dev`
- [ ] Badge renders correctly in SVG and PNG (if applicable)
- [x] Docs updated (if adding/changing a provider or query param)

## Testing

- `git diff --check`
- `pnpm --filter @shieldcn/web exec eslint --no-warn-ignored --max-warnings 0 components/code-block.tsx components/code-line.tsx components/sidebar.tsx`
- commit hook ran `pnpm --filter @shieldcn/web exec eslint --no-warn-ignored --max-warnings 0` for staged web files
- local `pnpm dev` was running and `/docs/skill` reloaded successfully

## Screenshots

Visual docs changes were reviewed locally during the running `pnpm dev` session. No badge renderer output changed.
