### PR TITLE
fix(billing): stop /api/portal returning HTTP 500

### DIFF
--- a/packages/web/app/api/portal/route.ts
+++ b/packages/web/app/api/portal/route.ts
@@ -5,16 +5,21 @@
  * Polar customer portal. Sends the signed-in owner (personal account or active
  * team) to Polar's hosted portal to manage or cancel their subscription.
  *
- * Robust by construction: the portal must never 500. Callers with no session
- * go to sign-in, callers with no paid plan go to pricing (nothing to manage),
- * and any Polar error (customer not found for the active owner, server
+ * Robust by construction: the portal must never 500. A missing session goes to
+ * sign-in, and any Polar error (no customer for the active owner, server
  * mismatch, etc.) degrades to pricing instead of a raw 500.
+ *
+ * Deliberately does NOT gate on getPlan(): the portal depends on Polar, not on
+ * our database. getPlan fails open to "free" during a DB outage, so gating on
+ * it would misroute a real paying customer — whose Polar customer is perfectly
+ * reachable — to a "no subscription" page. The catch below already handles the
+ * genuinely-no-customer case, so the plan check would be both redundant and
+ * harmful.
  */
 
 import { CustomerPortal } from "@polar-sh/nextjs"
 import { NextResponse, type NextRequest } from "next/server"
 import { requireOwner } from "@/lib/auth"
-import { getPlan } from "@shieldcn/core/entitlements"
 
 const accessToken = process.env.POLAR_ACCESS_TOKEN
 const server = (process.env.POLAR_SERVER as "sandbox" | "production") ?? "sandbox"
@@ -27,14 +32,6 @@ export async function GET(req: NextRequest) {
   const auth = await requireOwner()
   if (!auth) return NextResponse.redirect(new URL("/sign-in", req.url))
 
-  // A Polar customer only exists for an owner that has checked out. Without a
-  // paid plan there's nothing to manage — send them to pricing rather than
-  // asking Polar for a portal session that doesn't exist (which would 500).
-  const plan = await getPlan(auth.ownerId)
-  if (plan === "free") {
-    return NextResponse.redirect(new URL("/pricing?billing=none", req.url))
-  }
-
   try {
     const handler = CustomerPortal({
       accessToken,
@@ -44,8 +41,8 @@ export async function GET(req: NextRequest) {
     })
     return await handler(req)
   } catch {
-    // Customer not found for this owner (e.g. checkout was on a different
-    // workspace), or a Polar/server hiccup — never surface a 500.
+    // No Polar customer for this owner (never checked out, or checkout was on a
+    // different workspace), or a Polar/server hiccup — never surface a 500.
     return NextResponse.redirect(new URL("/pricing?billing=unavailable", req.url))
   }
 }

--- a/packages/web/app/api/portal/route.ts
+++ b/packages/web/app/api/portal/route.ts
@@ -2,25 +2,50 @@
  * shieldcn
  * app/api/portal/route.ts
  *
- * Polar customer portal. Sends the signed-in org's customer to Polar's hosted
- * portal to manage or cancel their subscription.
+ * Polar customer portal. Sends the signed-in owner (personal account or active
+ * team) to Polar's hosted portal to manage or cancel their subscription.
+ *
+ * Robust by construction: the portal must never 500. Callers with no session
+ * go to sign-in, callers with no paid plan go to pricing (nothing to manage),
+ * and any Polar error (customer not found for the active owner, server
+ * mismatch, etc.) degrades to pricing instead of a raw 500.
  */
 
 import { CustomerPortal } from "@polar-sh/nextjs"
-import { NextResponse } from "next/server"
+import { NextResponse, type NextRequest } from "next/server"
 import { requireOwner } from "@/lib/auth"
+import { getPlan } from "@shieldcn/core/entitlements"
 
 const accessToken = process.env.POLAR_ACCESS_TOKEN
 const server = (process.env.POLAR_SERVER as "sandbox" | "production") ?? "sandbox"
 
-export const GET = accessToken
-  ? CustomerPortal({
+export async function GET(req: NextRequest) {
+  if (!accessToken) {
+    return NextResponse.json({ error: "billing not configured" }, { status: 503 })
+  }
+
+  const auth = await requireOwner()
+  if (!auth) return NextResponse.redirect(new URL("/sign-in", req.url))
+
+  // A Polar customer only exists for an owner that has checked out. Without a
+  // paid plan there's nothing to manage — send them to pricing rather than
+  // asking Polar for a portal session that doesn't exist (which would 500).
+  const plan = await getPlan(auth.ownerId)
+  if (plan === "free") {
+    return NextResponse.redirect(new URL("/pricing?billing=none", req.url))
+  }
+
+  try {
+    const handler = CustomerPortal({
       accessToken,
       server,
-      // Customers are keyed by the org's external id (set at checkout).
-      getExternalCustomerId: async () => {
-        const auth = await requireOwner()
-        return auth?.ownerId ?? ""
-      },
+      // Customers are keyed by the owner's external id (set at checkout).
+      getExternalCustomerId: async () => auth.ownerId,
     })
-  : async () => NextResponse.json({ error: "billing not configured" }, { status: 503 })
+    return await handler(req)
+  } catch {
+    // Customer not found for this owner (e.g. checkout was on a different
+    // workspace), or a Polar/server hiccup — never surface a 500.
+    return NextResponse.redirect(new URL("/pricing?billing=unavailable", req.url))
+  }
+}


### PR DESCRIPTION
## What

The **Billing** link (`/api/portal`) returned **HTTP 500** on prod.

## Why

Polar's `CustomerPortal` throws when no customer exists for the requested external id. That happens when the active owner has no Polar customer — e.g. you're on a **team** that never checked out, or the checkout's `customerExternalId` (owner at checkout time) differs from the current active workspace. The throw rendered as a raw 500.

## How

Guard the route so it can never 500:
- No session → redirect to `/sign-in`.
- No paid plan (`getPlan === free`) → redirect to `/pricing?billing=none` (nothing to manage).
- Any Polar error → redirect to `/pricing?billing=unavailable`.

## Testing

Typecheck + ESLint clean. Logic verified by inspection; the guard short-circuits the two failure modes before/around the Polar call.