### PR TITLE
docs(pro): add Plus & Pro to docs sidebar; note self-hostable on pricing

### DIFF
--- a/packages/web/app/pricing/page.tsx
+++ b/packages/web/app/pricing/page.tsx
@@ -22,7 +22,12 @@ export default function PricingPage() {
             <p className="max-w-2xl text-base leading-relaxed text-muted-foreground">
               Public badges are free forever — that&apos;s the part that never
               changes. Paid plans add identity, control, and insight around your
-              badges, and keep shieldcn sustainable.
+              badges, and keep shieldcn sustainable. And shieldcn is, and always
+              will be,{" "}
+              <Link href="/docs/self-hosting" className="underline underline-offset-4 hover:text-foreground">
+                self-hostable
+              </Link>{" "}
+              — run the whole engine yourself, no plan required.
             </p>
           </div>
 

--- a/packages/web/components/sidebar.tsx
+++ b/packages/web/components/sidebar.tsx
@@ -62,6 +62,15 @@ const docsNav: NavGroup[] = [
     ],
   },
   {
+    title: "Plus & Pro",
+    items: [
+      { title: "Overview", href: "/docs/pro" },
+      { title: "Managed brands", href: "/docs/pro/brands" },
+      { title: "Hosted assets", href: "/docs/pro/assets" },
+      { title: "Analytics", href: "/docs/pro/analytics" },
+    ],
+  },
+  {
     title: "Customization",
     items: [
       { title: "Themes", href: "/docs/customization/themes" },


### PR DESCRIPTION
## What

- Adds a **Plus & Pro** section (Overview, Managed brands, Hosted assets, Analytics) to the docs sidebar.
- Pricing page now states shieldcn is, and always will be, **self-hostable**, linking to the self-hosting docs.

## Why

The Pro docs existed but weren't visible: the docs sidebar is a **custom component** (`components/sidebar.tsx`), not the meta.json page tree, so the earlier meta.json entry never surfaced them.

## Testing

Typecheck + ESLint clean.