### PR TITLE
feat(brands): let a brand set its showcase category

### DIFF
--- a/packages/core/src/brands.ts
+++ b/packages/core/src/brands.ts
@@ -52,6 +52,12 @@ export interface BrandProfile {
   palette?: BrandPaletteColor[]
   /** Up to 5 curated badges shown for this brand in the global showcase. */
   showcaseBadges?: BrandShowcaseBadge[]
+  /**
+   * Category heading this brand's showcase badges appear under on /showcase.
+   * Defaults to the brand name when unset. Lets several brands share a category,
+   * or a brand pick a friendlier label than its slug.
+   */
+  showcaseCategory?: string
 }
 
 export interface Brand {
@@ -100,6 +106,9 @@ function sanitizeProfile(input: unknown): BrandProfile {
     for (const key of ["title", "description", "slogan", "domain"] as const) {
       const v = o[key]
       if (typeof v === "string" && v.length <= 2000) out[key] = v
+    }
+    if (typeof o.showcaseCategory === "string" && o.showcaseCategory.trim()) {
+      out.showcaseCategory = o.showcaseCategory.trim().slice(0, 80)
     }
     if (Array.isArray(o.palette)) {
       out.palette = o.palette

--- a/packages/web/app/showcase/page.tsx
+++ b/packages/web/app/showcase/page.tsx
@@ -27,18 +27,33 @@ export default async function ShowcasePage() {
   let brandCategories: { name: string; description: string; icons: { title: string; subtitle: string; badgePath: string }[]; brand: true }[] = []
   if (showBrandBadges) {
     const brands = await listAllBrands()
-    brandCategories = brands
-      .filter((b) => (b.profile.showcaseBadges?.length ?? 0) > 0)
-      .map((b) => ({
-        name: b.name ?? b.slug,
-        description: `Showcase badges for the ${b.name ?? b.slug} brand.`,
-        brand: true as const,
-        icons: (b.profile.showcaseBadges ?? []).map((sb) => ({
-          title: sb.alt || `${b.name ?? b.slug} badge`,
+    // Group brands by their chosen showcase category (default: the brand name),
+    // so several brands can share one category heading. Preserves first-seen
+    // order of categories.
+    const byCategory = new Map<string, (typeof brandCategories)[number]>()
+    for (const b of brands) {
+      if ((b.profile.showcaseBadges?.length ?? 0) === 0) continue
+      const label = b.name ?? b.slug
+      const category = b.profile.showcaseCategory?.trim() || label
+      let entry = byCategory.get(category)
+      if (!entry) {
+        entry = {
+          name: category,
+          description: `Showcase badges for ${category}.`,
+          brand: true as const,
+          icons: [],
+        }
+        byCategory.set(category, entry)
+      }
+      for (const sb of b.profile.showcaseBadges ?? []) {
+        entry.icons.push({
+          title: sb.alt || `${label} badge`,
           subtitle: "brand badge",
           badgePath: `${sb.path}${sb.path.includes("?") ? "&" : "?"}brand=${b.slug}`,
-        })),
-      }))
+        })
+      }
+    }
+    brandCategories = Array.from(byCategory.values())
   }
 
   return (

--- a/packages/web/components/brand-editor.tsx
+++ b/packages/web/components/brand-editor.tsx
@@ -589,6 +589,21 @@ export function BrandEditor({
       </section>
 
       {/* Showcase badges — curated badges shown for this brand in /showcase */}
+      <section className="flex flex-col gap-1.5">
+        <Label htmlFor="brand-showcase-category">Showcase category</Label>
+        <Input
+          id="brand-showcase-category"
+          value={profile.showcaseCategory ?? ""}
+          onChange={(e) => setProfile((p) => ({ ...p, showcaseCategory: e.target.value || undefined }))}
+          placeholder={name || slug || "Brand name"}
+        />
+        <p className="text-xs text-muted-foreground">
+          The heading this brand&apos;s showcase badges appear under on{" "}
+          <code>/showcase</code>. Defaults to the brand name; brands that share a
+          category are grouped together.
+        </p>
+      </section>
+
       <BrandShowcaseEditor
         badges={profile.showcaseBadges ?? []}
         onChange={(next) => setProfile((p) => ({ ...p, showcaseBadges: next }))}


### PR DESCRIPTION
## What

Adds a **Showcase category** field to a brand, controlling the heading its showcase badges appear under on `/showcase`. Brands that share a category are grouped together.

## Why

Brand showcase badges were always forced into a category named after the brand. Now you can choose a friendlier label (or share one category across several brands).

## How

- `BrandProfile` gains `showcaseCategory` (sanitized server-side, <=80 chars).
- Brand editor: a "Showcase category" input above the showcase badges section, defaulting to the brand name.
- `/showcase` groups brands by `showcaseCategory` (fallback: brand name), merging badges from brands that share one.

## Testing

- Lint + build + tests green (web 91, core 310).

## Notes

- Reminder: brand showcase badges only appear on `/showcase` when the admin `showcaseBrandBadges` site setting is ON (currently off in prod). Toggle it in /dashboard/admin to surface them.

## Type

- [x] `feat`