### PR TITLE
feat(ai): surface Generate button, emit real shieldcn badges via the skill

### DIFF
--- a/packages/web/app/api/ai/readme/route.ts
+++ b/packages/web/app/api/ai/readme/route.ts
@@ -4,7 +4,9 @@
  *
  * Generate a README (as GitHub-flavored Markdown) from a repo summary or
  * pasted package metadata. The Studio imports the markdown into typed blocks
- * via lib/studio-import, so the model only needs to emit clean Markdown.
+ * via lib/studio-import, so the model emits clean Markdown — including a real
+ * shieldcn badge row (not a placeholder). Pro callers may pass a brand slug to
+ * style every generated badge with their brand.
  *
  * Plus+ only. Usage is metered through Polar (see lib/ai).
  */
@@ -12,14 +14,67 @@
 import { NextResponse, type NextRequest } from "next/server"
 import { generateText } from "ai"
 import { requireOwner } from "@/lib/auth"
-import { hasPlan } from "@shieldcn/core/entitlements"
+import { getPlan, hasPlan } from "@shieldcn/core/entitlements"
+import { getOwnedBrand } from "@shieldcn/core/brands"
 import { aiModel, meterAiUsage, aiErrorResponse, aiConfigured } from "@/lib/ai"
+import { loadBadgeSkill } from "@/lib/badge-skill"
 
-const SYSTEM = `You are a technical writer generating a project README.
-Output GitHub-flavored Markdown only — no preamble, no code fence around the
-whole document. Include: an H1 title, a one-line description, a shieldcn badge
-row placeholder line reading "<!-- badges -->", Installation, Usage, and
-License sections. Keep prose tight and concrete. Do not invent features.`
+const SITE = process.env.NEXT_PUBLIC_URL ?? "https://shieldcn.dev"
+
+/**
+ * Build the system prompt. Teaches the real shieldcn badge URL format so the
+ * model emits working badges inferred from the project, optionally styled with
+ * a brand (`?brand=slug`, applied to every badge URL).
+ */
+/** Inline badge reference used only if the skill file can't be loaded. */
+const INLINE_BADGES = (q: string) => `shieldcn badges are real image URLs on ${SITE}. Use these formats, filling in
+the project's real identifiers (never leave literal placeholders):
+- npm version:      ![npm](${SITE}/npm/v/PACKAGE.svg${q})
+- npm downloads:    ![downloads](${SITE}/npm/dm/PACKAGE.svg${q})
+- GitHub stars:     ![stars](${SITE}/github/stars/OWNER/REPO.svg${q})
+- GitHub license:   ![license](${SITE}/github/license/OWNER/REPO.svg${q})
+- GitHub CI:        ![build](${SITE}/github/OWNER/REPO/ci.svg${q})
+- PyPI version:     ![pypi](${SITE}/pypi/v/PACKAGE.svg${q})
+- Static badge:     ![label](${SITE}/badge/LABEL-MESSAGE-COLOR.svg${q})`
+
+function buildSystem(brandSlug: string | null): string {
+  const q = brandSlug ? `?brand=${brandSlug}` : ""
+  const styleNote = brandSlug
+    ? `IMPORTANT: append "${q}" to EVERY shieldcn badge URL so they render in the
+"${brandSlug}" brand style.`
+    : `Optionally append "?variant=branded" to badge URLs for a colored look.`
+
+  // Prefer the published shieldcn-badges skill as the authoritative badge
+  // reference; fall back to the inline subset if the file isn't available.
+  const skill = loadBadgeSkill()
+  const reference = skill
+    ? `Below is the official shieldcn badge skill. Follow its badge, group, chart,
+and header syntax exactly, using ${SITE} as the base URL.
+
+=== shieldcn-badges skill ===
+${skill}
+=== end skill ===`
+    : INLINE_BADGES(q)
+
+  return `You are a technical writer generating a project README, and an expert
+at shieldcn badges.
+
+Output GitHub-flavored Markdown only — no preamble, no surrounding code fence.
+
+Structure, in order:
+1. An H1 title.
+2. A one-line description.
+3. A centered badge row of 3–5 relevant shieldcn badges as Markdown images,
+   wrapped in <p align="center"> … </p>. Infer the package name / GitHub
+   owner+repo from the context and use real values.
+4. Installation, Usage, and License sections.
+
+${reference}
+
+${styleNote}
+Only include badges that make sense for the project. Keep prose tight and
+concrete. Do not invent features.`
+}
 
 export async function POST(req: NextRequest) {
   if (!aiConfigured) {
@@ -31,7 +86,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "AI requires the Plus plan" }, { status: 402 })
   }
 
-  let body: { summary?: string; repo?: string }
+  let body: { summary?: string; repo?: string; brand?: string }
   try {
     body = await req.json()
   } catch {
@@ -42,10 +97,18 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "provide a summary or repo" }, { status: 400 })
   }
 
+  // A brand is a Pro capability — accept it only when the caller is Pro and
+  // actually owns that brand; otherwise generate unbranded.
+  let brandSlug: string | null = null
+  if (body.brand && (await getPlan(auth.ownerId)) === "pro") {
+    const owned = await getOwnedBrand(auth.ownerId, body.brand)
+    if (owned) brandSlug = owned.slug
+  }
+
   try {
     const { text, usage } = await generateText({
       model: aiModel(),
-      system: SYSTEM,
+      system: buildSystem(brandSlug),
       prompt: `Write a README for this project:\n\n${context}`,
     })
     meterAiUsage(auth.ownerId, usage)

--- a/packages/web/components/studio/cloud-menu.tsx
+++ b/packages/web/components/studio/cloud-menu.tsx
@@ -107,6 +107,9 @@ export function StudioCloudMenu(props: StudioCloudMenuProps) {
   const [aiDialog, setAiDialog] = useState(false)
   const [aiPrompt, setAiPrompt] = useState("")
   const [aiBusy, setAiBusy] = useState(false)
+  // Pro: pick one of your brands to style the generated badges.
+  const [brands, setBrands] = useState<{ slug: string; name: string | null }[]>([])
+  const [aiBrand, setAiBrand] = useState("")
 
   // Baseline = the exact blocks/themeAware references at the last save or open.
   // Reference identity is cheap and exact: Studio makes a new array on every
@@ -290,7 +293,14 @@ export function StudioCloudMenu(props: StudioCloudMenuProps) {
   const onGenerateClick = useCallback(() => {
     if (!gatePlus("AI README generation")) return
     setAiDialog(true)
-  }, [gatePlus])
+    // Pro: load the owner's brands so generated badges can be styled with one.
+    if (isPro) {
+      void fetch("/api/brands", { credentials: "include" })
+        .then((r) => (r.ok ? r.json() : { brands: [] }))
+        .then((j) => setBrands(Array.isArray(j.brands) ? j.brands : []))
+        .catch(() => {})
+    }
+  }, [gatePlus, isPro])
 
   const runGenerate = useCallback(async () => {
     const summary = aiPrompt.trim() || getMarkdown().slice(0, 4000)
@@ -299,7 +309,7 @@ export function StudioCloudMenu(props: StudioCloudMenuProps) {
     try {
       const res = await fetch("/api/ai/readme", {
         method: "POST", headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ summary }),
+        body: JSON.stringify({ summary, brand: aiBrand || undefined }),
       })
       const json = await res.json()
       if (!res.ok) {
@@ -317,7 +327,7 @@ export function StudioCloudMenu(props: StudioCloudMenuProps) {
     } finally {
       setAiBusy(false)
     }
-  }, [aiPrompt, getMarkdown, applyMarkdown])
+  }, [aiPrompt, aiBrand, getMarkdown, applyMarkdown])
 
   const onSaveAsBrand = useCallback(() => {
     if (!gatePro("Managed brands")) return
@@ -365,10 +375,18 @@ export function StudioCloudMenu(props: StudioCloudMenuProps) {
         </div>
       )}
 
+      {/* Generate with AI — a first-class toolbar action, not buried in a menu. */}
+      <Tip label="Generate a README with AI">
+        <Button size="sm" className="h-8 gap-1.5 shadow-sm" onClick={onGenerateClick} aria-label="Generate with AI">
+          <Sparkles className="size-4" />
+          <span className="hidden md:inline">Generate</span>
+        </Button>
+      </Tip>
+
       <DropdownMenu>
-        <Tip label={currentDocId != null ? "Cloud, AI & brand" : "Save to cloud, AI & brand"}>
+        <Tip label={currentDocId != null ? "Cloud & brand" : "Save to cloud & brand"}>
           <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="sm" className="h-8 gap-1.5" aria-label="Cloud, AI & brand">
+            <Button variant="outline" size="sm" className="h-8 gap-1.5" aria-label="Cloud & brand">
               <Cloud className="size-4" />
               <span className="hidden lg:inline">Cloud</span>
               <ChevronDown className="size-3.5 opacity-60" />
@@ -389,15 +407,6 @@ export function StudioCloudMenu(props: StudioCloudMenuProps) {
           )}
           <DropdownMenuItem onSelect={onOpenClick}>
             <FolderOpen className="size-4" /> Open…
-          </DropdownMenuItem>
-
-          <DropdownMenuSeparator />
-          <DropdownMenuLabel className="flex items-center justify-between">
-            AI
-            {!isPlus && <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">Plus</span>}
-          </DropdownMenuLabel>
-          <DropdownMenuItem onSelect={onGenerateClick}>
-            <Sparkles className="size-4" /> Generate with AI…
           </DropdownMenuItem>
 
           <DropdownMenuSeparator />
@@ -503,6 +512,23 @@ export function StudioCloudMenu(props: StudioCloudMenuProps) {
             rows={6}
             placeholder="acme-cli — a fast task runner for monorepos. Install via npm i -g acme-cli. Run `acme run <task>`…"
           />
+          {/* Pro: style the generated badges with one of your brands. */}
+          {isPro && brands.length > 0 && (
+            <div className="flex items-center gap-2">
+              <label htmlFor="ai-brand" className="text-xs text-muted-foreground">Badge style</label>
+              <select
+                id="ai-brand"
+                value={aiBrand}
+                onChange={(e) => setAiBrand(e.target.value)}
+                className="h-8 flex-1 rounded-md border border-border bg-transparent px-2 text-sm"
+              >
+                <option value="">Default</option>
+                {brands.map((b) => (
+                  <option key={b.slug} value={b.slug}>{b.name ?? b.slug} brand</option>
+                ))}
+              </select>
+            </div>
+          )}
           <DialogFooter>
             <Button variant="ghost" onClick={() => setAiDialog(false)}>Cancel</Button>
             <Button onClick={runGenerate} disabled={aiBusy}>

--- a/packages/web/lib/badge-skill.ts
+++ b/packages/web/lib/badge-skill.ts
@@ -1,0 +1,37 @@
+/**
+ * shieldcn
+ * lib/badge-skill.ts
+ *
+ * Loads the shieldcn-badges SKILL.md — the same agent skill published at
+ * /.well-known/agent-skills — as authoritative badge context for AI README
+ * generation, so the model uses real shieldcn badge/group/chart/header syntax
+ * instead of a hand-maintained subset. Server-only; cached per process; fails
+ * soft to an empty string (the caller falls back to inline examples).
+ */
+
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+let cached: string | null = null
+
+/** The shieldcn-badges skill body (frontmatter stripped), or "" if unavailable. */
+export function loadBadgeSkill(): string {
+  if (cached !== null) return cached
+  // Mirror the skill route's path resolution — monorepo cwd varies by env.
+  const candidates = [
+    join(process.cwd(), "..", "..", "skills", "shieldcn-badges", "SKILL.md"),
+    join(process.cwd(), "../../skills/shieldcn-badges/SKILL.md"),
+    join(process.cwd(), "skills", "shieldcn-badges", "SKILL.md"),
+  ]
+  for (const p of candidates) {
+    try {
+      const raw = readFileSync(p, "utf-8")
+      cached = raw.replace(/^---[\s\S]*?\n---\n/, "").trim()
+      return cached
+    } catch {
+      /* try the next candidate */
+    }
+  }
+  cached = ""
+  return cached
+}


### PR DESCRIPTION
## What

Three improvements to AI README generation:

1. **Prominent Generate button.** "Generate with AI" is now a first-class toolbar button (Sparkles) in the Studio, not buried in the Cloud dropdown.
2. **Real shieldcn badges.** The prompt now feeds the published **shieldcn-badges SKILL.md** (the same agent skill at `/.well-known/agent-skills`) to the model as its authoritative badge reference — so it emits real, correctly-formatted shieldcn badge/group/chart/header URLs using the project's actual identifiers, instead of a `<!-- badges -->` placeholder. Falls back to an inline subset if the skill file can't be read (so it never breaks).
3. **Brand-styled badges (Pro).** Pick one of your brands in the generate dialog and every generated badge is styled with it (`?brand=slug`). The server verifies Pro + brand ownership before applying.

## Testing

- E2E against the live gateway: generated a README for `vercel/next.js` with **5 real shieldcn badges** (stars, forks, downloads, license, last-commit) using correct identifiers.
- Typecheck + ESLint clean; production build succeeds.

## Note

Depends on #178 (gateway free-tier model + decoupled metering), already merged.