### PR TITLE
feat(core): add subject and request origin to badge analytics

### DIFF
--- a/packages/core/src/route-glue.test.ts
+++ b/packages/core/src/route-glue.test.ts
@@ -23,6 +23,45 @@ describe("createBadgeHandlers", () => {
     expect(res.headers.get("content-type")).toContain("image/svg+xml")
   })
 
+  it("enriches badge_rendered with subject and request origin", async () => {
+    const onTrack = vi.fn()
+    const { GET } = createBadgeHandlers({ onTrack })
+    const res = await GET(
+      new Request("https://x.dev/badge/hello-world-blue.svg", {
+        headers: { referer: "https://www.npmjs.com/package/react" },
+      }),
+      ctx(["badge", "hello-world-blue.svg"]),
+    )
+    expect(res.status).toBe(200)
+    expect(onTrack).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "badge_rendered",
+        data: expect.objectContaining({
+          provider: "badge",
+          subject: "hello-world-blue",
+          source: "npm",
+          refererHost: "www.npmjs.com",
+        }),
+      }),
+    )
+  })
+
+  it("classifies GitHub Camo requests by user-agent (Camo strips Referer)", async () => {
+    const onTrack = vi.fn()
+    const { GET } = createBadgeHandlers({ onTrack })
+    await GET(
+      new Request("https://x.dev/badge/hello-world-blue.svg", {
+        headers: { "user-agent": "github-camo (876de43e)" },
+      }),
+      ctx(["badge", "hello-world-blue.svg"]),
+    )
+    expect(onTrack).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ source: "github-camo" }),
+      }),
+    )
+  })
+
   it("forwards onMetric to PUT — the exact gap engine's hand-written route had", async () => {
     const onMetric = vi.fn()
     const { PUT } = createBadgeHandlers({ onMetric })

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -3169,6 +3169,48 @@ export async function handleBadgeGET(
   }
 }
 
+/**
+ * The badge's identity — everything after the provider segment (e.g.
+ * "stars/vercel/next.js" for /github/stars/vercel/next.js.svg, or "v/react"
+ * for /npm/v/react.svg). Capped so pathological URLs can't bloat events.
+ */
+function badgeSubject(cleanSegments: string[]): string {
+  return cleanSegments.slice(1).join("/").slice(0, 200)
+}
+
+/**
+ * Classify where a badge request came from, for analytics.
+ *
+ * GitHub proxies README images through Camo (camo.githubusercontent.com),
+ * which strips the Referer header — so GitHub views are identified by
+ * user-agent instead. Camo also caches per our Cache-Control TTL, meaning
+ * GitHub counts are a floor ("at least N"), not a total. Other embedders
+ * (npm, docs sites) typically send a Referer; only its host is kept — never
+ * the full URL — to avoid collecting anything identifying.
+ */
+function requestOrigin(request: Request): Record<string, string> {
+  const ua = request.headers.get("user-agent") ?? ""
+  const referer = request.headers.get("referer")
+
+  if (/\bgithub-camo\b|camo\.githubusercontent\.com/i.test(ua)) {
+    return { source: "github-camo" }
+  }
+
+  let refererHost: string | undefined
+  if (referer) {
+    try {
+      refererHost = new URL(referer).hostname
+    } catch { /* malformed referer — ignore */ }
+  }
+  if (refererHost) {
+    if (refererHost === "www.npmjs.com" || refererHost === "npmjs.com") {
+      return { source: "npm", refererHost }
+    }
+    return { source: "referer", refererHost }
+  }
+  return { source: "direct" }
+}
+
 async function handleBadgeGETInner(
   request: Request,
   slug: string[],
@@ -3176,6 +3218,17 @@ async function handleBadgeGETInner(
 ) {
   const url = new URL(request.url)
   const searchParams = normalizeSearchParams(url.searchParams)
+
+  // Enrich every tracked event with the request origin (source + referer
+  // host) so analytics can answer "where is this badge embedded?".
+  if (options?.onTrack) {
+    const baseTrack = options.onTrack
+    const origin = requestOrigin(request)
+    options = {
+      ...options,
+      onTrack: (event) => baseTrack({ name: event.name, data: { ...origin, ...event.data } }),
+    }
+  }
 
   // Parse format from URL
   const { format, cleanSegments } = parseFormat(slug)
@@ -3650,6 +3703,7 @@ async function handleBadgeGETInner(
           name: "badge_rendered",
           data: {
             provider: cleanSegments[0] || "unknown",
+            subject: badgeSubject(cleanSegments),
             format: "gif",
             style,
             size: size ?? "sm",
@@ -3695,6 +3749,7 @@ async function handleBadgeGETInner(
       name: "badge_rendered",
       data: {
         provider,
+        subject: badgeSubject(cleanSegments),
         format,
         style,
         size: size ?? "sm",


### PR DESCRIPTION
## What

Enriches badge analytics with the badge's identity and where the request came from.

- `badge_rendered` now includes `subject` — everything after the provider segment (e.g. `stars/vercel/next.js`, `v/react`), capped at 200 chars. Emitted on both the svg/png and gif paths.
- Every tracked event is enriched once per request with:
  - `source`: `github-camo` (classified by user-agent, since GitHub's Camo proxy strips Referer), `npm`, `referer`, or `direct`
  - `refererHost`: hostname only — full referer URLs are never recorded (no PII)

## Why

Events previously carried only style metadata (provider, format, style…). You could answer "how many npm badges rendered" but not "which badge" or "embedded where" — the data needed for any per-badge analytics.

Note: GitHub counts are a floor, not a total — Camo caches per our Cache-Control TTL.

## How

A `requestOrigin()` classifier + a single `onTrack` wrapper at the top of `handleBadgeGETInner`, so all track sites (badges, groups, charts, sponsors, contributors, headers) get origin data without threading headers through each handler.

## Testing

Two new route-glue tests: referer-based enrichment (subject + npm source + host) and Camo UA classification. `tsc --noEmit` clean; route-glue, png-route, group-route suites pass.