### PR TITLE
feat(brands): surface uploaded marks in the logo icon picker

### DIFF
--- a/packages/web/components/brand-editor.tsx
+++ b/packages/web/components/brand-editor.tsx
@@ -555,19 +555,28 @@ export function BrandEditor({
         <div className="flex flex-col gap-1.5 sm:col-span-2">
           <Label>Logo icon</Label>
           <LogoPicker
-            // A hosted mark (logo=brand / data URI) is managed via the logo
-            // slots below; this field picks a SimpleIcons/React-Icons glyph.
+            // Picks a SimpleIcons/React-Icons glyph, OR the brand's own uploaded
+            // mark(s) surfaced as `brand` / `brand-alt` (extraOptions). Hosted
+            // data-URI logos are managed via the logo slots below.
             value={
-              !config.logo || config.logo.startsWith("data:") || config.logo.startsWith("brand")
+              !config.logo || config.logo.startsWith("data:")
                 ? ""
                 : config.logo
             }
             onChange={(v) => setConfig((c) => ({ ...c, logo: v || undefined }))}
+            extraOptions={[
+              ...(storedAssets["mark"] != null || logos.markUrl
+                ? [{ value: "brand", label: "Your mark" }]
+                : []),
+              ...(storedAssets["mark-alt"] != null
+                ? [{ value: "brand-alt", label: "Your alt mark" }]
+                : []),
+            ]}
             ariaLabel="Brand logo icon"
           />
           <p className="text-xs text-muted-foreground">
-            Pick an icon from Simple Icons / React Icons. Leave on Auto to use
-            your uploaded mark below (if any), else the provider default.
+            Pick a Simple Icons / React Icons glyph, or your uploaded mark. Leave
+            on Auto for your mark (if any), else the provider default.
           </p>
         </div>
       </section>

--- a/packages/web/components/logo-picker.tsx
+++ b/packages/web/components/logo-picker.tsx
@@ -120,9 +120,15 @@ interface LogoPickerProps {
   onChange: (value: string) => void
   /** Accessible name for the trigger button. @default "Logo icon" */
   ariaLabel?: string
+  /**
+   * Context-specific options prepended to the picker (e.g. a brand's uploaded
+   * marks as `brand` / `brand-alt`). Shown in a leading "Brand" group and used
+   * to resolve the trigger label for those values.
+   */
+  extraOptions?: { value: string; label: string }[]
 }
 
-export function LogoPicker({ value, onChange, ariaLabel = "Logo icon" }: LogoPickerProps) {
+export function LogoPicker({ value, onChange, ariaLabel = "Logo icon", extraOptions = [] }: LogoPickerProps) {
   const [open, setOpen] = React.useState(false)
   const [search, setSearch] = React.useState("")
   const [sourceFilter, setSourceFilter] = React.useState("all")
@@ -176,6 +182,8 @@ export function LogoPicker({ value, onChange, ariaLabel = "Logo icon" }: LogoPic
   const displayLabel = React.useMemo(() => {
     if (!value) return "Auto"
     if (value === "false") return "None"
+    const extra = extraOptions.find(o => o.value === value)
+    if (extra) return extra.label
     const popular = POPULAR_ICONS.find(o => o.value === value)
     if (popular) return popular.label
     // Check if it's a lu: prefix
@@ -187,7 +195,7 @@ export function LogoPicker({ value, onChange, ariaLabel = "Logo icon" }: LogoPic
       if (icon) return icon.title
     }
     return value
-  }, [value, allIcons])
+  }, [value, allIcons, extraOptions])
 
   // Search results
   const searchResults = React.useMemo(() => {
@@ -278,16 +286,31 @@ export function LogoPicker({ value, onChange, ariaLabel = "Logo icon" }: LogoPic
     }
 
     if (showingPopular) {
-      return Array.from(popularGroups.entries()).map(([group, opts]) => ({
-        heading: group,
-        items: opts.map(opt => ({
-          value: opt.value,
-          commandValue: opt.value || opt.label,
-          label: opt.label,
-          tag: opt.source || undefined,
-          tagClassName: SOURCE_COLORS[opt.source] || "bg-muted text-muted-foreground",
+      const brandSection: SearchablePickerSection[] = extraOptions.length
+        ? [{
+            heading: "Brand",
+            items: extraOptions.map(opt => ({
+              value: opt.value,
+              commandValue: opt.value,
+              label: opt.label,
+              tag: "Brand",
+              tagClassName: SOURCE_COLORS["shieldcn"] || "bg-muted text-muted-foreground",
+            })),
+          }]
+        : []
+      return [
+        ...brandSection,
+        ...Array.from(popularGroups.entries()).map(([group, opts]) => ({
+          heading: group,
+          items: opts.map(opt => ({
+            value: opt.value,
+            commandValue: opt.value || opt.label,
+            label: opt.label,
+            tag: opt.source || undefined,
+            tagClassName: SOURCE_COLORS[opt.source] || "bg-muted text-muted-foreground",
+          })),
         })),
-      }))
+      ]
     }
 
     return []
@@ -300,6 +323,7 @@ export function LogoPicker({ value, onChange, ariaLabel = "Logo icon" }: LogoPic
     showingPopular,
     showingSearch,
     sourceFilter,
+    extraOptions,
   ])
 
   const emptyContent = showingSearch && !loading ? (


### PR DESCRIPTION
## What

A brand's uploaded mark / alt mark now appear as selectable options in the Logo icon picker (a leading "Brand" group), so you can pick your hosted mark without remembering the `logo=brand` / `logo=brand-alt` convention.

## How

- `LogoPicker` gains an `extraOptions` prop (value/label), prepended to the picker and used to resolve the trigger label.
- brand-editor feeds it `brand` / `brand-alt` when those assets exist (or a freshly imported mark), and no longer blanks out a `brand*` value so the selection round-trips.

## Testing

- Lint + build green.

## Type

- [x] `feat`