### PR TITLE
fix(ai): use a gateway-free-tier model and decouple metering

### DIFF
--- a/packages/web/app/api/ai/polish/route.ts
+++ b/packages/web/app/api/ai/polish/route.ts
@@ -9,7 +9,7 @@ import { NextResponse, type NextRequest } from "next/server"
 import { generateText } from "ai"
 import { requireOwner } from "@/lib/auth"
 import { hasPlan } from "@shieldcn/core/entitlements"
-import { meteredModel, aiConfigured } from "@/lib/ai"
+import { aiModel, meterAiUsage, aiErrorResponse, aiConfigured } from "@/lib/ai"
 
 const SYSTEM = `You improve README prose. Return only the rewritten text with no
 commentary, preserving the author's meaning and any Markdown formatting. Make it
@@ -35,22 +35,17 @@ export async function POST(req: NextRequest) {
   if (!text.trim()) return NextResponse.json({ error: "missing text" }, { status: 400 })
 
   try {
-    const { text: out } = await generateText({
-      model: meteredModel(auth.ownerId),
+    const { text: out, usage } = await generateText({
+      model: aiModel(),
       system: SYSTEM,
       prompt: body.instruction
         ? `${body.instruction}\n\n---\n${text}`
         : `Polish this:\n\n---\n${text}`,
     })
+    meterAiUsage(auth.ownerId, usage)
     return NextResponse.json({ text: out })
   } catch (err) {
-    const msg = err instanceof Error ? err.message : "generation failed"
-    if (/credit|quota|limit|402|403/i.test(msg)) {
-      return NextResponse.json(
-        { error: "out of AI credits — upgrade or wait for the next cycle" },
-        { status: 402 },
-      )
-    }
-    return NextResponse.json({ error: msg }, { status: 500 })
+    const { error, status } = aiErrorResponse(err)
+    return NextResponse.json({ error }, { status })
   }
 }

--- a/packages/web/app/api/ai/readme/route.ts
+++ b/packages/web/app/api/ai/readme/route.ts
@@ -13,7 +13,7 @@ import { NextResponse, type NextRequest } from "next/server"
 import { generateText } from "ai"
 import { requireOwner } from "@/lib/auth"
 import { hasPlan } from "@shieldcn/core/entitlements"
-import { meteredModel, aiConfigured } from "@/lib/ai"
+import { aiModel, meterAiUsage, aiErrorResponse, aiConfigured } from "@/lib/ai"
 
 const SYSTEM = `You are a technical writer generating a project README.
 Output GitHub-flavored Markdown only — no preamble, no code fence around the
@@ -43,21 +43,15 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const { text } = await generateText({
-      model: meteredModel(auth.ownerId),
+    const { text, usage } = await generateText({
+      model: aiModel(),
       system: SYSTEM,
       prompt: `Write a README for this project:\n\n${context}`,
     })
+    meterAiUsage(auth.ownerId, usage)
     return NextResponse.json({ markdown: text })
   } catch (err) {
-    const msg = err instanceof Error ? err.message : "generation failed"
-    // Polar returns a 402/403 when the org is out of credits.
-    if (/credit|quota|limit|402|403/i.test(msg)) {
-      return NextResponse.json(
-        { error: "out of AI credits — upgrade or wait for the next cycle" },
-        { status: 402 },
-      )
-    }
-    return NextResponse.json({ error: msg }, { status: 500 })
+    const { error, status } = aiErrorResponse(err)
+    return NextResponse.json({ error }, { status })
   }
 }

--- a/packages/web/lib/ai.ts
+++ b/packages/web/lib/ai.ts
@@ -2,27 +2,27 @@
  * shieldcn
  * lib/ai.ts
  *
- * AI model factory for the Studio's Plus features. Models are resolved through
- * the Vercel AI Gateway, so a single AI_MODEL id (e.g. "anthropic/claude-...")
- * picks the provider and the gateway handles keys/routing/observability.
- * Auth is either AI_GATEWAY_API_KEY or the Vercel OIDC token (present on
- * Vercel deploys and in local `vercel env pull`).
+ * AI for the Studio's Plus features. Models resolve through the Vercel AI
+ * Gateway: a single AI_MODEL id (e.g. "openai/gpt-4o-mini") picks the provider
+ * and the gateway handles keys/routing/observability. Auth is either
+ * AI_GATEWAY_API_KEY or the Vercel OIDC token.
  *
- * The gateway model is wrapped with Polar's LLM ingestion strategy so token
- * usage is metered per organization (the external customer id) — Polar owns the
- * credit balance and overage.
+ * Metering is decoupled from generation: we generate with the plain gateway
+ * model, then record token usage against Polar as a best-effort, fire-and-forget
+ * event. Wrapping the model in Polar's LLM strategy coupled billing into the hot
+ * path and risked breaking generation on any SDK-version drift — so usage is now
+ * metered after the fact via the same events API used elsewhere.
  */
 
 import { gateway } from "ai"
 import type { LanguageModel } from "ai"
-import { Ingestion } from "@polar-sh/ingestion"
-import { LLMStrategy } from "@polar-sh/ingestion/strategies/LLM"
+import { meterEvent } from "@/lib/polar-meter"
 
-const AI_MODEL = process.env.AI_MODEL ?? "anthropic/claude-sonnet-4.5"
-/** Polar meter name the LLM strategy ingests token events under. */
+// Default to a model the AI Gateway free tier allows so AI works out of the box;
+// override with AI_MODEL (e.g. a premium model once the gateway has credits).
+const AI_MODEL = process.env.AI_MODEL || "openai/gpt-4o-mini"
+/** Polar meter name AI token usage is ingested under. */
 const AI_METER = "ai_tokens"
-const polarToken = process.env.POLAR_ACCESS_TOKEN
-const polarServer = (process.env.POLAR_SERVER as "sandbox" | "production") ?? "sandbox"
 
 /**
  * AI is usable when the gateway can authenticate — either an explicit gateway
@@ -32,36 +32,43 @@ export const aiConfigured = Boolean(
   process.env.AI_GATEWAY_API_KEY || process.env.VERCEL_OIDC_TOKEN,
 )
 
-/** Resolve the gateway model from the AI_MODEL env string. */
-function baseModel() {
-  return gateway(AI_MODEL)
+/** The gateway model to pass to generateText/streamText. */
+export function aiModel(): LanguageModel {
+  return gateway(AI_MODEL) as unknown as LanguageModel
 }
 
-/** Lazily-built Polar ingestion strategy (only when billing is configured). */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let strategy: any = null
-function getStrategy() {
-  if (!polarToken) return null
-  if (!strategy) {
-    strategy = Ingestion({ accessToken: polarToken, server: polarServer })
-      // The LLM strategy wraps an AI SDK v2 model; the gateway model is
-      // compatible at runtime but the published types differ by a version.
-      .strategy(new LLMStrategy(baseModel() as never))
-      // Emit one "ai_tokens" event per generation. The metadata carries
-      // inputTokens/outputTokens/totalTokens, which the Polar meter aggregates
-      // into the org's credit balance.
-      .ingest(AI_METER)
-  }
-  return strategy
+/** Token usage shape returned by the AI SDK's generateText. */
+export interface AiUsage {
+  inputTokens?: number
+  outputTokens?: number
+  totalTokens?: number
 }
 
 /**
- * Build the language model to pass to generateText/streamText. When Polar is
- * configured, returns a metered client bound to the org's external id;
- * otherwise returns the raw gateway model (usage simply isn't metered).
+ * Record AI token usage against the owner's Polar balance. Best-effort and
+ * fire-and-forget — metering must never fail or slow a generation.
  */
-export function meteredModel(orgId: string): LanguageModel {
-  const s = getStrategy()
-  if (!s) return baseModel() as unknown as LanguageModel
-  return s.client({ externalCustomerId: orgId }) as unknown as LanguageModel
+export function meterAiUsage(ownerId: string, usage: AiUsage | undefined): void {
+  if (!usage) return
+  void meterEvent(ownerId, AI_METER, {
+    inputTokens: usage.inputTokens ?? 0,
+    outputTokens: usage.outputTokens ?? 0,
+    totalTokens: usage.totalTokens ?? 0,
+  })
+}
+
+/**
+ * Classify a gateway/model error into a user-facing message + status. Gateway
+ * "no access / not found / needs credits" errors are surfaced as a clean 503
+ * rather than a raw 500, and out-of-credit errors as a 402 upsell.
+ */
+export function aiErrorResponse(err: unknown): { error: string; status: number } {
+  const msg = err instanceof Error ? err.message : String(err)
+  if (/free tier|do not have access|not found|upgrade to paid|no access/i.test(msg)) {
+    return { error: "The AI model isn't available on this account yet.", status: 503 }
+  }
+  if (/credit|quota|balance|insufficient|402|403/i.test(msg)) {
+    return { error: "Out of AI credits — upgrade or wait for the next cycle.", status: 402 }
+  }
+  return { error: "AI generation failed. Please try again.", status: 500 }
 }


### PR DESCRIPTION
## What

Fixes AI generation (README generate + polish), which was erroring for every user.

## Why

The default `AI_MODEL` was `anthropic/claude-sonnet-4.5`, which requires **paid Vercel AI Gateway credits**. On the free-tier gateway account every call failed with:

> Free tier users do not have access to this model.

## How

- Default `AI_MODEL` to `openai/gpt-4o-mini` (allowed on the gateway free tier, cheap, fine for READMEs). Prod `AI_MODEL` env updated to match. Override with a premium model once the gateway has credits.
- **Decouple metering from generation**: generate with the plain gateway model, then record token usage via the best-effort Polar events API (same one used for migration metering). Removes the fragile Polar `LLMStrategy` model wrapper from the hot path so SDK-version drift can never break generation.
- Classify gateway errors: no-access/not-found → 503, out-of-credits → 402, else a clean 500 message.

## Testing

- Verified against the live gateway: `gpt-4o-mini` generates and returns usage `{input, output, total}`; `claude-sonnet-4.5` returns the free-tier access error.
- Typecheck + ESLint clean.

## Note

Pre-flight credit enforcement (hard-stop at zero balance) is now post-hoc — usage is recorded but not blocked before generation. Fine for launch; a Polar customer-state balance check can be added later.
