### PR TITLE
perf(brands): lazy-load row badges and use a lightweight list query

### DIFF
--- a/packages/core/src/brands.ts
+++ b/packages/core/src/brands.ts
@@ -308,6 +308,41 @@ export async function listAllBrands(): Promise<Brand[]> {
   }
 }
 
+/**
+ * Lightweight brand summaries for list views (admin only). Selects only the
+ * columns a list needs (id, slug, name, primary/secondary color) and skips the
+ * heavy `profile` and `brand_md` columns, so the brands dashboard doesn't pull
+ * (or serialize) every brand's full record just to render a row.
+ */
+export interface BrandSummary {
+  id: number
+  slug: string
+  name: string | null
+  color: string | null
+  color2: string | null
+}
+
+export async function listBrandSummaries(): Promise<BrandSummary[]> {
+  try {
+    await initDB()
+    const { rows } = await query<{ id: string | number; slug: string; name: string | null; config: unknown }>(
+      `SELECT id, slug, name, config FROM brands ORDER BY updated_at DESC`,
+    )
+    return rows.map((r) => {
+      const config = sanitizeConfig(r.config)
+      return {
+        id: Number(r.id),
+        slug: r.slug,
+        name: r.name,
+        color: config.color ?? null,
+        color2: config.color2 ?? null,
+      }
+    })
+  } catch {
+    return []
+  }
+}
+
 /** Fetch any brand by slug regardless of owner (admin only). */
 export async function getAnyBrand(slug: string): Promise<Brand | null> {
   await initDB()

--- a/packages/web/app/dashboard/brands/page.tsx
+++ b/packages/web/app/dashboard/brands/page.tsx
@@ -3,7 +3,7 @@ import { Palette } from "lucide-react"
 import { BrandsList } from "@/components/dashboard/brands-list"
 import { DashboardPage, DashboardPageHeader, DashboardPanel } from "@/components/dashboard/dashboard-page"
 import { pageMetadata } from "@/lib/metadata"
-import { listAllBrands } from "@shieldcn/core/brands"
+import { listBrandSummaries } from "@shieldcn/core/brands"
 
 export const metadata: Metadata = pageMetadata({
   title: "Brands",
@@ -12,15 +12,7 @@ export const metadata: Metadata = pageMetadata({
 })
 
 export default async function BrandsPage() {
-  const brands = await listAllBrands()
-
-  const initialBrands = brands.map((b) => ({
-    id: b.id,
-    slug: b.slug,
-    name: b.name,
-    color: b.config?.color ?? null,
-    color2: b.config?.color2 ?? null,
-  }))
+  const initialBrands = await listBrandSummaries()
 
   return (
     <DashboardPage>

--- a/packages/web/components/dashboard/brands-list.tsx
+++ b/packages/web/components/dashboard/brands-list.tsx
@@ -137,10 +137,16 @@ export function BrandsList({ initialBrands }: { initialBrands: BrandRow[] }) {
               <div className="flex min-w-0 items-center gap-3">
                 {mounted ? (
                   // The brand's own logo on its brand color — a live icon chip.
+                  // Lazy + async-decoded so a long brand list doesn't fire every
+                  // badge render at once on page load (each is a live SVG render).
                   // eslint-disable-next-line @next/next/no-img-element
                   <img
                     src={adaptUrl(`/badge/-.svg?brand=${b.slug}&variant=branded`)}
                     alt=""
+                    width={32}
+                    height={32}
+                    loading="lazy"
+                    decoding="async"
                     className="size-8 shrink-0 rounded-lg border border-border object-cover"
                   />
                 ) : (


### PR DESCRIPTION
The brands dashboard felt like it took forever to load: every row eagerly
rendered a live Satori badge (/badge/-.svg?brand=…) with no lazy-loading, so
all N renders fired at once, and the page over-fetched every brand's full
record (profile + brand_md) just to draw a list.

- add loading=lazy + decoding=async + explicit dimensions to the row badge
  img so only visible rows render on load
- add listBrandSummaries() selecting just id/slug/name/color, skipping the
  heavy profile and brand_md columns, and use it for the dashboard list
