### PR TITLE
fix(auth): use SameSite=Lax so OAuth sign-in completes

### DIFF
--- a/packages/web/lib/auth/server.ts
+++ b/packages/web/lib/auth/server.ts
@@ -26,5 +26,11 @@ export const auth = createNeonAuth({
   baseUrl,
   cookies: {
     secret: cookieSecret,
+    // OAuth returns are a cross-site top-level navigation (github.com → neon
+    // auth → our domain). A SameSite=Strict cookie is NOT sent on that, so the
+    // PKCE challenge cookie would be missing and the verifier exchange would
+    // fail — bouncing the user back to sign-in still signed out. Lax is sent on
+    // top-level cross-site GET navigations, which is exactly the OAuth return.
+    sameSite: "lax",
   },
 })


### PR DESCRIPTION
## What

Sets the Neon Auth cookie `sameSite` to `"lax"` so OAuth (GitHub/Google) sign-in completes on production.

## Why

Signing in with GitHub on prod redirected **straight back to `/sign-in`**, still signed out.

Root cause: the PKCE **challenge cookie** was written `SameSite=Strict`:

```
__Secure-neon-auth.session_challange=…; Secure; SameSite=Strict
```

The OAuth return (`github.com → neon auth → shieldcn.dev/…?neon_auth_session_verifier=…`) is a **cross-site top-level navigation**, on which `SameSite=Strict` cookies are **not sent**. So the verifier exchange in `middleware.ts` found no challenge cookie, returned `null`, and fell through to the login redirect.

## How

`SameSite=Lax` **is** sent on top-level cross-site GET navigations — exactly the OAuth return — so the challenge cookie survives, the exchange succeeds, and the session cookie is written. Lax is the standard setting for session cookies that must survive OAuth redirects.

## Testing

- Typecheck + ESLint clean.
- Verified against the live prod init response that the challenge cookie was `SameSite=Strict` (the bug); this flips it to `Lax`.

## Scope

One-line cookie config change in `lib/auth/server.ts`. No behavior change beyond the OAuth fix; email/password sign-in was already working.
