### PR TITLE
refactor(picker): virtualize icon list with brand previews and deferred search

### DIFF
--- a/packages/web/components/logo-picker.tsx
+++ b/packages/web/components/logo-picker.tsx
@@ -83,6 +83,33 @@ const SOURCE_COLORS: Record<string, string> = {
   shieldcn: "bg-primary text-primary-foreground",
 }
 
+// ---------------------------------------------------------------------------
+// Brand logo preview — lazy <img> from the SimpleIcons CDN, hidden on error
+// ---------------------------------------------------------------------------
+
+function BrandIconPreview({ slug }: { slug: string }) {
+  // Track the slug that failed rather than a boolean, so a new slug resets
+  // during render without needing a setState-in-effect.
+  const [failedSlug, setFailedSlug] = React.useState<string | null>(null)
+  if (failedSlug === slug) return null
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={`https://cdn.simpleicons.org/${encodeURIComponent(slug)}`}
+      alt=""
+      loading="lazy"
+      className="size-4 object-contain"
+      onError={() => setFailedSlug(slug)}
+    />
+  )
+}
+
+/** Return a preview node for SimpleIcons entries only (covers brand logos). */
+function brandPreview(slug: string, isSimpleIcon: boolean): React.ReactNode {
+  if (!isSimpleIcon || !slug || slug === "false") return undefined
+  return <BrandIconPreview slug={slug} />
+}
+
 const SOURCE_SHORT: Record<string, string> = {
   simple: "SI",
   lucide: "Lu",
@@ -131,6 +158,8 @@ interface LogoPickerProps {
 export function LogoPicker({ value, onChange, ariaLabel = "Logo icon", extraOptions = [] }: LogoPickerProps) {
   const [open, setOpen] = React.useState(false)
   const [search, setSearch] = React.useState("")
+  // Defer the expensive 30k-icon filter so typing stays responsive.
+  const deferredSearch = React.useDeferredValue(search)
   const [sourceFilter, setSourceFilter] = React.useState("all")
   const [allIcons, setAllIcons] = React.useState<IconEntry[] | null>(null)
   const [loading, setLoading] = React.useState(false)
@@ -199,8 +228,8 @@ export function LogoPicker({ value, onChange, ariaLabel = "Logo icon", extraOpti
 
   // Search results
   const searchResults = React.useMemo(() => {
-    if (!allIcons || !search.trim() || search.length < 2) return []
-    const q = search.toLowerCase()
+    if (!allIcons || !deferredSearch.trim() || deferredSearch.length < 2) return []
+    const q = deferredSearch.toLowerCase()
     const filtered = allIcons.filter(i => {
       if (sourceFilter !== "all" && i.source !== sourceFilter) return false
       return i.title.toLowerCase().includes(q) || i.slug.toLowerCase().includes(q)
@@ -214,15 +243,13 @@ export function LogoPicker({ value, onChange, ariaLabel = "Logo icon", extraOpti
       if (aExact !== bExact) return aExact - bExact
       return at.localeCompare(bt)
     })
-    return filtered.slice(0, 50)
-  }, [allIcons, search, sourceFilter])
+    return filtered.slice(0, 500)
+  }, [allIcons, deferredSearch, sourceFilter])
 
   // Browse results (no search, just filtered by source)
   const browseResults = React.useMemo(() => {
     if (!allIcons || search.length >= 2 || sourceFilter === "all") return []
-    return allIcons
-      .filter(i => i.source === sourceFilter)
-      .slice(0, 50)
+    return allIcons.filter(i => i.source === sourceFilter)
   }, [allIcons, search, sourceFilter])
 
   // Group popular icons
@@ -257,11 +284,12 @@ export function LogoPicker({ value, onChange, ariaLabel = "Logo icon", extraOpti
           label: icon.title,
           tag: SOURCE_SHORT[icon.source] || icon.source,
           tagClassName: SOURCE_COLORS[icon.source] || "bg-muted text-muted-foreground",
+          icon: brandPreview(icon.slug, icon.source === "simple"),
           meta: icon.slug,
         })),
-        footer: resultCount >= 50 && (
+        footer: resultCount >= 500 && (
           <div className="px-3 py-1.5 text-[10px] text-muted-foreground">
-            Showing first 50 results. Refine your search for more.
+            Showing first 500 results. Refine your search for more.
           </div>
         ),
       }]
@@ -269,19 +297,15 @@ export function LogoPicker({ value, onChange, ariaLabel = "Logo icon", extraOpti
 
     if (showingBrowse) {
       return [{
-        heading: `${ICON_SOURCES.find(s => s.value === sourceFilter)?.label} (${resultCount}${browseResults.length >= 50 ? "+" : ""})`,
+        heading: `${ICON_SOURCES.find(s => s.value === sourceFilter)?.label} (${resultCount})`,
         items: browseResults.map(icon => ({
           value: icon.slug,
           label: icon.title,
           tag: SOURCE_SHORT[icon.source] || icon.source,
           tagClassName: SOURCE_COLORS[icon.source] || "bg-muted text-muted-foreground",
+          icon: brandPreview(icon.slug, icon.source === "simple"),
           meta: icon.slug,
         })),
-        footer: browseResults.length >= 50 && (
-          <div className="px-3 py-1.5 text-[10px] text-muted-foreground">
-            Type to search within this source.
-          </div>
-        ),
       }]
     }
 
@@ -308,6 +332,7 @@ export function LogoPicker({ value, onChange, ariaLabel = "Logo icon", extraOpti
             label: opt.label,
             tag: opt.source || undefined,
             tagClassName: SOURCE_COLORS[opt.source] || "bg-muted text-muted-foreground",
+            icon: brandPreview(opt.value, opt.source === "Simple Icons"),
           })),
         })),
       ]

--- a/packages/web/components/searchable-picker.tsx
+++ b/packages/web/components/searchable-picker.tsx
@@ -3,21 +3,21 @@
  * components/searchable-picker
  *
  * Reusable searchable popover picker shell for controls that need search,
- * filter chips, grouped results, selected state, and compact item tags.
+ * filter chips, grouped results, selected state, compact item tags, and
+ * optional icon previews.
+ *
+ * The results list is virtualized with @tanstack/react-virtual so it can
+ * render tens of thousands of rows without a hard result cap. Keyboard
+ * navigation (Arrow keys + Enter) is handled manually since virtualization
+ * is incompatible with cmdk's DOM-based selection.
  */
 
 "use client"
 
 import * as React from "react"
+import { useVirtualizer } from "@tanstack/react-virtual"
 import { Check, ChevronsUpDown, Loader2, Search, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import {
-  Command,
-  CommandGroup,
-  CommandItem,
-  CommandList,
-  CommandSeparator,
-} from "@/components/ui/command"
 import {
   Popover,
   PopoverContent,
@@ -34,6 +34,8 @@ export interface SearchablePickerItem {
   value: string
   label: string
   commandValue?: string
+  /** Optional leading preview node (e.g. an icon glyph or brand logo). */
+  icon?: React.ReactNode
   tag?: string
   tagClassName?: string
   meta?: string
@@ -84,6 +86,18 @@ interface SearchablePickerProps {
   showSectionSeparators?: boolean
 }
 
+// ---------------------------------------------------------------------------
+// Flattened row model — sections/items collapsed into a single virtual list
+// ---------------------------------------------------------------------------
+
+type Row =
+  | { kind: "header"; node: React.ReactNode }
+  | { kind: "heading"; label?: string; separator: boolean }
+  | { kind: "item"; item: SearchablePickerItem; sectionKey: string }
+  | { kind: "footer"; node: React.ReactNode; key: string }
+
+const ESTIMATED_ROW = 32
+
 export function SearchablePicker({
   value,
   triggerLabel,
@@ -122,13 +136,92 @@ export function SearchablePicker({
     onOpenChange?.(nextOpen)
   }, [onOpenChange])
 
-  const visibleSections = sections.filter(section => section.items.length > 0)
+  const visibleSections = React.useMemo(
+    () => sections.filter(section => section.items.length > 0),
+    [sections],
+  )
   const hasItems = visibleSections.length > 0
 
   const selectItem = React.useCallback((nextValue: string) => {
     onValueChange(nextValue)
     setOpen(false)
   }, [onValueChange, setOpen])
+
+  // Flatten sections into virtual rows and track which rows are selectable.
+  const { rows, itemRowIndexes } = React.useMemo(() => {
+    const flat: Row[] = []
+    const selectable: number[] = []
+    if (listHeader) flat.push({ kind: "header", node: listHeader })
+    visibleSections.forEach((section, sectionIndex) => {
+      if (section.heading || (showSectionSeparators && sectionIndex > 0)) {
+        flat.push({
+          kind: "heading",
+          label: section.heading,
+          separator: showSectionSeparators && sectionIndex > 0,
+        })
+      }
+      const sectionKey = section.heading ?? String(sectionIndex)
+      for (const item of section.items) {
+        if (!item.disabled) selectable.push(flat.length)
+        flat.push({ kind: "item", item, sectionKey })
+      }
+      if (section.footer) {
+        flat.push({ kind: "footer", node: section.footer, key: `${sectionKey}-footer` })
+      }
+    })
+    return { rows: flat, itemRowIndexes: selectable }
+  }, [visibleSections, listHeader, showSectionSeparators])
+
+  // Active row for keyboard navigation (index into `rows`).
+  const [activeRow, setActiveRow] = React.useState<number>(-1)
+  const parentRef = React.useRef<HTMLDivElement>(null)
+
+  // eslint-disable-next-line react-hooks/incompatible-library -- virtualizer output is intentionally read fresh each render
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => ESTIMATED_ROW,
+    overscan: 10,
+  })
+
+  // Reset active row to the first selectable whenever the result set changes.
+  React.useEffect(() => {
+    setActiveRow(itemRowIndexes.length > 0 ? itemRowIndexes[0] : -1)
+  }, [itemRowIndexes])
+
+  const moveActive = React.useCallback((direction: 1 | -1) => {
+    if (itemRowIndexes.length === 0) return
+    const pos = itemRowIndexes.indexOf(activeRow)
+    const nextPos =
+      pos === -1
+        ? direction === 1 ? 0 : itemRowIndexes.length - 1
+        : (pos + direction + itemRowIndexes.length) % itemRowIndexes.length
+    const nextRow = itemRowIndexes[nextPos]
+    setActiveRow(nextRow)
+    virtualizer.scrollToIndex(nextRow, { align: "auto" })
+  }, [activeRow, itemRowIndexes, virtualizer])
+
+  const handleKeyDown = React.useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault()
+      moveActive(1)
+      return
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault()
+      moveActive(-1)
+      return
+    }
+    if (event.key === "Enter") {
+      const row = rows[activeRow]
+      if (row && row.kind === "item" && !row.item.disabled) {
+        event.preventDefault()
+        selectItem(row.item.value)
+        return
+      }
+    }
+    onSearchKeyDown?.(event)
+  }, [activeRow, moveActive, onSearchKeyDown, rows, selectItem])
 
   return (
     <Popover open={resolvedOpen} onOpenChange={setOpen}>
@@ -151,7 +244,7 @@ export function SearchablePicker({
         className={cn("w-[min(380px,calc(100vw-2rem))] p-0", contentClassName)}
         align="start"
       >
-        <Command shouldFilter={false}>
+        <div className="flex flex-col">
           <div className="flex items-center border-b px-3">
             <Search className="mr-2 size-3.5 shrink-0 opacity-50" />
             <input
@@ -159,7 +252,8 @@ export function SearchablePicker({
               placeholder={placeholder}
               value={search}
               onChange={event => onSearchChange(event.target.value)}
-              onKeyDown={onSearchKeyDown}
+              onKeyDown={handleKeyDown}
+              aria-autocomplete="list"
               className="flex h-9 w-full bg-transparent py-2 text-xs outline-none placeholder:text-muted-foreground"
             />
             {search && (
@@ -200,61 +294,103 @@ export function SearchablePicker({
             </div>
           )}
 
-          <CommandList className={cn("max-h-[320px]", listClassName)}>
-            {loading ? (
-              <div className="flex items-center justify-center gap-2 p-6 text-xs text-muted-foreground">
-                <Loader2 className="size-4 animate-spin" />
-                {loadingLabel}
+          {loading ? (
+            <div className="flex items-center justify-center gap-2 p-6 text-xs text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              {loadingLabel}
+            </div>
+          ) : hasItems ? (
+            <div
+              ref={parentRef}
+              className={cn("max-h-[320px] overflow-y-auto overflow-x-hidden p-1", listClassName)}
+              role="listbox"
+            >
+              <div
+                className="relative w-full"
+                style={{ height: `${virtualizer.getTotalSize()}px` }}
+              >
+                {virtualizer.getVirtualItems().map(virtualRow => {
+                  const row = rows[virtualRow.index]
+                  return (
+                    <div
+                      key={virtualRow.key}
+                      data-index={virtualRow.index}
+                      ref={virtualizer.measureElement}
+                      className="absolute left-0 top-0 w-full"
+                      style={{ transform: `translateY(${virtualRow.start}px)` }}
+                    >
+                      {row.kind === "header" && row.node}
+
+                      {row.kind === "heading" && (
+                        <>
+                          {row.separator && <div className="mx-1 my-1 h-px bg-border" />}
+                          {row.label && (
+                            <div className="px-2 py-1.5 text-[10px] font-medium text-muted-foreground">
+                              {row.label}
+                            </div>
+                          )}
+                        </>
+                      )}
+
+                      {row.kind === "footer" && row.node}
+
+                      {row.kind === "item" && (() => {
+                        const { item } = row
+                        const selected = value === item.value
+                        const active = virtualRow.index === activeRow
+                        return (
+                          <button
+                            type="button"
+                            role="option"
+                            aria-selected={selected}
+                            disabled={item.disabled}
+                            onClick={() => selectItem(item.value)}
+                            onMouseMove={() => setActiveRow(virtualRow.index)}
+                            className={cn(
+                              "flex w-full items-center gap-1.5 rounded-sm px-2 py-1.5 text-left text-xs outline-none",
+                              active && "bg-accent text-accent-foreground",
+                              item.disabled && "pointer-events-none opacity-50",
+                            )}
+                          >
+                            <Check className={cn("size-3 shrink-0", selected ? "opacity-100" : "opacity-0")} />
+                            {item.icon && (
+                              <span className="flex size-4 shrink-0 items-center justify-center">
+                                {item.icon}
+                              </span>
+                            )}
+                            <span className="flex-1 truncate">{item.label}</span>
+                            {item.tag && (
+                              <span className={cn(
+                                "inline-flex shrink-0 items-center rounded px-1 py-0.5 text-[9px] font-medium leading-none",
+                                item.tagClassName ?? "bg-muted text-muted-foreground",
+                              )}>
+                                {item.tag}
+                              </span>
+                            )}
+                            {item.meta && (
+                              <span className={cn(
+                                "max-w-[100px] truncate text-[10px] font-mono text-muted-foreground",
+                                item.metaClassName,
+                              )}>
+                                {item.meta}
+                              </span>
+                            )}
+                          </button>
+                        )
+                      })()}
+                    </div>
+                  )
+                })}
               </div>
-            ) : hasItems ? (
-              <>
-                {listHeader}
-                {visibleSections.map((section, sectionIndex) => (
-                  <React.Fragment key={section.heading ?? sectionIndex}>
-                    {showSectionSeparators && sectionIndex > 0 && <CommandSeparator />}
-                    <CommandGroup heading={section.heading}>
-                    {section.items.map(item => (
-                        <CommandItem
-                          key={`${section.heading ?? sectionIndex}:${item.value || item.commandValue || item.label}`}
-                          value={item.commandValue ?? item.value}
-                          disabled={item.disabled}
-                          onSelect={() => selectItem(item.value)}
-                          className="text-xs gap-1.5"
-                        >
-                          <Check className={cn("size-3 shrink-0", value === item.value ? "opacity-100" : "opacity-0")} />
-                          <span className="flex-1 truncate">{item.label}</span>
-                          {item.tag && (
-                            <span className={cn(
-                              "inline-flex shrink-0 items-center rounded px-1 py-0.5 text-[9px] font-medium leading-none",
-                              item.tagClassName ?? "bg-muted text-muted-foreground",
-                            )}>
-                              {item.tag}
-                            </span>
-                          )}
-                          {item.meta && (
-                            <span className={cn(
-                              "max-w-[100px] truncate text-[10px] font-mono text-muted-foreground",
-                              item.metaClassName,
-                            )}>
-                              {item.meta}
-                            </span>
-                          )}
-                        </CommandItem>
-                      ))}
-                      {section.footer}
-                    </CommandGroup>
-                  </React.Fragment>
-                ))}
-              </>
-            ) : (
-              emptyContent ?? (
-                <div className="p-4 text-center text-xs text-muted-foreground">
-                  {emptyLabel}
-                </div>
-              )
-            )}
-          </CommandList>
-        </Command>
+            </div>
+          ) : (
+            emptyContent ?? (
+              <div className="p-4 text-center text-xs text-muted-foreground">
+                {emptyLabel}
+              </div>
+            )
+          )}
+        </div>
       </PopoverContent>
     </Popover>
   )

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -28,6 +28,7 @@
     "@shieldcn/core": "workspace:*",
     "@tabler/icons-react": "^3.44.0",
     "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-virtual": "^3.14.5",
     "@tiptap/extension-heading": "^3.27.1",
     "@tiptap/extension-paragraph": "^3.27.1",
     "@tiptap/extension-text-align": "^3.27.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,7 +117,7 @@ importers:
     dependencies:
       '@sentry/nextjs':
         specifier: ^10.63.0
-        version: 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.107.2(lightningcss@1.32.0))
+        version: 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.107.2(lightningcss@1.32.0))
       '@shieldcn/core':
         specifier: workspace:*
         version: link:../core
@@ -187,7 +187,7 @@ importers:
         version: 2.6.2
       '@sentry/nextjs':
         specifier: ^10.63.0
-        version: 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.107.2(lightningcss@1.32.0))
+        version: 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.107.2(lightningcss@1.32.0))
       '@shieldcn/core':
         specifier: workspace:*
         version: link:../core
@@ -197,6 +197,9 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/react-virtual':
+        specifier: ^3.14.5
+        version: 3.14.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tiptap/extension-heading':
         specifier: ^3.27.1
         version: 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
@@ -2833,9 +2836,18 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
+  '@tanstack/react-virtual@3.14.5':
+    resolution: {integrity: sha512-4EKRXh7zBLkbKbFmG3AUVkircuHd+7OdT1pocJSepxtfBd3qnrJgJ5rtPkRYyo9fmyVb2+pI2xPy5oYvMLQy6A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/table-core@8.21.3':
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
+
+  '@tanstack/virtual-core@3.17.3':
+    resolution: {integrity: sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==}
 
   '@tiptap/core@3.27.1':
     resolution: {integrity: sha512-rV6Qn4wmC6BxfF+4mu6bqGWj9vA4oXXhsrpXaJL2uhjxeHAGofjwcHof2X84VYzeyXgdlsGmqKie4TAppVXZUQ==}
@@ -9654,7 +9666,7 @@ snapshots:
     dependencies:
       '@sentry/core': 10.63.0
 
-  '@sentry/nextjs@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.107.2(lightningcss@1.32.0))':
+  '@sentry/nextjs@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.107.2(lightningcss@1.32.0))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@rollup/plugin-commonjs': 28.0.1(rollup@4.62.2)
@@ -9915,7 +9927,15 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  '@tanstack/react-virtual@3.14.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.3
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@tanstack/table-core@8.21.3': {}
+
+  '@tanstack/virtual-core@3.17.3': {}
 
   '@tiptap/core@3.27.1(@tiptap/pm@3.27.1)':
     dependencies:
@@ -11677,8 +11697,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.10
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -11700,7 +11720,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11711,22 +11731,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11737,7 +11757,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3


### PR DESCRIPTION
The badge builder's logo picker capped results at 50 with no virtualization
and showed no icon glyphs, making brand selection painful across 30k+ icons.

- Virtualize the results list with @tanstack/react-virtual (custom keyboard
  nav since cmdk can't virtualize), removing the hard 50-result cap
- Add lazy brand-logo previews via the SimpleIcons CDN for brand entries
- Defer the 30k-icon filter with useDeferredValue so typing stays responsive
- Raise search cap to 500 and show full per-source browse counts
