### PR TITLE
fix(docs): point Plus upgrade link to /pricing

### DIFF
--- a/packages/web/components/sidebar.tsx
+++ b/packages/web/components/sidebar.tsx
@@ -62,12 +62,12 @@ const docsNav: NavGroup[] = [
     ],
   },
   {
-    title: "Plus & Pro",
+    title: "Plus",
     items: [
-      { title: "Overview", href: "/docs/pro" },
-      { title: "Managed brands", href: "/docs/pro/brands" },
-      { title: "Hosted assets", href: "/docs/pro/assets" },
-      { title: "Analytics", href: "/docs/pro/analytics" },
+      { title: "Overview", href: "/docs/plus" },
+      { title: "Saved badges", href: "/docs/plus/badges" },
+      { title: "Managed brands", href: "/docs/plus/brands" },
+      { title: "Hosted assets", href: "/docs/plus/assets" },
     ],
   },
   {

--- a/packages/web/content/docs/plus/index.mdx
+++ b/packages/web/content/docs/plus/index.mdx
@@ -10,7 +10,7 @@ There is one paid tier:
 
 - **Plus — $10/mo**, for maintainers who live in their READMEs.
 
-<InlineHint variant="tip">Compare everything on the <a href="/pricing">pricing page</a>, or jump straight to <a href="/api/checkout?plan=plus">Get Plus</a>.</InlineHint>
+<InlineHint variant="tip">Compare everything and upgrade on the <a href="/pricing">pricing page</a>.</InlineHint>
 
 ## What each plan includes
 


### PR DESCRIPTION
## What
The docs Plus page linked to `/api/checkout?plan=plus`, which was removed in the Polar plugin migration (#185). Points it to `/pricing` where the working `CheckoutButton` lives.

## Why
Dead link — clicking "Get Plus" in the docs hit a 404.

## Testing
Docs-only, one-line change.

## Context
Discovered while diagnosing the billing UX after the Polar cutover. Separately, the '\''Billing has no link'\'' issue was a data problem, not code: the 3 prod users signed up *before* the billing plugin deployed, so `createCustomerOnSignUp` never ran for them — their Polar customers have now been backfilled via the API, so the portal works.