### PR TITLE
feat(brands): pick a Simple Icons / React Icons glyph as a brand logo

### DIFF
--- a/packages/web/components/brand-editor.tsx
+++ b/packages/web/components/brand-editor.tsx
@@ -15,6 +15,7 @@ import { useRouter } from "next/navigation"
 import { Check, Loader2, Save, Upload, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { ContextDevLogo } from "@/components/context-dev-logo"
+import { LogoPicker } from "@/components/logo-picker"
 import { BrandDemoBadges } from "@/components/brand-demo-badges"
 import { BrandShowcaseEditor } from "@/components/brand-showcase-editor"
 import { Button } from "@/components/ui/button"
@@ -550,6 +551,24 @@ export function BrandEditor({
               ))}
             </SelectContent>
           </Select>
+        </div>
+        <div className="flex flex-col gap-1.5 sm:col-span-2">
+          <Label>Logo icon</Label>
+          <LogoPicker
+            // A hosted mark (logo=brand / data URI) is managed via the logo
+            // slots below; this field picks a SimpleIcons/React-Icons glyph.
+            value={
+              !config.logo || config.logo.startsWith("data:") || config.logo.startsWith("brand")
+                ? ""
+                : config.logo
+            }
+            onChange={(v) => setConfig((c) => ({ ...c, logo: v || undefined }))}
+            ariaLabel="Brand logo icon"
+          />
+          <p className="text-xs text-muted-foreground">
+            Pick an icon from Simple Icons / React Icons. Leave on Auto to use
+            your uploaded mark below (if any), else the provider default.
+          </p>
         </div>
       </section>
 


### PR DESCRIPTION
## What

Adds a **Logo icon** field to the brand editor so an admin can set any Simple Icons / React Icons glyph as a brand's logo (via the existing `LogoPicker`).

## Why

`config.logo` already accepts an icon slug end-to-end (it flows through `applyBrandToParams` → the badge logo resolver), but the editor only exposed hosted-mark uploads. Combined with provider-slug branding (#199), this lets a brand fully control both the **color and the icon** of every `variant=branded` badge for its provider.

## How

- Wire `LogoPicker` into the editor's style-tokens section, bound to `config.logo`.
- "Auto" leaves `logo` unset → uploaded mark (`logo=brand`) if any, else the provider default. A picked slug overrides the auto hosted-mark.
- `config.logo` already persists (in `BRAND_PARAM_KEYS`, sanitized server-side).

## Testing

- Lint + build green.
- Verified live: a brand `{ color, logo: react }` rendered a branded badge with the brand color **and** the React icon.

## Type

- [x] `feat`