### PR TITLE
feat(badge-modal): emit real markdown and add adaptive copy tab

### DIFF
--- a/packages/web/components/badge-group-modal.tsx
+++ b/packages/web/components/badge-group-modal.tsx
@@ -5,7 +5,7 @@ import Link from "next/link"
 import { Copy, Check, ExternalLink, Plus, Trash2, GripVertical } from "lucide-react"
 import { useBadgeMode } from "@/lib/use-badge-mode"
 import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard"
-import { formatBadgeOutput } from "@/lib/badge-output"
+import { formatBadgeOutput, isThemeAdaptiveBadgeUrl } from "@/lib/badge-output"
 import {
   Dialog,
   DialogContent,
@@ -40,7 +40,17 @@ const SIZES = ["xs", "sm", "default", "lg"]
 const THEMES = ["_none", "zinc", "slate", "blue", "green", "rose", "orange", "violet", "purple", "cyan", "emerald"]
 const MODES = ["dark", "light"]
 
-type OutputFormat = "markdown" | "url" | "html" | "rst" | "asciidoc"
+type OutputFormat = "markdown" | "adaptive" | "url" | "html" | "rst" | "asciidoc"
+
+// Human labels for the copy-format tabs.
+const FORMAT_LABELS: Record<OutputFormat, string> = {
+  markdown: "markdown",
+  adaptive: "adaptive",
+  url: "url",
+  html: "html",
+  rst: "rst",
+  asciidoc: "asciidoc",
+}
 
 /** Parse a group badge path into individual segment paths. */
 function parseGroupPath(badgePath: string): { segments: string[]; variant: string; size: string; theme: string; mode: string } {
@@ -145,6 +155,8 @@ export function BadgeGroupModal({
   const formattedOutput = useMemo(() => {
     switch (outputFormat) {
       case "markdown":
+        return formatBadgeOutput(fullUrl, "markdown", { alt: title })
+      case "adaptive":
         return formatBadgeOutput(fullUrl, "markdown", {
           alt: title,
           preferPicture: true,
@@ -161,6 +173,15 @@ export function BadgeGroupModal({
       case "asciidoc": return formatBadgeOutput(fullUrl, "asciidoc", { alt: title })
     }
   }, [outputFormat, fullUrl, title])
+
+  // The <picture> "adaptive" tab only applies to theme-adaptive badges;
+  // for fixed-color badges it would just duplicate the plain markdown.
+  const copyFormats = useMemo<OutputFormat[]>(() => {
+    const base: OutputFormat[] = ["markdown"]
+    if (isThemeAdaptiveBadgeUrl(fullUrl, { ignoreMode: true })) base.push("adaptive")
+    base.push("url", "html", "rst", "asciidoc")
+    return base
+  }, [fullUrl])
 
   const handleCopy = useCallback(() => copy(formattedOutput), [copy, formattedOutput])
 
@@ -280,7 +301,7 @@ export function BadgeGroupModal({
         <div className="space-y-2">
           <Label className="text-xs font-medium">Copy badge group</Label>
           <div className="flex flex-wrap gap-1.5">
-            {(["markdown", "url", "html", "rst", "asciidoc"] as OutputFormat[]).map((format) => (
+            {copyFormats.map((format) => (
               <button
                 key={format}
                 onClick={() => setOutputFormat(format)}
@@ -290,7 +311,7 @@ export function BadgeGroupModal({
                     : "border-border bg-background text-muted-foreground hover:bg-muted hover:text-foreground"
                 }`}
               >
-                {format}
+                {FORMAT_LABELS[format]}
               </button>
             ))}
           </div>

--- a/packages/web/components/badge-modal.tsx
+++ b/packages/web/components/badge-modal.tsx
@@ -22,7 +22,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { SvgIconUpload } from "@/components/svg-icon-upload"
-import { formatBadgeOutput } from "@/lib/badge-output"
+import { formatBadgeOutput, isThemeAdaptiveBadgeUrl } from "@/lib/badge-output"
 import { allowedVariantsForPath } from "@shieldcn/core/badges/registry"
 
 interface BadgeModalProps {
@@ -39,7 +39,17 @@ const SIZES = ["xs", "sm", "default", "lg"]
 const THEMES = ["_none", "zinc", "slate", "blue", "green", "rose", "orange", "violet", "purple", "cyan", "emerald"]
 const MODES = ["dark", "light"]
 
-type OutputFormat = "markdown" | "url" | "html" | "rst" | "asciidoc"
+type OutputFormat = "markdown" | "adaptive" | "url" | "html" | "rst" | "asciidoc"
+
+// Human labels for the copy-format tabs.
+const FORMAT_LABELS: Record<OutputFormat, string> = {
+  markdown: "markdown",
+  adaptive: "adaptive",
+  url: "url",
+  html: "html",
+  rst: "rst",
+  asciidoc: "asciidoc",
+}
 
 function withStyleParams(
   badgePath: string,
@@ -164,6 +174,8 @@ export function BadgeModal({
   const formattedOutput = useMemo(() => {
     switch (outputFormat) {
       case "markdown":
+        return formatBadgeOutput(fullUrl, "markdown", { alt: title })
+      case "adaptive":
         return formatBadgeOutput(fullUrl, "markdown", {
           alt: title,
           preferPicture: true,
@@ -183,6 +195,15 @@ export function BadgeModal({
         return formatBadgeOutput(fullUrl, "asciidoc", { alt: title })
     }
   }, [outputFormat, fullUrl, title])
+
+  // The <picture> "adaptive" tab only applies to theme-adaptive badges;
+  // for fixed-color badges it would just duplicate the plain markdown.
+  const copyFormats = useMemo<OutputFormat[]>(() => {
+    const base: OutputFormat[] = ["markdown"]
+    if (isThemeAdaptiveBadgeUrl(fullUrl, { ignoreMode: true })) base.push("adaptive")
+    base.push("url", "html", "rst", "asciidoc")
+    return base
+  }, [fullUrl])
 
   const handleCopy = useCallback(() => copy(formattedOutput), [copy, formattedOutput])
 
@@ -279,7 +300,7 @@ export function BadgeModal({
         <div className="space-y-2">
           <Label className="text-xs font-medium">Copy badge</Label>
           <div className="flex flex-wrap gap-1.5">
-            {(["markdown", "url", "html", "rst", "asciidoc"] as OutputFormat[]).map((format) => (
+            {copyFormats.map((format) => (
               <button
                 key={format}
                 onClick={() => setOutputFormat(format)}
@@ -289,7 +310,7 @@ export function BadgeModal({
                     : "border-border bg-background text-muted-foreground hover:bg-muted hover:text-foreground"
                 }`}
               >
-                {format}
+                {FORMAT_LABELS[format]}
               </button>
             ))}
           </div>


### PR DESCRIPTION
The markdown tab emitted a raw <picture> HTML block for theme-adaptive
variants, so copying 'as markdown' produced HTML that doesn't render as
markdown outside GitHub-flavored contexts.

- markdown tab now always outputs plain `![alt](url)`
- add a dedicated 'adaptive' tab for the light/dark <picture> form, shown
  only for theme-adaptive badges
- apply the same change to the badge group modal
