### PR TITLE
fix(badges): branded badge markdown stays an image, not a <picture>

### DIFF
--- a/packages/web/lib/badge-output.test.ts
+++ b/packages/web/lib/badge-output.test.ts
@@ -1,0 +1,42 @@
+/**
+ * shieldcn
+ * lib/badge-output.test
+ *
+ * The showcase / badge modal renders a theme-adaptive <picture> only for
+ * variants whose colors change with the light/dark theme. A `branded` badge is
+ * driven by its fixed brand color, so its Markdown must stay a plain
+ * `![alt](url)` — not turn into an HTML <picture> block.
+ */
+
+import { describe, it, expect } from "vitest"
+import { formatBadgeOutput, isThemeAdaptiveBadgeUrl } from "./badge-output"
+
+const BASE = "https://shieldcn.dev"
+
+describe("branded badges are not theme-adaptive", () => {
+  it("isThemeAdaptiveBadgeUrl is false for branded (even ignoring mode)", () => {
+    const url = `${BASE}/badge/React.svg?variant=branded&brand=react&mode=dark`
+    expect(isThemeAdaptiveBadgeUrl(url, { ignoreMode: true })).toBe(false)
+  })
+
+  it("markdown for a branded badge is a plain image, not <picture>", () => {
+    const url = `${BASE}/badge/React.svg?variant=branded&brand=react&mode=dark`
+    const md = formatBadgeOutput(url, "markdown", {
+      alt: "React",
+      preferPicture: true,
+      ignoreModeForPicture: true,
+    })
+    expect(md).toBe(`![React](${url})`)
+    expect(md).not.toContain("<picture")
+  })
+
+  it("still emits <picture> for a genuinely theme-derived variant (outline)", () => {
+    const url = `${BASE}/npm/react.svg?variant=outline`
+    const md = formatBadgeOutput(url, "markdown", {
+      alt: "npm",
+      preferPicture: true,
+      ignoreModeForPicture: true,
+    })
+    expect(md).toContain("<picture")
+  })
+})

--- a/packages/web/lib/badge-output.ts
+++ b/packages/web/lib/badge-output.ts
@@ -7,12 +7,16 @@
 
 type BadgeOutputFormat = "markdown" | "html" | "url" | "rst" | "asciidoc"
 
+// Variants whose colors are derived from the light/dark theme, so the badge
+// genuinely changes between modes and benefits from a theme-adaptive <picture>.
+// `branded` is intentionally excluded: its background is the fixed brand color
+// (contrast-aware text), so it renders identically in dark and light — emitting
+// a <picture> would just duplicate the same badge and turn Markdown into HTML.
 const THEME_DERIVED_VARIANTS = new Set([
   "default",
   "secondary",
   "outline",
   "ghost",
-  "branded",
 ])
 
 const COLOR_LOCKING_PARAMS = [


### PR DESCRIPTION
## What

In the showcase / badge modal, the **markdown** tab for a branded badge was showing an HTML `<picture>` block instead of `![alt](url)`.

## Why

The modal emits a theme-adaptive `<picture>` for variants whose colors change with the reader's light/dark theme. `branded` was in that set \u2014 but a branded badge's background is the fixed brand color (contrast-aware text), so it renders identically in both modes. The `<picture>` was pointless *and* turned the "markdown" output into HTML.

## How

Remove `branded` from `THEME_DERIVED_VARIANTS`. Branded badges now copy as plain Markdown; default/secondary/outline/ghost still get the theme-adaptive `<picture>`. Adds a regression test.

## Testing

- 3 new tests + lint + build green.

## Type

- [x] `fix`