### PR TITLE
feat(auth): last-used method, Turnstile captcha, auth UI redesign + legal docs

### DIFF
--- a/packages/web/app/privacy/page.tsx
+++ b/packages/web/app/privacy/page.tsx
@@ -5,7 +5,7 @@ import { pageMetadata } from "@/lib/metadata"
 
 export const metadata: Metadata = pageMetadata({
   title: "Privacy",
-  description: "How shieldcn handles your data — anonymous analytics, no cookies, no tracking, no stored personal data.",
+  description: "How shieldcn handles your data — anonymous analytics, strictly-necessary cookies only, no tracking, minimal account data.",
   path: "/privacy",
 })
 
@@ -25,10 +25,13 @@ export default function PrivacyPage() {
               <p>
                 shieldcn is a free, open-source badge service. We collect minimal,
                 anonymous analytics to understand how the site is used and anonymous
-                diagnostic data to keep the service reliable. We do not store personal
-                information, set cookies, or sell your data. We rely on a small number
-                of privacy-respecting subprocessors (listed below), and configure each
-                so that no identifying data is retained.
+                diagnostic data to keep the service reliable. We never sell your data
+                or use tracking cookies. Anonymous browsing stores nothing about you;
+                the only personal data we hold is the account details of signed-in
+                users (name and email), and the only cookies we set are strictly
+                necessary ones (see “Cookies”). We rely on a small number of
+                privacy-respecting subprocessors (listed below), and configure each so
+                that no identifying data is retained.
               </p>
             </section>
 
@@ -76,10 +79,16 @@ export default function PrivacyPage() {
             </section>
 
             <section className="space-y-2">
-              <h2 className="text-base font-semibold text-foreground">No cookies</h2>
+              <h2 className="text-base font-semibold text-foreground">Cookies</h2>
               <p>
-                shieldcn does not set any cookies. We do not use fingerprinting
-                or any other cross-session tracking mechanism.
+                We use cookies only where they&apos;re strictly necessary for the
+                site to work — never for advertising, tracking, or profiling. If
+                you sign in, we set a secure, httpOnly session cookie to keep you
+                logged in, a small cookie recording which method you last signed
+                in with (to show a “last used” hint), and, when bot protection is
+                enabled, a short-lived Cloudflare Turnstile cookie on the auth
+                pages. Browsing the site signed-out sets no cookies. We do not
+                use fingerprinting or any cross-session tracking mechanism.
               </p>
             </section>
 

--- a/packages/web/components/auth/auth-form.tsx
+++ b/packages/web/components/auth/auth-form.tsx
@@ -8,9 +8,19 @@
  * client directly (no third-party auth UI). The GitHub social button redirects
  * through the same-origin /api/auth handler; email/password resolves inline and
  * pushes to the callback URL on success.
+ *
+ * Two auth-plugin integrations live here:
+ *  - lastLoginMethod: a "Last used" badge on the method (github / email) the
+ *    returning user signed in with last (read from a cookie via authClient).
+ *  - captcha (Turnstile): when configured, the solved token is sent on the
+ *    protected requests via the `x-captcha-response` header. Without a site key
+ *    the widget renders nothing and the header is simply omitted.
+ *
+ * Rendered both as a full page (/sign-in, /sign-up) and inside a modal
+ * (AuthModal) — the layout is self-contained so it works in either shell.
  */
 
-import { useState } from "react"
+import { useState, useSyncExternalStore } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import Link from "next/link"
 import { Loader2 } from "lucide-react"
@@ -18,52 +28,90 @@ import { authClient } from "@/lib/auth/client"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
 import { GitHubMark } from "@/components/auth/provider-marks"
+import { TurnstileWidget, turnstileEnabled } from "@/components/auth/turnstile-widget"
+import { cn } from "@/lib/utils"
 
 type Mode = "sign-in" | "sign-up"
+
+/** Small "Last used" pill shown next to the method the user signed in with last. */
+function LastUsedBadge() {
+  return (
+    <span className="ml-auto rounded-full bg-foreground/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+      Last used
+    </span>
+  )
+}
 
 export function AuthForm({
   mode,
   callbackURL = "/dashboard",
+  onSuccess,
+  className,
 }: {
   mode: Mode
   callbackURL?: string
+  /** Called after a successful email sign-in/up (e.g. to close a modal). */
+  onSuccess?: () => void
+  className?: string
 }) {
   const router = useRouter()
   const searchParams = useSearchParams()
   const resetOk = searchParams.get("reset") === "success"
   const isSignUp = mode === "sign-up"
+
   const [name, setName] = useState("")
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
   const [pending, setPending] = useState(false)
   const [social, setSocial] = useState<"github" | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [captchaToken, setCaptchaToken] = useState<string | null>(null)
+
+  // Last-used method is cookie-backed and client-only. useSyncExternalStore
+  // reads it after hydration (server snapshot is null) with no effect churn.
+  const lastMethod = useSyncExternalStore(
+    () => () => {},
+    () => {
+      try {
+        return authClient.getLastUsedLoginMethod?.() ?? null
+      } catch {
+        return null
+      }
+    },
+    () => null,
+  )
+
+  /** Attach the Turnstile token to protected requests when configured. */
+  function fetchOptions() {
+    if (!turnstileEnabled || !captchaToken) return undefined
+    return { headers: { "x-captcha-response": captchaToken } }
+  }
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault()
     setError(null)
+    if (turnstileEnabled && !captchaToken) {
+      setError("Please complete the challenge below.")
+      return
+    }
     setPending(true)
     try {
+      const opts = fetchOptions()
       const res = isSignUp
-        ? await authClient.signUp.email({ name, email, password, callbackURL })
-        : await authClient.signIn.email({ email, password, callbackURL })
+        ? await authClient.signUp.email({ name, email, password, callbackURL, fetchOptions: opts })
+        : await authClient.signIn.email({ email, password, callbackURL, fetchOptions: opts })
       if (res.error) {
         setError(res.error.message ?? "Something went wrong")
+        setCaptchaToken(null) // force a fresh challenge on retry
         return
       }
+      onSuccess?.()
       router.push(callbackURL)
       router.refresh()
     } catch (err) {
       setError(err instanceof Error ? err.message : "Something went wrong")
+      setCaptchaToken(null)
     } finally {
       setPending(false)
     }
@@ -83,42 +131,52 @@ export function AuthForm({
   const busy = pending || social !== null
 
   return (
-    <Card className="w-full max-w-sm">
-      <CardHeader>
-        <CardTitle>{isSignUp ? "Create your account" : "Welcome back"}</CardTitle>
-        <CardDescription>
-          {isSignUp
-            ? "Start saving READMEs, badges, and brands."
-            : "Sign in to your shieldcn workspace."}
-        </CardDescription>
-      </CardHeader>
+    <div className={cn("w-full max-w-sm", className)}>
+      <div className="rounded-2xl border border-border bg-card p-6 shadow-sm">
+        {/* Header */}
+        <div className="mb-6 flex flex-col gap-1 text-center">
+          <h1 className="text-xl font-semibold tracking-tight">
+            {isSignUp ? "Create your account" : "Welcome back"}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            {isSignUp
+              ? "Start saving READMEs, badges, and brands."
+              : "Sign in to your shieldcn workspace."}
+          </p>
+        </div>
 
-      <CardContent className="flex flex-col gap-4">
         {resetOk && !isSignUp && (
-          <p className="rounded-md bg-emerald-500/10 px-3 py-2 text-sm text-emerald-500 ring-1 ring-inset ring-emerald-500/20">
+          <p className="mb-4 rounded-md bg-emerald-500/10 px-3 py-2 text-sm text-emerald-500 ring-1 ring-inset ring-emerald-500/20">
             Password reset — sign in with your new password.
           </p>
         )}
-        <div className="flex flex-col gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            className="w-full"
-            disabled={busy}
-            onClick={() => onSocial("github")}
-          >
-            {social === "github" ? <Loader2 className="size-4 animate-spin" /> : <GitHubMark className="size-4" />}
-            Continue with GitHub
-          </Button>
-        </div>
 
-        <div className="relative py-1 text-center">
+        {/* Social */}
+        <Button
+          type="button"
+          variant={lastMethod === "github" ? "default" : "outline"}
+          className="w-full"
+          disabled={busy}
+          onClick={() => onSocial("github")}
+        >
+          {social === "github" ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <GitHubMark className="size-4" />
+          )}
+          Continue with GitHub
+          {lastMethod === "github" && <LastUsedBadge />}
+        </Button>
+
+        {/* Divider */}
+        <div className="relative py-4 text-center">
           <span className="relative z-10 bg-card px-2 text-xs text-muted-foreground">
-            or
+            or continue with email
           </span>
           <span className="absolute inset-x-0 top-1/2 -z-0 h-px bg-border" />
         </div>
 
+        {/* Email / password */}
         <form onSubmit={onSubmit} className="flex flex-col gap-3">
           {isSignUp && (
             <div className="flex flex-col gap-1.5">
@@ -137,6 +195,7 @@ export function AuthForm({
             <Input
               id="email"
               type="email"
+              placeholder="you@example.com"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               autoComplete="email"
@@ -166,32 +225,50 @@ export function AuthForm({
             />
           </div>
 
+          {/* Turnstile challenge (renders only when configured) */}
+          {turnstileEnabled && (
+            <div className="flex justify-center">
+              <TurnstileWidget onToken={setCaptchaToken} />
+            </div>
+          )}
+
           {error && <p className="text-sm text-destructive">{error}</p>}
 
-          <Button type="submit" className="w-full" disabled={busy}>
+          <Button type="submit" className="relative w-full" disabled={busy}>
             {pending && <Loader2 className="size-4 animate-spin" />}
             {isSignUp ? "Create account" : "Sign in"}
+            {lastMethod === "email" && <LastUsedBadge />}
           </Button>
         </form>
-      </CardContent>
 
-      <CardFooter className="justify-center text-sm text-muted-foreground">
-        {isSignUp ? (
-          <span>
-            Already have an account?{" "}
-            <Link href="/sign-in" className="underline underline-offset-4 hover:text-foreground">
-              Sign in
-            </Link>
-          </span>
-        ) : (
-          <span>
-            New to shieldcn?{" "}
-            <Link href="/sign-up" className="underline underline-offset-4 hover:text-foreground">
-              Create an account
-            </Link>
-          </span>
-        )}
-      </CardFooter>
-    </Card>
+        {/* Toggle */}
+        <p className="mt-6 text-center text-sm text-muted-foreground">
+          {isSignUp ? (
+            <>
+              Already have an account?{" "}
+              <Link href="/sign-in" className="text-foreground underline underline-offset-4">
+                Sign in
+              </Link>
+            </>
+          ) : (
+            <>
+              New to shieldcn?{" "}
+              <Link href="/sign-up" className="text-foreground underline underline-offset-4">
+                Create an account
+              </Link>
+            </>
+          )}
+        </p>
+      </div>
+
+      {/* Legal footnote */}
+      <p className="mt-4 px-6 text-center text-xs text-muted-foreground">
+        By continuing, you agree to our{" "}
+        <Link href="/privacy" className="underline underline-offset-4 hover:text-foreground">
+          Privacy Policy
+        </Link>
+        .
+      </p>
+    </div>
   )
 }

--- a/packages/web/components/auth/auth-form.tsx
+++ b/packages/web/components/auth/auth-form.tsx
@@ -20,7 +20,8 @@
  * (AuthModal) — the layout is self-contained so it works in either shell.
  */
 
-import { useState, useSyncExternalStore } from "react"
+import { useRef, useState, useSyncExternalStore } from "react"
+import type { TurnstileInstance } from "@marsidev/react-turnstile"
 import { useRouter, useSearchParams } from "next/navigation"
 import Link from "next/link"
 import { Loader2 } from "lucide-react"
@@ -67,6 +68,13 @@ export function AuthForm({
   const [social, setSocial] = useState<"github" | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [captchaToken, setCaptchaToken] = useState<string | null>(null)
+  const turnstileRef = useRef<TurnstileInstance | undefined>(undefined)
+
+  /** Clear the token and reset the widget so it issues a fresh, usable one. */
+  function resetCaptcha() {
+    setCaptchaToken(null)
+    turnstileRef.current?.reset()
+  }
 
   // Last-used method is cookie-backed and client-only. useSyncExternalStore
   // reads it after hydration (server snapshot is null) with no effect churn.
@@ -103,7 +111,7 @@ export function AuthForm({
         : await authClient.signIn.email({ email, password, callbackURL, fetchOptions: opts })
       if (res.error) {
         setError(res.error.message ?? "Something went wrong")
-        setCaptchaToken(null) // force a fresh challenge on retry
+        resetCaptcha() // token is single-use — re-challenge so retry works
         return
       }
       onSuccess?.()
@@ -111,7 +119,7 @@ export function AuthForm({
       router.refresh()
     } catch (err) {
       setError(err instanceof Error ? err.message : "Something went wrong")
-      setCaptchaToken(null)
+      resetCaptcha()
     } finally {
       setPending(false)
     }
@@ -228,7 +236,7 @@ export function AuthForm({
           {/* Turnstile challenge (renders only when configured) */}
           {turnstileEnabled && (
             <div className="flex justify-center">
-              <TurnstileWidget onToken={setCaptchaToken} />
+              <TurnstileWidget widgetRef={turnstileRef} onToken={setCaptchaToken} />
             </div>
           )}
 

--- a/packages/web/components/auth/auth-modal.tsx
+++ b/packages/web/components/auth/auth-modal.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+/**
+ * shieldcn
+ * components/auth/auth-modal.tsx
+ *
+ * Sign-in in a modal — open the auth form from anywhere (e.g. the header) without
+ * a full page navigation. Reuses AuthForm; a successful sign-in closes the modal.
+ * The dedicated /sign-in and /sign-up pages remain for direct links, deep links,
+ * and OAuth returns.
+ */
+
+import { useState } from "react"
+import { Suspense } from "react"
+import {
+  Dialog, DialogContent, DialogTitle, DialogTrigger,
+} from "@/components/ui/dialog"
+import { AuthForm } from "@/components/auth/auth-form"
+
+export function AuthModal({
+  trigger,
+  mode = "sign-in",
+  callbackURL,
+}: {
+  trigger: React.ReactNode
+  mode?: "sign-in" | "sign-up"
+  callbackURL?: string
+}) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent className="border-none bg-transparent p-0 shadow-none sm:max-w-sm [&>button]:hidden">
+        {/* Accessible title (visually hidden — the card renders its own heading). */}
+        <DialogTitle className="sr-only">
+          {mode === "sign-up" ? "Create your account" : "Sign in"}
+        </DialogTitle>
+        <Suspense fallback={null}>
+          <AuthForm mode={mode} callbackURL={callbackURL} onSuccess={() => setOpen(false)} />
+        </Suspense>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/packages/web/components/auth/turnstile-widget.tsx
+++ b/packages/web/components/auth/turnstile-widget.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+/**
+ * shieldcn
+ * components/auth/turnstile-widget.tsx
+ *
+ * Cloudflare Turnstile widget for auth forms. Renders the challenge and hands
+ * the solved token back via onToken; on expiry/error it clears the token so the
+ * form knows to re-challenge. No-ops (renders nothing, reports "configured:
+ * false") when NEXT_PUBLIC_TURNSTILE_SITE_KEY is unset, so local dev and any
+ * environment without Turnstile configured keep working without a challenge.
+ *
+ * The token is sent to Better Auth via the `x-captcha-response` header on the
+ * protected requests (see auth-form.tsx). The server captcha plugin verifies it.
+ */
+
+import { useTheme } from "next-themes"
+import { Turnstile } from "@marsidev/react-turnstile"
+
+const SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY
+
+/** True when Turnstile is configured (a site key is present). */
+export const turnstileEnabled = Boolean(SITE_KEY)
+
+export function TurnstileWidget({
+  onToken,
+}: {
+  /** Fired with the solved token, or null when it expires / errors. */
+  onToken: (token: string | null) => void
+}) {
+  const { resolvedTheme } = useTheme()
+  if (!SITE_KEY) return null
+
+  return (
+    <Turnstile
+      siteKey={SITE_KEY}
+      options={{
+        theme: resolvedTheme === "light" ? "light" : "dark",
+        size: "flexible",
+      }}
+      onSuccess={(token) => onToken(token)}
+      onError={() => onToken(null)}
+      onExpire={() => onToken(null)}
+    />
+  )
+}

--- a/packages/web/components/auth/turnstile-widget.tsx
+++ b/packages/web/components/auth/turnstile-widget.tsx
@@ -15,7 +15,7 @@
  */
 
 import { useTheme } from "next-themes"
-import { Turnstile } from "@marsidev/react-turnstile"
+import { Turnstile, type TurnstileInstance } from "@marsidev/react-turnstile"
 
 const SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY
 
@@ -24,15 +24,23 @@ export const turnstileEnabled = Boolean(SITE_KEY)
 
 export function TurnstileWidget({
   onToken,
+  widgetRef,
 }: {
   /** Fired with the solved token, or null when it expires / errors. */
   onToken: (token: string | null) => void
+  /**
+   * Ref to the widget instance so the form can reset() it after a failed
+   * submit. Turnstile tokens are single-use — without a reset the widget won't
+   * issue a new one and the user is stuck until it naturally expires.
+   */
+  widgetRef?: React.Ref<TurnstileInstance | undefined>
 }) {
   const { resolvedTheme } = useTheme()
   if (!SITE_KEY) return null
 
   return (
     <Turnstile
+      ref={widgetRef}
       siteKey={SITE_KEY}
       options={{
         theme: resolvedTheme === "light" ? "light" : "dark",

--- a/packages/web/components/auth/user-menu.tsx
+++ b/packages/web/components/auth/user-menu.tsx
@@ -19,6 +19,7 @@ import {
   Palette,
 } from "lucide-react"
 import { authClient } from "@/lib/auth/client"
+import { AuthModal } from "@/components/auth/auth-modal"
 import { Button } from "@/components/ui/button"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import {
@@ -49,9 +50,14 @@ export function UserMenu() {
   if (!session?.user) {
     return (
       <div className="flex items-center gap-1.5">
-        <Button variant="ghost" size="sm" asChild>
-          <Link href="/sign-in">Sign in</Link>
-        </Button>
+        <AuthModal
+          mode="sign-in"
+          trigger={
+            <Button variant="ghost" size="sm">
+              Sign in
+            </Button>
+          }
+        />
         <Button size="sm" asChild>
           <Link href="/sign-up">Sign up</Link>
         </Button>

--- a/packages/web/lib/auth/client.ts
+++ b/packages/web/lib/auth/client.ts
@@ -11,9 +11,9 @@
 "use client"
 
 import { createAuthClient } from "better-auth/react"
-import { organizationClient } from "better-auth/client/plugins"
+import { organizationClient, lastLoginMethodClient } from "better-auth/client/plugins"
 import { polarClient } from "@polar-sh/better-auth/client"
 
 export const authClient = createAuthClient({
-  plugins: [organizationClient(), polarClient()],
+  plugins: [organizationClient(), lastLoginMethodClient(), polarClient()],
 })

--- a/packages/web/lib/auth/server.ts
+++ b/packages/web/lib/auth/server.ts
@@ -21,7 +21,7 @@
  */
 
 import { betterAuth } from "better-auth"
-import { organization } from "better-auth/plugins"
+import { organization, lastLoginMethod, captcha } from "better-auth/plugins"
 import { polar, checkout, portal, webhooks } from "@polar-sh/better-auth"
 import { Polar } from "@polar-sh/sdk"
 import { getPool, query } from "@shieldcn/core/db"
@@ -157,6 +157,24 @@ export const auth = betterAuth({
     // personal-first ownerId resolution keys off (org id when active, else the
     // personal user id).
     organization(),
+
+    // Track the last auth method a user used (email vs github) so the sign-in
+    // UI can show a "Last used" hint. Cookie-based (httpOnly:false so the client
+    // can read it) — no DB column, no PII.
+    lastLoginMethod(),
+
+    // Cloudflare Turnstile bot protection on the default sensitive endpoints
+    // (/sign-up/email, /sign-in/email, /request-password-reset). Only enabled
+    // when the secret is configured, so local dev + builds without a key aren't
+    // gated (the client widget also no-ops without a site key).
+    ...(process.env.TURNSTILE_SECRET_KEY
+      ? [
+          captcha({
+            provider: "cloudflare-turnstile",
+            secretKey: process.env.TURNSTILE_SECRET_KEY,
+          }),
+        ]
+      : []),
 
     // Billing. Checkout + portal + webhooks via Polar. Customers are keyed by
     // the user id (externalId) — the same owner key our subscriptions table +

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -21,6 +21,7 @@
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@marsidev/react-turnstile": "^1.5.3",
     "@number-flow/react": "^0.6.1",
     "@openpanel/nextjs": "^1.5.1",
     "@polar-sh/better-auth": "^1.8.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,9 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.7)
+      '@marsidev/react-turnstile':
+        specifier: ^1.5.3
+        version: 1.5.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@number-flow/react':
         specifier: ^0.6.1
         version: 0.6.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -1491,6 +1494,12 @@ packages:
     engines: {node: '>= 10.16.0'}
     peerDependencies:
       jsep: ^0.4.0||^1.0.0
+
+  '@marsidev/react-turnstile@1.5.3':
+    resolution: {integrity: sha512-8Dij2jiNGNczq1U4EKpO4do2XepcTPxSMc2ZzvHndO+gcp68tvMULm27z2P99rGkdB89hc3452NZeu2Rti4g6A==}
+    peerDependencies:
+      react: ^17.0.2 || ^18.0.0 || ^19.0
+      react-dom: ^17.0.2 || ^18.0.0 || ^19.0
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
@@ -8635,6 +8644,11 @@ snapshots:
   '@jsep-plugin/regex@1.0.4(jsep@1.4.0)':
     dependencies:
       jsep: 1.4.0
+
+  '@marsidev/react-turnstile@1.5.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@mdx-js/mdx@3.1.1':
     dependencies:


### PR DESCRIPTION
## What
- **Last login method** — a "Last used" badge on the GitHub / email button ([plugin](https://better-auth.com/docs/plugins/last-login-method)).
- **Turnstile captcha** — bot protection on sign-up, sign-in, password-reset ([plugin](https://better-auth.com/docs/plugins/captcha) + [@marsidev/react-turnstile](https://www.npmjs.com/package/@marsidev/react-turnstile)).
- **Redesigned auth UI** — cleaner centered card, now also a **modal** (open sign-in from the header, no page nav).
- **Legal docs** — a proper **Terms of Service** (no-refund + goodwill clause, North Carolina governing law) and an **expanded Privacy Policy** covering accounts + billing. Standardized contact on `shieldcn@fwdtojustin.com`.

## Why
Requested: last-login hint, captcha, nicer auth UI, and "proper auth/account privacy documents + terms" with a no-refund policy. The old privacy copy ("no cookies / no personal data") predated accounts + billing and was inaccurate.

## How
- Plugins are **env-gated**: Turnstile only registers with `TURNSTILE_SECRET_KEY`; the widget only renders with `NEXT_PUBLIC_TURNSTILE_SITE_KEY`. Token rides on protected requests via `x-captcha-response`; the widget is **reset on failed submit** (single-use tokens) — fixes the Seer HIGH finding.
- `AuthForm` is self-contained (page + modal); `lastMethod` via `useSyncExternalStore`.
- **Terms** (`/terms`): accounts, Plus billing (Polar = merchant of record), refunds (all sales final + discretionary goodwill + legal carveout), acceptable use, IP, liability, NC governing law.
- **Privacy** (`/privacy`): new Accounts, Billing, Data-retention, Your-rights sections; subprocessors expanded (Vercel, Neon, Polar, Turnstile + existing OpenPanel/Sentry). Cross-linked terms ↔ privacy; footer gains a Terms link.

## Config needed for captcha (prod)
Set `NEXT_PUBLIC_TURNSTILE_SITE_KEY` + `TURNSTILE_SECRET_KEY` (Cloudflare Turnstile). Until then captcha is off; everything else works.

## Testing
- In-browser: redesigned page + modal, LAST USED badge, Turnstile hidden without a key, /terms + /privacy render.
- `typecheck` ✓, `eslint .` ✓, **314 core / 78 web** tests.

## Note
`shieldcn@fwdtojustin.com` must be a working inbox (referenced for refunds, data requests, and support).