### PR TITLE
fix(build): allowlist OPENPANEL_* env vars in turbo

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -18,7 +18,8 @@
     "PGDATABASE",
     "NEON_PROJECT_ID",
     "UPSTASH_REDIS_REST_URL",
-    "UPSTASH_REDIS_REST_TOKEN"
+    "UPSTASH_REDIS_REST_TOKEN",
+    "OPENPANEL_*"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## What
Adds `OPENPANEL_*` to `globalEnv` in turbo.json.

## Why
The Vercel build (`pnpm turbo build --filter=@shieldcn/web`) strips env vars not allowlisted in turbo.json. The build log warned:

> the following environment variables are set on your Vercel project, but missing from "turbo.json" ... - OPENPANEL_CLIENT_SECRET

`/stats` is statically prerendered (revalidate 1h), so it rendered with `configured=false` and baked the "Analytics are temporarily unavailable" fallback into production — even though the env vars are set correctly on the project and the OpenPanel API works with those creds.

## Testing
Verified the creds work against the Insights API directly; env values confirmed correct via `vercel env pull` (secret len 24). After merge + deploy, /stats should prerender with live data.