### PR TITLE
feat(teams): cap team creation at one per user

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,8 @@
     "./entitlements": "./src/entitlements.ts",
     "./brands": "./src/brands.ts",
     "./badge-stats": "./src/badge-stats.ts",
-    "./studio-docs": "./src/studio-docs.ts"
+    "./studio-docs": "./src/studio-docs.ts",
+    "./teams": "./src/teams.ts"
   },
   "dependencies": {
     "@resvg/resvg-wasm": "^2.6.2",

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -258,5 +258,17 @@ export async function initDB() {
     );
     CREATE INDEX IF NOT EXISTS idx_badge_stats_brand
       ON badge_stats_daily (brand_id, day DESC);
+
+    -- Team-creation ledger. Team/member data lives in the hosted Neon Auth
+    -- store; we record each team a user *creates* here so the create cap can
+    -- be enforced (a user gets one created team; more only via invitation).
+    -- Keyed by the created org id so a double-submit can't double-count.
+    CREATE TABLE IF NOT EXISTS team_creations (
+      org_id TEXT PRIMARY KEY,
+      creator_user_id TEXT NOT NULL,
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    );
+    CREATE INDEX IF NOT EXISTS idx_team_creations_creator
+      ON team_creations (creator_user_id);
   `)
 }

--- a/packages/core/src/teams.ts
+++ b/packages/core/src/teams.ts
@@ -1,0 +1,57 @@
+/**
+ * @shieldcn/core
+ * src/teams.ts
+ *
+ * Team-creation cap. A user gets their personal account plus any teams they're
+ * invited to; they may *create* only a limited number themselves (abuse
+ * prevention). Team/member data lives in the hosted Neon Auth store, so we
+ * can't cheaply count "teams I own" there — instead we record each creation in
+ * our own Postgres (keyed by the created org id) and count against that.
+ *
+ * All reads fail open (never block a request on a DB hiccup); enforcement is
+ * best-effort-strict: the count is authoritative when the DB is reachable.
+ */
+
+import { query, initDB } from "./db"
+
+/** How many teams a single user may create. More come only via invitation. */
+export const TEAM_CREATE_LIMIT = 1
+
+/** Number of teams this user has created (owns). Fail-open to 0. */
+export async function countTeamsCreated(userId: string): Promise<number> {
+  if (!userId) return 0
+  try {
+    await initDB()
+    const { rows } = await query<{ n: string }>(
+      `SELECT COUNT(*)::text AS n FROM team_creations WHERE creator_user_id = $1`,
+      [userId],
+    )
+    return Number(rows[0]?.n ?? 0)
+  } catch {
+    return 0
+  }
+}
+
+/** Whether the user is under their team-creation cap. */
+export async function canCreateTeam(userId: string): Promise<boolean> {
+  return (await countTeamsCreated(userId)) < TEAM_CREATE_LIMIT
+}
+
+/**
+ * Record that a user created a team. Idempotent on the org id, so a retried
+ * webhook / double-submit doesn't double-count. Best-effort.
+ */
+export async function recordTeamCreation(orgId: string, userId: string): Promise<void> {
+  if (!orgId || !userId) return
+  try {
+    await initDB()
+    await query(
+      `INSERT INTO team_creations (org_id, creator_user_id)
+         VALUES ($1, $2)
+       ON CONFLICT (org_id) DO NOTHING`,
+      [orgId, userId],
+    )
+  } catch {
+    /* best-effort */
+  }
+}

--- a/packages/web/app/api/auth/[...path]/route.ts
+++ b/packages/web/app/api/auth/[...path]/route.ts
@@ -5,8 +5,50 @@
  * Neon Auth API proxy. All client auth calls (sign-in, sign-up, social,
  * session, organization) route through here and are proxied to the hosted
  * Neon Auth service, with session cookies signed for our own domain.
+ *
+ * Team-creation cap: org creation is intercepted so a user can create only a
+ * limited number of teams (more come via invitation). The check + record run
+ * against our own Postgres ledger, since team ownership lives in the hosted
+ * store and isn't cheaply queryable there.
  */
 
+import { NextResponse, type NextRequest } from "next/server"
 import { auth } from "@/lib/auth/server"
+import { canCreateTeam, recordTeamCreation } from "@shieldcn/core/teams"
 
-export const { GET, POST } = auth.handler()
+const handlers = auth.handler()
+
+export const GET = handlers.GET
+
+export async function POST(
+  req: NextRequest,
+  ctx: { params: Promise<{ path: string[] }> },
+) {
+  // Gate + ledger team creation.
+  if (req.nextUrl.pathname.endsWith("/organization/create")) {
+    const { data } = await auth.getSession().catch(() => ({ data: null }))
+    const userId = data?.user?.id
+    if (userId) {
+      if (!(await canCreateTeam(userId))) {
+        return NextResponse.json(
+          { message: "You can only create one team. To join more, ask to be invited." },
+          { status: 403 },
+        )
+      }
+      const res = await handlers.POST(req, ctx)
+      // Record the created org so it counts against the cap. Best-effort; a
+      // failure here never fails the create the user already completed.
+      if (res.ok) {
+        try {
+          const created = (await res.clone().json()) as { id?: string }
+          if (created?.id) await recordTeamCreation(created.id, userId)
+        } catch {
+          /* ignore — response wasn't JSON or had no id */
+        }
+      }
+      return res
+    }
+  }
+
+  return handlers.POST(req, ctx)
+}


### PR DESCRIPTION
## What

Caps team creation: a user may create **one** team; more come only via invitation.

## Why

Team creation was uncapped — a user could spin up unlimited teams.

## How

Team/member data lives in the hosted Neon Auth store, so "teams I own" isn't cheaply queryable there. Instead each created org is recorded in a small Postgres ledger (`team_creations`) keyed by org id, and creation is gated authoritatively in the **auth proxy**: `organization/create` is blocked past the cap (403 with a clear message the create dialog already surfaces), and on success the new org is recorded.

- `packages/core/src/teams.ts` — `TEAM_CREATE_LIMIT`, `countTeamsCreated`, `canCreateTeam`, `recordTeamCreation` (fail-open reads).
- `team_creations` table in `db.ts`.
- Auth proxy intercepts `organization/create`.

## Notes

- Existing teams predate the ledger and are grandfathered (going forward, the cap holds).
- Follow-up polish: hide the "New team" button client-side via a `canCreateTeam` flag on `/api/me` (currently the user sees the 403 message on attempt).