### PR TITLE
fix(billing): create Polar customer non-blocking so signup can't fail

### DIFF
--- a/packages/core/src/entitlements.test.ts
+++ b/packages/core/src/entitlements.test.ts
@@ -10,6 +10,7 @@ import {
   ownerIdFromSubscription,
   syncSubscriptionFromPolar,
   syncCustomerStateFromPolar,
+  deleteSubscriptionForCustomer,
 } from "./entitlements"
 
 describe("planForProduct", () => {
@@ -138,6 +139,25 @@ describe("syncCustomerStateFromPolar", () => {
   it("no-ops without an externalId", async () => {
     let called = false
     await syncCustomerStateFromPolar(async () => { called = true }, { id: "cus_x" })
+    expect(called).toBe(false)
+  })
+})
+
+describe("deleteSubscriptionForCustomer", () => {
+  it("deletes the owner's subscriptions row", async () => {
+    const calls: { text: string; params: unknown[] }[] = []
+    await deleteSubscriptionForCustomer(async (text, params) => { calls.push({ text, params }) }, {
+      id: "cus_1",
+      externalId: "user_1",
+    })
+    expect(calls).toHaveLength(1)
+    expect(calls[0].text).toContain("DELETE FROM subscriptions")
+    expect(calls[0].params[0]).toBe("user_1")
+  })
+
+  it("no-ops without an externalId", async () => {
+    let called = false
+    await deleteSubscriptionForCustomer(async () => { called = true }, { id: "cus_x" })
     expect(called).toBe(false)
   })
 })

--- a/packages/core/src/entitlements.ts
+++ b/packages/core/src/entitlements.ts
@@ -217,3 +217,25 @@ export async function syncCustomerStateFromPolar(
     customer: { id: state.id ?? null, externalId: ownerId },
   })
 }
+
+/** A Polar customer payload (from onCustomerUpdated / onCustomerDeleted). */
+export interface PolarCustomerLike {
+  id?: string | null
+  externalId?: string | null
+}
+
+/**
+ * Handle a deleted Polar customer: drop the owner's subscriptions row so
+ * getPlan() falls back to free. Keyed by externalId (the user id). No-op when
+ * the owner can't be resolved.
+ */
+export async function deleteSubscriptionForCustomer(
+  runQuery: (text: string, params: unknown[]) => Promise<unknown>,
+  customer: PolarCustomerLike,
+): Promise<void> {
+  const ownerId =
+    typeof customer.externalId === "string" && customer.externalId ? customer.externalId : null
+  if (!ownerId) return
+  await runQuery(`DELETE FROM subscriptions WHERE owner_id = $1`, [ownerId])
+  invalidatePlan(ownerId)
+}

--- a/packages/web/lib/auth/server.ts
+++ b/packages/web/lib/auth/server.ts
@@ -28,6 +28,7 @@ import { getPool, query } from "@shieldcn/core/db"
 import {
   syncSubscriptionFromPolar,
   syncCustomerStateFromPolar,
+  deleteSubscriptionForCustomer,
 } from "@shieldcn/core/entitlements"
 
 // A ≥32-char secret is required by Better Auth. In a build environment that
@@ -72,9 +73,8 @@ export const auth = betterAuth({
 
   user: {
     // When a user deletes their account, delete their Polar customer too so we
-    // don't leave an orphaned billing record. externalId is the user id
-    // (createCustomerOnSignUp). Best-effort: a Polar hiccup must not block the
-    // account deletion itself.
+    // don't leave an orphaned billing record. externalId is the user id.
+    // Best-effort: a Polar hiccup must not block the account deletion itself.
     deleteUser: {
       enabled: true,
       afterDelete: async (u) => {
@@ -83,6 +83,43 @@ export const auth = betterAuth({
         } catch {
           // ignore — the customer may already be gone or billing unconfigured
         }
+      },
+    },
+  },
+
+  databaseHooks: {
+    user: {
+      create: {
+        // Create a Polar customer for EVERY new user (free included), keyed by
+        // externalId = user.id, so the whole user base is visible in Polar.
+        //
+        // This is a create.after hook (runs after the user row is committed and
+        // outside the signup transaction), and it's fully wrapped in try/catch,
+        // so a Polar failure — downtime, a rejected email, a rate limit — can
+        // NEVER block signup. (The plugin's own createCustomerOnSignUp uses a
+        // throwing before-hook, which is why it's disabled below.) Checkout also
+        // auto-creates the customer from externalCustomerId as a backstop.
+        after: async (u) => {
+          if (!process.env.POLAR_ACCESS_TOKEN) return
+          try {
+            const { result } = await polarClient.customers.list({ email: u.email })
+            const existing = result.items[0]
+            if (!existing) {
+              await polarClient.customers.create({
+                email: u.email,
+                name: u.name || undefined,
+                externalId: u.id,
+              })
+            } else if (existing.externalId !== u.id) {
+              await polarClient.customers.update({
+                id: existing.id,
+                customerUpdate: { externalId: u.id },
+              })
+            }
+          } catch {
+            // best-effort — checkout will create the customer if this missed
+          }
+        },
       },
     },
   },
@@ -100,12 +137,14 @@ export const auth = betterAuth({
     // personal user id).
     organization(),
 
-    // Billing. Checkout + portal + webhooks via Polar. createCustomerOnSignUp
-    // keys the Polar customer by the user id (externalId), which is exactly the
-    // owner key our subscriptions table + getPlan() use.
+    // Billing. Checkout + portal + webhooks via Polar. Customers are keyed by
+    // the user id (externalId) — the same owner key our subscriptions table +
+    // getPlan() use. The plugin's createCustomerOnSignUp is disabled because its
+    // throwing before-hook would block signup on any Polar failure; we create
+    // the customer via a non-blocking create.after hook instead (above).
     polar({
       client: polarClient,
-      createCustomerOnSignUp: true,
+      createCustomerOnSignUp: false,
       use: [
         checkout({
           products: polarProductId
@@ -125,8 +164,14 @@ export const auth = betterAuth({
           onSubscriptionCanceled: (p) => syncSubscriptionFromPolar(query, p.data as never),
           onSubscriptionRevoked: (p) => syncSubscriptionFromPolar(query, p.data as never),
           // Robust catch-all for access: whenever anything about a customer
-          // changes, reconcile our subscriptions row from their active subs.
+          // changes (incl. their subscriptions), reconcile our subscriptions
+          // row from their active subs. This is the event that carries
+          // activeSubscriptions, so it's the authoritative access sync.
           onCustomerStateChanged: (p) => syncCustomerStateFromPolar(query, p.data as never),
+          // Deleting a Polar customer drops their subscriptions row so getPlan()
+          // falls back to free. (customer.updated carries only profile fields,
+          // not subscriptions, so it doesn't touch entitlements.)
+          onCustomerDeleted: (p) => deleteSubscriptionForCustomer(query, p.data as never),
         }),
       ],
     }),


### PR DESCRIPTION
## What
The Polar plugin's `createCustomerOnSignUp` runs a **throwing `create.before` hook** — if Polar rejects the email or is down, the entire signup **500s and no account is created**. Found via a prod test signup (`@example.com` → `Polar customer creation failed`).

## Why
Signup must never depend on a third-party billing call succeeding. But we still want every user (**free included**) to appear as a Polar customer so the whole user base is visible in Polar.

## How
- `createCustomerOnSignUp: false` — disables the throwing before-hook.
- Add `databaseHooks.user.create.after` that creates/links the Polar customer (`externalId = user.id`), fully `try/catch`-wrapped. It runs **after** the user row is committed and **outside** the signup transaction (Better Auth queues `create.after` post-transaction), so a Polar failure can **never** block signup.
- Checkout already auto-creates the customer from `externalCustomerId` as a backstop.

### Full customer sync (the reported gap)
- `onCustomerDeleted` → new `deleteSubscriptionForCustomer()` drops the owner's `subscriptions` row so `getPlan()` falls back to free — keeps the DB honest when a Polar customer is deleted.
- `onCustomerStateChanged` stays the authoritative access sync (it carries `activeSubscriptions`). `customer.updated` is intentionally not wired (profile-only, no entitlement impact).

## Testing
- `pnpm typecheck` ✓, `eslint` ✓, **314 core / 78 web** tests (new coverage for `deleteSubscriptionForCustomer`).
- Root cause reproduced on prod; this makes signup resilient.

## Prod note
After merge+deploy: subscribe the Polar webhook endpoint to `customer.deleted` (in addition to `customer.state_changed` + subscription events) so the deletion sync fires.