### PR TITLE
feat(brands): default showcase badges to the branded variant

### DIFF
--- a/packages/web/components/badge-builder-core.tsx
+++ b/packages/web/components/badge-builder-core.tsx
@@ -87,11 +87,11 @@ function brandedEligible(path: string): boolean {
  * variant the selected badge doesn't support. Mirrors the dropdown's rule:
  * registry-allowed AND (not `branded`, or branded-eligible).
  */
-function clampVariant(next: BuilderState): BuilderState {
+function clampVariant(next: BuilderState, brandStyled = false): BuilderState {
   const allowed = allowedVariantsForPath(next.path)
   const ok =
     allowed.includes(next.variant as never) &&
-    (next.variant !== "branded" || brandedEligible(next.path))
+    (next.variant !== "branded" || brandStyled || brandedEligible(next.path))
   return ok ? next : { ...next, variant: "default" }
 }
 
@@ -110,6 +110,13 @@ interface BadgeBuilderCoreProps {
   showHeader?: boolean
   /** Whether to show format (SVG/PNG) selector. Default: true */
   showFormat?: boolean
+  /**
+   * Brand-showcase context: the badge is always rendered with `?brand=slug`, so
+   * the brand supplies the color/logo. Makes the `branded` variant always
+   * selectable (not just for provider badges) so a brand's showcase badges can
+   * default to and use branded. Default: false.
+   */
+  brandStyled?: boolean
   /** Additional content rendered below the preview area. */
   children?: React.ReactNode
 }
@@ -124,6 +131,7 @@ export function BadgeBuilderCore({
   badgeUrl,
   showHeader = true,
   showFormat = true,
+  brandStyled = false,
   children,
 }: BadgeBuilderCoreProps) {
   const [showRawPath, setShowRawPath] = useState(false)
@@ -178,9 +186,9 @@ export function BadgeBuilderCore({
 
   const updatePath = useCallback((preset: BadgePreset, values: Record<string, string>, extraState?: Partial<BuilderState>) => {
     const path = resolveTemplate(preset, values)
-    onChange(clampVariant({ ...s, ...extraState, path }))
+    onChange(clampVariant({ ...s, ...extraState, path }, brandStyled))
     setImgError(false)
-  }, [s, onChange])
+  }, [s, onChange, brandStyled])
 
   const handlePresetChange = useCallback((indexStr: string) => {
     const idx = parseInt(indexStr, 10)
@@ -219,10 +227,10 @@ export function BadgeBuilderCore({
     setRawPathInput(val)
     if (debounceRef.current) clearTimeout(debounceRef.current)
     debounceRef.current = setTimeout(() => {
-      onChange(clampVariant({ ...s, path: val }))
+      onChange(clampVariant({ ...s, path: val }, brandStyled))
       setImgError(false)
     }, URL_DEBOUNCE_MS)
-  }, [s, onChange])
+  }, [s, onChange, brandStyled])
 
   const prevPath = useRef(s.path)
   useEffect(() => {
@@ -237,7 +245,7 @@ export function BadgeBuilderCore({
   const currentProvider = useMemo(() => s.path.split("/").filter(Boolean)[0] || "", [s.path])
   const brandedIcon = PROVIDER_ICON[currentProvider] || ""
   // Shared with clampVariant so the dropdown and the selected state never drift.
-  const hasBranded = brandedEligible(s.path)
+  const hasBranded = brandStyled || brandedEligible(s.path)
 
   // Variants the SELECTED badge actually supports, per the core registry
   // (source of truth). Combined with the branded-icon check below so the

--- a/packages/web/components/brand-showcase-editor.tsx
+++ b/packages/web/components/brand-showcase-editor.tsx
@@ -53,7 +53,9 @@ export function BrandShowcaseEditor({
   const { adaptUrl } = useBadgeMode()
   const mounted = useHydrated()
   const [open, setOpen] = useState(false)
-  const [draft, setDraft] = useState<BuilderState>({ ...BUILDER_DEFAULTS })
+  // Showcase badges are always rendered with ?brand=slug, so default them to
+  // the branded variant — the brand supplies the color/logo.
+  const [draft, setDraft] = useState<BuilderState>({ ...BUILDER_DEFAULTS, variant: "branded" })
   const [alt, setAlt] = useState("")
 
   const atLimit = badges.length >= MAX_BRAND_SHOWCASE
@@ -62,7 +64,7 @@ export function BrandShowcaseEditor({
   function addBadge() {
     if (!draftPath) return
     onChange([...badges, { path: draftPath, alt: alt.trim() || undefined }])
-    setDraft({ ...BUILDER_DEFAULTS })
+    setDraft({ ...BUILDER_DEFAULTS, variant: "branded" })
     setAlt("")
     setOpen(false)
   }
@@ -132,7 +134,7 @@ export function BrandShowcaseEditor({
             </DialogDescription>
           </DialogHeader>
 
-          <BadgeBuilderCore state={draft} onChange={setDraft} badgeUrl={draftPath} showHeader={false} />
+          <BadgeBuilderCore state={draft} onChange={setDraft} badgeUrl={draftPath} showHeader={false} brandStyled />
 
           <div className="flex flex-col gap-1.5">
             <Label htmlFor="showcase-alt">Caption (optional)</Label>


### PR DESCRIPTION
## What

When adding a **showcase badge** to a brand, the builder now defaults to the `branded` variant, and `branded` is always selectable there (not just for provider badges).

## Why

A brand's showcase badges are always rendered with `?brand=slug`, so the brand supplies the color and logo — branded is the natural default and should apply to any badge (including custom/static ones). Previously the builder defaulted to `default` and gated `branded` to provider paths, so brand showcase badges couldn't showcase the brand look.

## How

- `brand-showcase-editor` seeds new badges with `variant=branded` (and resets to it after adding).
- `BadgeBuilderCore` gains a `brandStyled` prop that makes `branded` always eligible; threaded through `clampVariant` and the variant dropdown so selected state and options never drift.
- Non-brand builders (landing, sandbox, migrate) pass nothing → `brandStyled=false` → unchanged behavior.

## Testing

- Lint + build green.
- `buildBadgePath` includes `variant=branded`, so saved showcase paths render branded via `?brand=slug` (verified branded+brand rendering in #199).

## Type

- [x] `feat`