### PR TITLE
feat(badges): raise saved caps to 5/75 + dashboard badge builder

### DIFF
--- a/packages/core/src/saved-badges.ts
+++ b/packages/core/src/saved-badges.ts
@@ -19,8 +19,8 @@ import { query, initDB } from "./db"
  * (the account-creation hook); Plus raises it. Kept in step with the saved-
  * README caps so the two libraries feel consistent.
  */
-export const FREE_BADGE_LIMIT = 2
-export const PLUS_BADGE_LIMIT = 50
+export const FREE_BADGE_LIMIT = 5
+export const PLUS_BADGE_LIMIT = 75
 
 /** Saved-badge cap for a plan. Single source of truth for route + dashboard. */
 export function badgeLimitForPlan(plan: string): number {

--- a/packages/core/src/studio-docs.ts
+++ b/packages/core/src/studio-docs.ts
@@ -12,8 +12,8 @@ import { query, initDB } from "./db"
  * Saved-document caps. Free gets a small cloud allowance so signing up is
  * worthwhile (the account-creation hook); paid plans raise it.
  */
-export const FREE_DOC_LIMIT = 2
-export const PLUS_DOC_LIMIT = 50
+export const FREE_DOC_LIMIT = 5
+export const PLUS_DOC_LIMIT = 75
 
 /** Saved-README cap for a plan. Single source of truth for route + dashboard. */
 export function docLimitForPlan(plan: string): number {

--- a/packages/web/app/dashboard/page.tsx
+++ b/packages/web/app/dashboard/page.tsx
@@ -99,7 +99,7 @@ export default async function DashboardPage() {
             )}
             {plan === "free" && (
               <p className="text-xs text-muted-foreground">
-                Free syncs 2 READMEs.{" "}
+                Free syncs 5 READMEs.{" "}
                 <Link href="/pricing" className="underline underline-offset-4 hover:text-foreground">
                   Plus
                 </Link>{" "}

--- a/packages/web/components/badge-builder.tsx
+++ b/packages/web/components/badge-builder.tsx
@@ -105,8 +105,11 @@ export function BadgeBuilder() {
             copyError={copyError}
             onCopy={() => copy(output)}
           />
-          <div className="flex justify-end">
-            <SaveBadgeButton state={s} />
+          <div className="flex items-center justify-between gap-3 rounded-lg border border-border bg-muted/20 px-3 py-2.5">
+            <p className="text-xs text-muted-foreground">
+              Save this badge to reuse it in any README.
+            </p>
+            <SaveBadgeButton state={s} className="shrink-0" />
           </div>
         </>
       )}

--- a/packages/web/components/dashboard/badges-library.tsx
+++ b/packages/web/components/dashboard/badges-library.tsx
@@ -19,6 +19,7 @@ import Link from "next/link"
 import { BadgeCheck, Copy, Loader2, Trash2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { UsageMeter } from "@/components/dashboard/usage-meter"
+import { NewBadgeDialog } from "@/components/dashboard/new-badge-dialog"
 import { useBadgeMode } from "@/lib/use-badge-mode"
 import { useHydrated } from "@/lib/use-hydrated"
 import { buildBadgeUrl, BUILDER_DEFAULTS, type BuilderState } from "@/lib/badge-builder-shared"
@@ -107,9 +108,20 @@ export function BadgesLibrary({
           upsellHref={plan === "free" ? "/pricing" : undefined}
           upsellLabel="Upgrade for more"
         />
-        <Button asChild size="sm" disabled={atLimit}>
-          <Link href={atLimit ? "/pricing" : "/studio"}>Save from Studio</Link>
-        </Button>
+        <div className="flex items-center gap-2">
+          {atLimit ? (
+            <Button asChild size="sm" variant="outline">
+              <Link href="/pricing">Upgrade for more</Link>
+            </Button>
+          ) : (
+            <>
+              <Button asChild size="sm" variant="outline">
+                <Link href="/studio">From Studio</Link>
+              </Button>
+              <NewBadgeDialog onSaved={refresh} disabled={atLimit} />
+            </>
+          )}
+        </div>
       </div>
 
       {badges.length === 0 ? (
@@ -120,14 +132,17 @@ export function BadgesLibrary({
           <div className="flex flex-col gap-1">
             <h2 className="text-lg font-semibold">No saved badges yet</h2>
             <p className="mx-auto max-w-sm text-sm text-muted-foreground">
-              Configure a badge in the Studio or the builder, hit{" "}
+              Configure a badge here or in the Studio, hit{" "}
               <strong>Save badge</strong>, and it lands here — ready to reuse
               anywhere with one click.
             </p>
           </div>
-          <Button asChild>
-            <Link href="/studio">Open the Studio</Link>
-          </Button>
+          <div className="flex items-center gap-2">
+            <NewBadgeDialog onSaved={refresh} />
+            <Button asChild variant="outline">
+              <Link href="/studio">Open the Studio</Link>
+            </Button>
+          </div>
         </div>
       ) : (
         <ul className="flex flex-col divide-y divide-border rounded-lg border border-border">

--- a/packages/web/components/dashboard/new-badge-dialog.tsx
+++ b/packages/web/components/dashboard/new-badge-dialog.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+/**
+ * shieldcn
+ * components/dashboard/new-badge-dialog.tsx
+ *
+ * Build + save a badge without leaving the dashboard. Wraps BadgeBuilderCore in
+ * a dialog with the standard SaveBadgeButton; on a successful save it closes and
+ * calls onSaved so the library refreshes. This is the dashboard-native path to
+ * grow the saved-badges library (the Studio inspector remains the other path).
+ */
+
+import { useMemo, useState } from "react"
+import { Plus } from "lucide-react"
+import { BadgeBuilderCore } from "@/components/badge-builder-core"
+import { SaveBadgeButton } from "@/components/save-badge-button"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger,
+} from "@/components/ui/dialog"
+import {
+  BUILDER_DEFAULTS, buildBadgeUrl, type BuilderState,
+} from "@/lib/badge-builder-shared"
+
+export function NewBadgeDialog({
+  onSaved,
+  disabled,
+}: {
+  /** Called after a badge is saved (refresh the library list). */
+  onSaved: () => void
+  /** True when the user is at their plan cap (button is disabled). */
+  disabled?: boolean
+}) {
+  const [open, setOpen] = useState(false)
+  const [s, setS] = useState<BuilderState>(BUILDER_DEFAULTS)
+
+  // Build with a real origin on the client so the preview + saved URL match.
+  const baseUrl = typeof window !== "undefined" ? window.location.origin : "https://shieldcn.dev"
+  const url = useMemo(() => buildBadgeUrl(s, baseUrl), [s, baseUrl])
+
+  function handleSaved() {
+    onSaved()
+    setOpen(false)
+    setS(BUILDER_DEFAULTS) // reset for the next badge
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm" disabled={disabled}>
+          <Plus className="size-4" /> New badge
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[90vh] gap-4 overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>New badge</DialogTitle>
+          <DialogDescription>
+            Configure a badge and save it to your library — reuse it in any README.
+          </DialogDescription>
+        </DialogHeader>
+
+        <BadgeBuilderCore state={s} onChange={setS} badgeUrl={url} showHeader={false}>
+          {url && (
+            <div className="flex justify-end border-t border-border pt-4">
+              <SaveBadgeButton state={s} size="default" variant="default" onSaved={handleSaved} />
+            </div>
+          )}
+        </BadgeBuilderCore>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/packages/web/components/pricing-table.tsx
+++ b/packages/web/components/pricing-table.tsx
@@ -32,7 +32,7 @@ export const TIERS: Tier[] = [
       "All badge providers, variants & themes",
       "Charts, headers, sponsor & contributor walls",
       "Query-param styling on every badge",
-      "Save 2 READMEs + 2 badges to the cloud",
+      "Save 5 READMEs + 5 badges to the cloud",
       "Single-repo shields.io migration preview",
     ],
   },
@@ -45,7 +45,7 @@ export const TIERS: Tier[] = [
     cta: { label: "Get Plus", checkout: "plus" },
     features: [
       "Everything in Free",
-      "Save 50 READMEs (sync across devices)",
+      "Save 75 READMEs (sync across devices)",
       "Saved badges library — reuse a badge anywhere",
       "Mass migration — open PRs across all your repos",
       "AI: generate & polish READMEs",

--- a/packages/web/components/save-badge-button.tsx
+++ b/packages/web/components/save-badge-button.tsx
@@ -43,6 +43,7 @@ export function SaveBadgeButton({
   size = "sm",
   variant = "outline",
   className,
+  onSaved,
 }: {
   state: BuilderState
   /** Suggested library name (falls back to the badge label / path). */
@@ -50,6 +51,8 @@ export function SaveBadgeButton({
   size?: "sm" | "default" | "lg" | "icon"
   variant?: "outline" | "default" | "ghost" | "secondary"
   className?: string
+  /** Fired after a successful save (e.g. to close a dialog + refresh a list). */
+  onSaved?: () => void
 }) {
   const router = useRouter()
   const { me } = useMe()
@@ -84,6 +87,7 @@ export function SaveBadgeButton({
           action: { label: "View", onClick: () => router.push("/dashboard/badges") },
         })
         setTimeout(() => setSaved(false), 2500)
+        onSaved?.()
         return
       }
       const json = await res.json().catch(() => ({}))
@@ -100,7 +104,7 @@ export function SaveBadgeButton({
     } finally {
       setBusy(false)
     }
-  }, [me.signedIn, state, defaultName, router])
+  }, [me.signedIn, state, defaultName, router, onSaved])
 
   return (
     <Button size={size} variant={variant} className={className} onClick={onSave} disabled={busy}>

--- a/packages/web/components/studio/inspectors.tsx
+++ b/packages/web/components/studio/inspectors.tsx
@@ -689,24 +689,11 @@ function BadgeItemEditor({ item, onChange, onRemove, index }: {
     <div className="rounded-md border border-border bg-muted/30 p-3 space-y-3">
       <div className="flex items-center justify-between">
         <span className="text-xs font-semibold text-foreground">Badge {index + 1}</span>
-        <div className="flex items-center gap-0.5">
-          <Tip label="Save to your badge library">
-            <span>
-              <SaveBadgeButton
-                state={s}
-                defaultName={item.alt}
-                size="icon"
-                variant="ghost"
-                className="size-6 text-muted-foreground hover:text-foreground"
-              />
-            </span>
-          </Tip>
-          <Tip label="Remove badge">
-            <Button variant="ghost" size="icon" className="size-6 text-muted-foreground hover:text-destructive" onClick={onRemove} aria-label={`Remove badge ${index + 1}`}>
-              <Trash2 className="size-3.5" />
-            </Button>
-          </Tip>
-        </div>
+        <Tip label="Remove badge">
+          <Button variant="ghost" size="icon" className="size-6 text-muted-foreground hover:text-destructive" onClick={onRemove} aria-label={`Remove badge ${index + 1}`}>
+            <Trash2 className="size-3.5" />
+          </Button>
+        </Tip>
       </div>
 
       <Field label="Type">
@@ -817,6 +804,16 @@ function BadgeItemEditor({ item, onChange, onRemove, index }: {
       <Field label="Link URL">
         <Input value={s.linkUrl} onChange={e => set({ linkUrl: e.target.value })} placeholder="https://…" className="text-xs" />
       </Field>
+
+      <div className="border-t border-border pt-3">
+        <SaveBadgeButton
+          state={s}
+          defaultName={item.alt}
+          size="sm"
+          variant="outline"
+          className="w-full"
+        />
+      </div>
     </div>
   )
 }

--- a/packages/web/content/docs/plus/badges.mdx
+++ b/packages/web/content/docs/plus/badges.mdx
@@ -35,8 +35,8 @@ From the [dashboard library](/dashboard/badges) you can:
 
 | Plan | Saved badges |
 |---|:---:|
-| Free | 2 |
-| Plus | 50 |
+| Free | 5 |
+| Plus | 75 |
 
 Deleting a saved badge only removes it from your library — any README that
 already references its URL is unaffected.

--- a/packages/web/content/docs/plus/index.mdx
+++ b/packages/web/content/docs/plus/index.mdx
@@ -20,8 +20,8 @@ There is one paid tier:
 | Charts, headers, sponsor & contributor walls | ✅ | ✅ |
 | Query-param styling on every badge | ✅ | ✅ |
 | Single-repo shields.io migration preview | ✅ | ✅ |
-| Saved READMEs in the Studio (cloud sync) | ✅ (2) | ✅ (50) |
-| [Saved badges library](/docs/plus/badges) (reusable, cloud sync) | ✅ (2) | ✅ (50) |
+| Saved READMEs in the Studio (cloud sync) | ✅ (5) | ✅ (75) |
+| [Saved badges library](/docs/plus/badges) (reusable, cloud sync) | ✅ (5) | ✅ (75) |
 | Mass migration — open PRs across all repos | — | ✅ |
 | AI — generate & polish READMEs | — | ✅ |
 | [Managed brand](/docs/plus/brands) | — | ✅ (1) |


### PR DESCRIPTION
## What
- **Caps**: saved badges & saved READMEs → **free 5, plus 75** (were 2/50).
- **Studio save UX**: replaced the tiny, easy-to-miss ghost icon with a clear full-width **Save badge** button at the bottom of each badge inspector.
- **Dashboard-native creation**: new `NewBadgeDialog` lets you build + save a badge from `/dashboard/badges` without opening the Studio.
- **Landing builder polish**: the stranded right-aligned Save button is now a bordered action bar with a hint.

## Why
You couldn't easily save a badge from the Studio (the action was a 6px ghost icon in a cramped header), and saving really wanted a dashboard home. Also bumping the free/plus saved-asset allowance.

## How
- Cap constants live in `core` (`saved-badges.ts`, `studio-docs.ts`) — single source of truth; updated all surfaced copy (pricing table, dashboard hint, `plus/badges` + `plus/index` docs tables).
- `NewBadgeDialog` embeds `BadgeBuilderCore` + `SaveBadgeButton`; `SaveBadgeButton` gained an `onSaved` callback to close the dialog and refresh the list.
- **Brands left untouched** (Plus-only, capped at 1) — a managed brand is a deliberate paywall, not a "saved asset" allowance.

## Testing
- Cap enforcement (unit tests), save API 201, dashboard renders **New badge** + **From Studio**, landing builder verified via screenshot.
- `typecheck` ✓, `eslint .` ✓, **314 core / 78 web** tests.

## Screenshots
Landing builder — Save badge now sits in a balanced action bar under the copy output (verified in-browser).