### PR TITLE
fix(brands): uploaded mark as logo + stop double brand= in showcase

### DIFF
--- a/packages/core/src/brands.ts
+++ b/packages/core/src/brands.ts
@@ -99,6 +99,15 @@ function sanitizeConfig(input: unknown): BrandConfig {
 
 const HEX_RE = /^#?[0-9a-fA-F]{3,8}$/
 
+/** Remove any `brand=` query param from a badge path (the showcase adds it). */
+export function stripBrandParam(path: string): string {
+  const q = path.indexOf("?")
+  if (q === -1) return path
+  const base = path.slice(0, q)
+  const params = path.slice(q + 1).split("&").filter((p) => p && !p.startsWith("brand="))
+  return params.length ? `${base}?${params.join("&")}` : base
+}
+
 function sanitizeProfile(input: unknown): BrandProfile {
   const out: BrandProfile = {}
   if (input && typeof input === "object") {
@@ -129,7 +138,9 @@ function sanitizeProfile(input: unknown): BrandProfile {
         .filter((b) => /^\/[a-zA-Z0-9]/.test(b.path) && !b.path.includes("://"))
         .slice(0, MAX_BRAND_SHOWCASE)
         .map((b) => ({
-          path: b.path.slice(0, 600),
+          // Never store a `brand=` param: the showcase applies the brand by
+          // context, so a baked-in one would duplicate (?brand=x&brand=x).
+          path: stripBrandParam(b.path).slice(0, 600),
           alt: typeof b.alt === "string" ? b.alt.slice(0, 120) : undefined,
         }))
     }

--- a/packages/web/app/showcase/page.tsx
+++ b/packages/web/app/showcase/page.tsx
@@ -3,7 +3,7 @@ import { SiteShell } from "@/components/site-shell"
 import ShowcaseClient from "./showcase-client"
 import { pageMetadata } from "@/lib/metadata"
 import { getBoolSetting } from "@shieldcn/core/settings"
-import { listAllBrands } from "@shieldcn/core/brands"
+import { listAllBrands, stripBrandParam } from "@shieldcn/core/brands"
 
 // The showcase reflects an admin-controlled setting; revalidate periodically so
 // a toggle propagates without a deploy (and never serves a permanently-cached
@@ -49,7 +49,12 @@ export default async function ShowcasePage() {
         entry.icons.push({
           title: sb.alt || `${label} badge`,
           subtitle: "brand badge",
-          badgePath: `${sb.path}${sb.path.includes("?") ? "&" : "?"}brand=${b.slug}`,
+          badgePath: (() => {
+            // Strip any baked-in brand= (older saved paths) so we never emit
+            // ?brand=x&brand=x, then apply this brand.
+            const p = stripBrandParam(sb.path)
+            return `${p}${p.includes("?") ? "&" : "?"}brand=${b.slug}`
+          })(),
         })
       }
     }

--- a/packages/web/components/brand-editor.tsx
+++ b/packages/web/components/brand-editor.tsx
@@ -319,6 +319,13 @@ export function BrandEditor({
       setStoredAssets((prev) => ({ ...prev, [kind]: file.name }))
       // Bust the <img> cache for logos so the preview reflects the new file.
       setLogoRev((r) => r + 1)
+      // Uploading a mark means "use this as the logo": point config.logo at the
+      // hosted mark so badges render it. Otherwise a seeded slug (e.g.
+      // logo=react) keeps overriding the freshly uploaded SVG. Skip only if the
+      // logo is already a hosted mark. Save to persist.
+      if (kind === "mark" && !(config.logo ?? "").startsWith("brand")) {
+        setConfig((c) => ({ ...c, logo: "brand" }))
+      }
       toast.success(`Uploaded ${file.name}`)
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "upload failed")


### PR DESCRIPTION
## What

Two brand-showcase fixes:

1. **Uploaded SVG marks now show.** Uploading a mark points `config.logo` at it (`logo=brand`) instead of leaving a seeded slug (e.g. `logo=react`) to override the freshly uploaded SVG.
2. **No more `?brand=x&brand=x`.** Showcase badge paths no longer carry a `brand=` param — `sanitizeProfile` strips it on save, and the showcase page strips any legacy one before applying the brand.

## Why

- Users reported "SVG uploads aren't populating the icon" — the seeded `config.logo` slug was winning over the uploaded mark.
- A saved showcase badge produced a duplicated `&brand=claude&brand=claude` URL.

## Companion data fix (already applied to prod)

Stripped baked-in `brand=` from existing showcase paths (2 brands, incl. claude).

## Testing

- Lint + build + tests green (web 91, core 310).

## Type

- [x] `fix`