### PR TITLE
feat(auth): password reset + email verification via Resend

### DIFF
--- a/packages/web/app/forgot-password/page.tsx
+++ b/packages/web/app/forgot-password/page.tsx
@@ -1,22 +1,19 @@
 import type { Metadata } from "next"
-import { Suspense } from "react"
 import { SiteShell } from "@/components/site-shell"
-import { AuthForm } from "@/components/auth/auth-form"
+import { ForgotPasswordForm } from "@/components/auth/forgot-password-form"
 import { pageMetadata } from "@/lib/metadata"
 
 export const metadata: Metadata = pageMetadata({
-  title: "Sign in",
-  description: "Sign in to your shieldcn workspace.",
-  path: "/sign-in",
+  title: "Forgot password",
+  description: "Reset your shieldcn password.",
+  path: "/forgot-password",
 })
 
-export default function SignInPage() {
+export default function ForgotPasswordPage() {
   return (
     <SiteShell>
       <main className="flex min-w-0 flex-1 items-center justify-center px-6 py-20">
-        <Suspense fallback={null}>
-          <AuthForm mode="sign-in" />
-        </Suspense>
+        <ForgotPasswordForm />
       </main>
     </SiteShell>
   )

--- a/packages/web/app/reset-password/page.tsx
+++ b/packages/web/app/reset-password/page.tsx
@@ -1,21 +1,21 @@
 import type { Metadata } from "next"
 import { Suspense } from "react"
 import { SiteShell } from "@/components/site-shell"
-import { AuthForm } from "@/components/auth/auth-form"
+import { ResetPasswordForm } from "@/components/auth/reset-password-form"
 import { pageMetadata } from "@/lib/metadata"
 
 export const metadata: Metadata = pageMetadata({
-  title: "Sign in",
-  description: "Sign in to your shieldcn workspace.",
-  path: "/sign-in",
+  title: "Reset password",
+  description: "Choose a new password for your shieldcn account.",
+  path: "/reset-password",
 })
 
-export default function SignInPage() {
+export default function ResetPasswordPage() {
   return (
     <SiteShell>
       <main className="flex min-w-0 flex-1 items-center justify-center px-6 py-20">
         <Suspense fallback={null}>
-          <AuthForm mode="sign-in" />
+          <ResetPasswordForm />
         </Suspense>
       </main>
     </SiteShell>

--- a/packages/web/app/sign-up/page.tsx
+++ b/packages/web/app/sign-up/page.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from "next"
+import { Suspense } from "react"
 import { SiteShell } from "@/components/site-shell"
 import { AuthForm } from "@/components/auth/auth-form"
 import { pageMetadata } from "@/lib/metadata"
 
 export const metadata: Metadata = pageMetadata({
   title: "Sign up",
-  description: "Create a shieldcn account to save READMEs, brands, and analytics.",
+  description: "Create a shieldcn account to save READMEs, badges, and brands.",
   path: "/sign-up",
 })
 
@@ -13,7 +14,9 @@ export default function SignUpPage() {
   return (
     <SiteShell>
       <main className="flex min-w-0 flex-1 items-center justify-center px-6 py-20">
-        <AuthForm mode="sign-up" callbackURL="/welcome" />
+        <Suspense fallback={null}>
+          <AuthForm mode="sign-up" callbackURL="/welcome" />
+        </Suspense>
       </main>
     </SiteShell>
   )

--- a/packages/web/components/auth/auth-form.tsx
+++ b/packages/web/components/auth/auth-form.tsx
@@ -11,7 +11,7 @@
  */
 
 import { useState } from "react"
-import { useRouter } from "next/navigation"
+import { useRouter, useSearchParams } from "next/navigation"
 import Link from "next/link"
 import { Loader2 } from "lucide-react"
 import { authClient } from "@/lib/auth/client"
@@ -38,6 +38,8 @@ export function AuthForm({
   callbackURL?: string
 }) {
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const resetOk = searchParams.get("reset") === "success"
   const isSignUp = mode === "sign-up"
   const [name, setName] = useState("")
   const [email, setEmail] = useState("")
@@ -92,6 +94,11 @@ export function AuthForm({
       </CardHeader>
 
       <CardContent className="flex flex-col gap-4">
+        {resetOk && !isSignUp && (
+          <p className="rounded-md bg-emerald-500/10 px-3 py-2 text-sm text-emerald-500 ring-1 ring-inset ring-emerald-500/20">
+            Password reset — sign in with your new password.
+          </p>
+        )}
         <div className="flex flex-col gap-2">
           <Button
             type="button"
@@ -137,7 +144,17 @@ export function AuthForm({
             />
           </div>
           <div className="flex flex-col gap-1.5">
-            <Label htmlFor="password">Password</Label>
+            <div className="flex items-center justify-between">
+              <Label htmlFor="password">Password</Label>
+              {!isSignUp && (
+                <Link
+                  href="/forgot-password"
+                  className="text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+                >
+                  Forgot password?
+                </Link>
+              )}
+            </div>
             <Input
               id="password"
               type="password"

--- a/packages/web/components/auth/forgot-password-form.tsx
+++ b/packages/web/components/auth/forgot-password-form.tsx
@@ -1,0 +1,115 @@
+"use client"
+
+/**
+ * shieldcn
+ * components/auth/forgot-password-form.tsx
+ *
+ * "Forgot password" — collects an email and triggers Better Auth's
+ * requestPasswordReset, which emails a reset link (via lib/email.ts). Always
+ * shows a neutral success message regardless of whether the email exists
+ * (avoids user enumeration).
+ */
+
+import { useState } from "react"
+import Link from "next/link"
+import { Loader2, MailCheck } from "lucide-react"
+import { authClient } from "@/lib/auth/client"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle,
+} from "@/components/ui/card"
+
+export function ForgotPasswordForm() {
+  const [email, setEmail] = useState("")
+  const [pending, setPending] = useState(false)
+  const [sent, setSent] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setPending(true)
+    try {
+      // redirectTo is where the emailed link lands (the reset page).
+      const { error } = await authClient.requestPasswordReset({
+        email,
+        redirectTo: "/reset-password",
+      })
+      // Show success either way — don't reveal whether the email is registered.
+      if (error && error.status !== 200) {
+        // Only surface hard failures (e.g. network); enumeration-safe otherwise.
+        setSent(true)
+      } else {
+        setSent(true)
+      }
+    } catch {
+      setError("Something went wrong. Please try again.")
+    } finally {
+      setPending(false)
+    }
+  }
+
+  if (sent) {
+    return (
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <div className="mb-1 flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary ring-1 ring-inset ring-primary/20">
+            <MailCheck className="size-5" />
+          </div>
+          <CardTitle>Check your email</CardTitle>
+          <CardDescription>
+            If an account exists for <span className="font-medium text-foreground">{email}</span>,
+            we&apos;ve sent a password reset link. It expires in 1 hour.
+          </CardDescription>
+        </CardHeader>
+        <CardFooter>
+          <Button asChild variant="outline" className="w-full">
+            <Link href="/sign-in">Back to sign in</Link>
+          </Button>
+        </CardFooter>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className="w-full max-w-sm">
+      <CardHeader>
+        <CardTitle>Reset your password</CardTitle>
+        <CardDescription>
+          Enter your email and we&apos;ll send you a link to choose a new password.
+        </CardDescription>
+      </CardHeader>
+      <form onSubmit={onSubmit}>
+        <CardContent className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              autoComplete="email"
+              required
+              autoFocus
+            />
+          </div>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          <Button type="submit" className="w-full" disabled={pending}>
+            {pending && <Loader2 className="size-4 animate-spin" />}
+            Send reset link
+          </Button>
+        </CardContent>
+      </form>
+      <CardFooter>
+        <Link
+          href="/sign-in"
+          className="mx-auto text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+        >
+          Back to sign in
+        </Link>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/packages/web/components/auth/reset-password-form.tsx
+++ b/packages/web/components/auth/reset-password-form.tsx
@@ -1,0 +1,130 @@
+"use client"
+
+/**
+ * shieldcn
+ * components/auth/reset-password-form.tsx
+ *
+ * Reset-password page. Better Auth redirects the emailed link here with
+ * ?token=… (or ?error=INVALID_TOKEN if it lapsed). Collects a new password and
+ * calls authClient.resetPassword({ newPassword, token }); on success, sends the
+ * user to sign in.
+ */
+
+import { useState } from "react"
+import Link from "next/link"
+import { useRouter, useSearchParams } from "next/navigation"
+import { Loader2 } from "lucide-react"
+import { authClient } from "@/lib/auth/client"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle,
+} from "@/components/ui/card"
+
+export function ResetPasswordForm() {
+  const router = useRouter()
+  const params = useSearchParams()
+  const token = params.get("token")
+  const linkError = params.get("error")
+
+  const [password, setPassword] = useState("")
+  const [confirm, setConfirm] = useState("")
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Invalid / expired / missing token — the link is unusable.
+  if (!token || linkError) {
+    return (
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle>Link expired</CardTitle>
+          <CardDescription>
+            This password reset link is invalid or has expired. Request a new one to continue.
+          </CardDescription>
+        </CardHeader>
+        <CardFooter className="flex flex-col gap-2">
+          <Button asChild className="w-full">
+            <Link href="/forgot-password">Request a new link</Link>
+          </Button>
+          <Button asChild variant="ghost" className="w-full">
+            <Link href="/sign-in">Back to sign in</Link>
+          </Button>
+        </CardFooter>
+      </Card>
+    )
+  }
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    if (password !== confirm) {
+      setError("Passwords don't match.")
+      return
+    }
+    setPending(true)
+    try {
+      const { error } = await authClient.resetPassword({ newPassword: password, token: token! })
+      if (error) {
+        setError(error.message ?? "Couldn't reset your password. The link may have expired.")
+        return
+      }
+      router.push("/sign-in?reset=success")
+    } catch {
+      setError("Something went wrong. Please try again.")
+    } finally {
+      setPending(false)
+    }
+  }
+
+  return (
+    <Card className="w-full max-w-sm">
+      <CardHeader>
+        <CardTitle>Choose a new password</CardTitle>
+        <CardDescription>Enter a new password for your account.</CardDescription>
+      </CardHeader>
+      <form onSubmit={onSubmit}>
+        <CardContent className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="new-password">New password</Label>
+            <Input
+              id="new-password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              autoComplete="new-password"
+              required
+              minLength={8}
+              autoFocus
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="confirm-password">Confirm password</Label>
+            <Input
+              id="confirm-password"
+              type="password"
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              autoComplete="new-password"
+              required
+              minLength={8}
+            />
+          </div>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          <Button type="submit" className="w-full" disabled={pending}>
+            {pending && <Loader2 className="size-4 animate-spin" />}
+            Reset password
+          </Button>
+        </CardContent>
+      </form>
+      <CardFooter>
+        <Link
+          href="/sign-in"
+          className="mx-auto text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+        >
+          Back to sign in
+        </Link>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/packages/web/lib/auth/server.ts
+++ b/packages/web/lib/auth/server.ts
@@ -25,6 +25,7 @@ import { organization } from "better-auth/plugins"
 import { polar, checkout, portal, webhooks } from "@polar-sh/better-auth"
 import { Polar } from "@polar-sh/sdk"
 import { getPool, query } from "@shieldcn/core/db"
+import { sendEmail, resetPasswordEmail, verifyEmail } from "@/lib/email"
 import {
   syncSubscriptionFromPolar,
   syncCustomerStateFromPolar,
@@ -69,6 +70,26 @@ export const auth = betterAuth({
 
   emailAndPassword: {
     enabled: true,
+    // Revoke other sessions when a password is reset (a reset often means the
+    // account was compromised or the user forgot it on a shared device).
+    revokeSessionsOnPasswordReset: true,
+    // "Forgot password" → email a reset link. Fire-and-forget: don't await the
+    // send (avoids timing attacks + a slow provider blocking the request).
+    sendResetPassword: async ({ user, url }) => {
+      const { subject, html, text } = resetPasswordEmail(url)
+      void sendEmail({ to: user.email, subject, html, text })
+    },
+  },
+
+  emailVerification: {
+    // Send a verification email on sign-up, but DON'T require it to use the app
+    // (requireEmailVerification stays off). Non-blocking — unverified users can
+    // still sign in; verification is encouraged, not enforced.
+    sendOnSignUp: true,
+    sendVerificationEmail: async ({ user, url }) => {
+      const { subject, html, text } = verifyEmail(url)
+      void sendEmail({ to: user.email, subject, html, text })
+    },
   },
 
   user: {

--- a/packages/web/lib/email.ts
+++ b/packages/web/lib/email.ts
@@ -1,0 +1,104 @@
+/**
+ * shieldcn
+ * lib/email.ts
+ *
+ * Transactional email via Resend. Used by the Better Auth flows
+ * (password reset, email verification). Kept intentionally small: one Resend
+ * client, a couple of branded HTML templates, and a single send() that never
+ * throws — a mail failure must not break an auth request.
+ *
+ * Configured via env:
+ *   RESEND_API_KEY   — Resend API key (unset in local dev; sends are skipped)
+ *   EMAIL_FROM       — verified sender, e.g. "shieldcn <noreply@shieldcn.dev>"
+ */
+
+import { Resend } from "resend"
+
+const apiKey = process.env.RESEND_API_KEY
+const from = process.env.EMAIL_FROM || "shieldcn <noreply@shieldcn.dev>"
+const SITE = process.env.NEXT_PUBLIC_URL || "https://shieldcn.dev"
+
+// Lazily construct the client so a missing key doesn't crash module load
+// (local dev / build without email configured). Sends are skipped when unset.
+const resend = apiKey ? new Resend(apiKey) : null
+
+export interface SendArgs {
+  to: string
+  subject: string
+  html: string
+  text: string
+}
+
+/**
+ * Send an email, best-effort. Never throws — returns false on failure or when
+ * email isn't configured, so the caller (an auth flow) is never blocked.
+ */
+export async function sendEmail({ to, subject, html, text }: SendArgs): Promise<boolean> {
+  if (!resend) {
+    // Not configured (e.g. local dev). Log so devs can grab the link from stdout.
+    if (process.env.NODE_ENV !== "production") {
+      console.info(`[email:skipped] to=${to} subject="${subject}"\n${text}`)
+    }
+    return false
+  }
+  try {
+    const { error } = await resend.emails.send({ from, to, subject, html, text })
+    if (error) {
+      console.error("[email] send failed:", error.message)
+      return false
+    }
+    return true
+  } catch (e) {
+    console.error("[email] send threw:", e instanceof Error ? e.message : e)
+    return false
+  }
+}
+
+// ── Templates ────────────────────────────────────────────────────────────────
+
+/** Shared shell: dark, minimal, matches the shieldcn aesthetic. */
+function shell(heading: string, body: string, cta: { label: string; url: string }): string {
+  return `<!doctype html>
+<html>
+  <body style="margin:0;background:#09090b;color:#e4e4e7;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,sans-serif;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#09090b;padding:40px 16px;">
+      <tr><td align="center">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:440px;background:#111113;border:1px solid #27272a;border-radius:12px;padding:32px;">
+          <tr><td>
+            <p style="margin:0 0 24px;font-size:15px;font-weight:700;letter-spacing:-0.01em;color:#fafafa;">shieldcn</p>
+            <h1 style="margin:0 0 12px;font-size:20px;font-weight:600;letter-spacing:-0.02em;color:#fafafa;">${heading}</h1>
+            <p style="margin:0 0 24px;font-size:14px;line-height:1.6;color:#a1a1aa;">${body}</p>
+            <a href="${cta.url}" style="display:inline-block;background:#fafafa;color:#09090b;text-decoration:none;font-size:14px;font-weight:600;padding:10px 18px;border-radius:8px;">${cta.label}</a>
+            <p style="margin:24px 0 0;font-size:12px;line-height:1.6;color:#71717a;">Or paste this link into your browser:<br><a href="${cta.url}" style="color:#a1a1aa;word-break:break-all;">${cta.url}</a></p>
+          </td></tr>
+        </table>
+        <p style="margin:20px 0 0;font-size:12px;color:#52525b;"><a href="${SITE}" style="color:#71717a;text-decoration:none;">${SITE.replace(/^https?:\/\//, "")}</a></p>
+      </td></tr>
+    </table>
+  </body>
+</html>`
+}
+
+export function resetPasswordEmail(url: string): { subject: string; html: string; text: string } {
+  return {
+    subject: "Reset your shieldcn password",
+    html: shell(
+      "Reset your password",
+      "We got a request to reset your shieldcn password. Click below to choose a new one. This link expires in 1 hour. If you didn't request this, you can safely ignore this email.",
+      { label: "Reset password", url },
+    ),
+    text: `Reset your shieldcn password:\n${url}\n\nThis link expires in 1 hour. If you didn't request this, ignore this email.`,
+  }
+}
+
+export function verifyEmail(url: string): { subject: string; html: string; text: string } {
+  return {
+    subject: "Verify your email for shieldcn",
+    html: shell(
+      "Verify your email",
+      "Confirm your email address to secure your shieldcn account. Click below to verify.",
+      { label: "Verify email", url },
+    ),
+    text: `Verify your email for shieldcn:\n${url}`,
+  }
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -76,6 +76,7 @@
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
+    "resend": "^6.17.1",
     "shiki": "^4.3.0",
     "sonner": "^2.0.7",
     "svgo": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,7 +193,7 @@ importers:
         version: 2.6.2
       '@sentry/nextjs':
         specifier: ^10.63.0
-        version: 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.107.2(lightningcss@1.32.0))
+        version: 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.107.2(lightningcss@1.32.0))
       '@shieldcn/core':
         specifier: workspace:*
         version: link:../core
@@ -341,6 +341,9 @@ importers:
       remark-parse:
         specifier: ^11.0.0
         version: 11.0.0
+      resend:
+        specifier: ^6.17.1
+        version: 6.17.1
       shiki:
         specifier: ^4.3.0
         version: 4.3.0
@@ -6373,6 +6376,9 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
@@ -6706,6 +6712,15 @@ packages:
 
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
+
+  resend@6.17.1:
+    resolution: {integrity: sha512-QhHHIRPPM9Tq2uilWmNF8C8kd6nLkUmiFgDQCt1v4eR4o+6p86qrK+Vn12jnAs0jR8Gf6ABdxI18/90LGQ7GVA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -9774,31 +9789,6 @@ snapshots:
   '@sentry/feedback@10.63.0':
     dependencies:
       '@sentry/core': 10.63.0
-
-  '@sentry/nextjs@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.107.2(lightningcss@1.32.0))':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@rollup/plugin-commonjs': 28.0.1(rollup@4.62.2)
-      '@sentry/browser-utils': 10.63.0
-      '@sentry/bundler-plugin-core': 5.3.0
-      '@sentry/conventions': 0.12.0
-      '@sentry/core': 10.63.0
-      '@sentry/node': 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))
-      '@sentry/opentelemetry': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
-      '@sentry/react': 10.63.0(react@19.2.7)
-      '@sentry/vercel-edge': 10.63.0
-      '@sentry/webpack-plugin': 5.3.0(webpack@5.107.2(lightningcss@1.32.0))
-      next: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      rollup: 4.62.2
-      stacktrace-parser: 0.1.11
-    transitivePeerDependencies:
-      - '@opentelemetry/core'
-      - '@opentelemetry/exporter-trace-otlp-http'
-      - '@opentelemetry/sdk-trace-base'
-      - encoding
-      - react
-      - supports-color
-      - webpack
 
   '@sentry/nextjs@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.107.2(lightningcss@1.32.0))':
     dependencies:
@@ -14075,6 +14065,8 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postal-mime@2.7.4: {}
+
   postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.16)(tsx@4.22.5)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
@@ -14560,6 +14552,11 @@ snapshots:
       - supports-color
 
   reselect@5.1.1: {}
+
+  resend@6.17.1:
+    dependencies:
+      postal-mime: 2.7.4
+      standardwebhooks: 1.0.0
 
   resolve-from@4.0.0: {}
 


### PR DESCRIPTION
## What
Adds the missing email flows to the self-hosted Better Auth setup:
- **Password reset** ("forgot password" → email → reset page)
- **Email verification** (sent on signup, **not required** to use the app)

Wired to **Resend** directly in Better Auth's callbacks — no `@better-auth/infra` SaaS. The Resend × Vercel integration provisions `RESEND_API_KEY`; `shieldcn.dev` is a verified sender.

## Why
The bare `emailAndPassword: { enabled: true }` had **no email at all** — no password recovery (users could get locked out) and no verification.

## How
- **`lib/email.ts`** — Resend client + branded dark HTML templates. `send()` never throws and is skipped (logs the link) when `RESEND_API_KEY` is unset, so dev + build work without email configured.
- **`server.ts`** — `sendResetPassword`, `sendVerificationEmail` + `sendOnSignUp: true` (verification encouraged, not enforced), `revokeSessionsOnPasswordReset: true`.
- **UI** — `/forgot-password` (enumeration-safe) + `/reset-password` (reads `?token`), a "Forgot password?" link on sign-in, and a post-reset success banner. sign-in/up wrapped in `Suspense`.
- Fixed stale sign-up copy ("analytics" → "badges").

## Testing
- Verified on dev: signup fires the verify email; forgot-password fires the reset email; **full reset loop works** (link → token → `resetPassword` → 200).
- Resend send from `noreply@shieldcn.dev` confirmed working in prod.
- `typecheck` ✓, `eslint .` ✓, **314 core / 78 web** tests.

## Prod note
No new config needed — `RESEND_API_KEY` is already set (all envs) and the domain is verified. `EMAIL_FROM` defaults to `shieldcn <noreply@shieldcn.dev>`; set the env var only to change the sender.