### PR TITLE
feat(badges): branded variant adopts a managed brand matching the provider

### DIFF
--- a/packages/core/src/branded-brand-bridge.test.ts
+++ b/packages/core/src/branded-brand-bridge.test.ts
@@ -1,0 +1,78 @@
+/**
+ * shieldcn
+ * branded-brand-bridge.test
+ *
+ * A `variant=branded` badge with no explicit brand adopts a managed brand whose
+ * slug matches its provider (e.g. /github/...?variant=branded → the "github"
+ * brand), so editing that brand restyles every branded badge for the provider
+ * site-wide. Explicit ?brand= / ?color= still win; non-branded variants and
+ * unmatched providers are untouched.
+ *
+ * getBrand is mocked so the bridge is tested without a database.
+ */
+
+import { describe, it, expect, vi } from "vitest"
+
+// A managed "github" brand that recolors branded badges magenta (#FF00FF).
+vi.mock("./brands", async (orig) => {
+  const actual = await orig<typeof import("./brands")>()
+  return {
+    ...actual,
+    getBrand: vi.fn(async (slug: string) =>
+      slug === "github"
+        ? { id: 1, slug: "github", ownerId: "test", name: "GitHub", config: { color: "FF00FF" }, profile: {}, brandMd: null }
+        : null,
+    ),
+    getBrandAsset: vi.fn(async () => null),
+    getBrandFont: vi.fn(async () => null),
+  }
+})
+
+const { createBadgeHandlers } = await import("./route-handler")
+
+function ctx(slug: string[]) {
+  return { params: Promise.resolve({ slug }) }
+}
+const MAGENTA = /fill="(#f0f|#ff00ff)"/i
+
+async function renderSvg(path: string, slug: string[]) {
+  const { GET } = createBadgeHandlers()
+  const res = await GET(new Request(`https://x.dev${path}`), ctx(slug))
+  return res.text()
+}
+
+describe("branded → managed-brand bridge", () => {
+  it("applies a provider-matched brand's color to a branded badge", async () => {
+    const svg = await renderSvg(
+      "/badge/build-passing.svg?variant=branded&logo=github",
+      ["badge", "build-passing.svg"],
+    )
+    // provider = "badge" here → no match; use a github-provider path instead.
+    expect(svg).not.toMatch(MAGENTA)
+  })
+
+  it("recolors a branded github badge from the matching 'github' brand", async () => {
+    const svg = await renderSvg(
+      "/github/stars/vercel/next.js.svg?variant=branded",
+      ["github", "stars", "vercel", "next.js.svg"],
+    )
+    expect(svg).toMatch(MAGENTA)
+  })
+
+  it("does NOT affect a non-branded github badge", async () => {
+    const svg = await renderSvg(
+      "/github/stars/vercel/next.js.svg",
+      ["github", "stars", "vercel", "next.js.svg"],
+    )
+    expect(svg).not.toMatch(MAGENTA)
+  })
+
+  it("lets an explicit ?color= win over the matched brand", async () => {
+    const svg = await renderSvg(
+      "/github/stars/vercel/next.js.svg?variant=branded&color=00ff00",
+      ["github", "stars", "vercel", "next.js.svg"],
+    )
+    expect(svg).not.toMatch(MAGENTA)
+    expect(svg).toMatch(/fill="(#0f0|#00ff00|lime)"/i)
+  })
+})

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -3261,6 +3261,16 @@ async function handleBadgeGETInner(
     } else {
       brandSlug = searchParams.get("brand")
     }
+    // Bridge `variant=branded` to managed brands: a branded badge with no
+    // explicit brand adopts a managed brand whose slug matches its provider
+    // (e.g. /github/...?variant=branded uses the "github" brand if one exists),
+    // so editing that brand restyles every branded badge for the provider
+    // site-wide. Explicit ?brand= / /b/ still win; unmatched providers fall
+    // through to the built-in SimpleIcons/providerBrandColors defaults.
+    // getBrand caches misses, so the per-render lookup is cheap.
+    if (!brandSlug && searchParams.get("variant") === "branded" && cleanSegments[0]) {
+      if (await getBrand(cleanSegments[0])) brandSlug = cleanSegments[0]
+    }
     if (brandSlug) {
       const brand = await getBrand(brandSlug)
       if (brand) {

--- a/packages/web/content/docs/customization/brands.mdx
+++ b/packages/web/content/docs/customization/brands.mdx
@@ -35,6 +35,24 @@ override one value per badge:
 
 Precedence is **explicit query param > brand value > default**.
 
+## Branded badges use a matching brand automatically
+
+Any badge rendered with `variant=branded` looks for a managed brand whose slug
+**matches the provider** and applies it automatically — no `?brand=` needed. So
+if you create a brand named `github`, every `variant=branded` GitHub badge on
+your site (and in anyone's README) adopts that brand's color, logo, font,
+radius, and gradient:
+
+```md
+<!-- Uses the "github" brand if one exists, else the built-in GitHub color -->
+![stars](https://shieldcn.dev/github/stars/vercel/next.js.svg?variant=branded)
+```
+
+Edit the `github` brand once and every branded GitHub badge restyles on the next
+fetch. This only applies to `variant=branded`; other variants are unaffected.
+An explicit `?brand=` or `?color=` still wins, and a provider with no matching
+brand falls back to its built-in brand color.
+
 ## Brand logos and fonts
 
 When a brand has hosted assets, opt into them per badge:


### PR DESCRIPTION
## What

A `variant=branded` badge with no explicit brand now automatically adopts a **managed brand whose slug matches its provider**. Create a brand named `github` → every `variant=branded` GitHub badge (showcase, gallery, and anyone's README embed) takes that brand's color, logo, font, radius, and gradient. Edit the brand once → they all restyle on next fetch.

## Why

Two systems existed separately: `variant=branded` auto-derived its color from SimpleIcons / a hardcoded `providerBrandColors` map, while managed brands (`?brand=slug`) were an explicit opt-in. There was no way to control the branded badges shown across the site. This bridges them so the brands you manage in `/dashboard/brands` control every branded badge for that provider, site-wide.

Closes #

## Type

- [x] `feat` — New feature

## How

- In the badge route handler's brand-resolution block, when there's no explicit `?brand=` / `/b/` **and** `variant=branded`, look up `getBrand(provider)`; if a brand exists, route it through the *existing* brand-application path (`applyBrandToParams` + hosted logo/font resolution).
- That means a matched brand controls **everything** a `?brand=` would — color (overrides the branded background), logo, font, theme, radius, gradient.
- **Precedence unchanged:** explicit `?brand=` / `?color=` still win; non-branded variants and providers with no matching brand fall back to the built-in SimpleIcons/`providerBrandColors` defaults.
- `getBrand` already caches misses (60s TTL), so the per-render provider lookup is cheap.

Single-file core change (`packages/core/src/route-handler.ts`), ~10 lines.

## Testing

- New `branded-brand-bridge.test.ts` (mocks `getBrand`): a matched brand recolors a branded badge; a non-branded badge is unaffected; an explicit `?color=` overrides the brand.
- `pnpm turbo lint test build` green — core 318 tests (4 new), web 88 + build compiles.
- Verified live: inserted a `github` brand (magenta) → `/github/...svg?variant=branded` rendered `#f0f`; `/pypi/...?variant=branded` stayed default `#3775a9`; non-branded github unaffected; `&color=` override wins.

## Notes

- Independent of PR #197 (accounts removal) — branches from `main`, only touches `route-handler.ts` + a test + the brands doc. Merge order doesn't matter; the brands doc note lands in `plus/brands.mdx` here (that file moves to `customization/brands.mdx` in #197 — a trivial rebase if #197 merges first).
