### PR TITLE
perf(brands): cheap chip via mark asset + SVGO on uploaded svgs

### DIFF
--- a/packages/core/src/brands.ts
+++ b/packages/core/src/brands.ts
@@ -12,8 +12,33 @@
  * badge with defaults and never breaks the image.
  */
 
+import { optimize as optimizeSvgo } from "svgo"
 import { query, initDB } from "./db"
 import { cacheGet, cacheSet } from "./cache"
+
+/**
+ * Optimize + sanitize an uploaded SVG with SVGO before it is stored and served.
+ * Shrinks payloads (faster asset serving) and strips metadata. `removeScripts`
+ * is added explicitly because SVGO v4's preset-default no longer strips <script>
+ * — and these assets are served as image/svg+xml, which can execute scripts when
+ * opened directly. preset-default keeps the viewBox, so downstream badge
+ * rendering and <img> scaling stay correct. Fail-open: returns the original
+ * bytes if the input isn't parseable, so an odd-but-valid upload is never
+ * rejected here.
+ */
+function optimizeSvgBuffer(data: Buffer): Buffer {
+  try {
+    const { data: out } = optimizeSvgo(data.toString("utf8"), {
+      multipass: true,
+      plugins: ["preset-default", "removeScripts"],
+    })
+    const optimized = Buffer.from(out, "utf8")
+    // Guard against pathological growth; keep whichever is smaller.
+    return optimized.length > 0 && optimized.length <= data.length ? optimized : data
+  } catch {
+    return data
+  }
+}
 
 /** Style keys a brand may carry. Kept in sync with the badge/header params. */
 const BRAND_PARAM_KEYS = [
@@ -544,6 +569,10 @@ export async function putBrandAsset(
   fileName?: string | null,
 ): Promise<void> {
   await initDB()
+  // Run every uploaded SVG through SVGO before storing (smaller + sanitized).
+  if (/\bsvg\b/i.test(contentType)) {
+    data = optimizeSvgBuffer(data)
+  }
   const { rows } = await query<{ slug: string }>(
     `INSERT INTO brand_assets (brand_id, kind, content_type, file_name, data, updated_at)
        VALUES ($1, $2, $3, $4, $5, NOW())

--- a/packages/web/components/dashboard/brands-list.tsx
+++ b/packages/web/components/dashboard/brands-list.tsx
@@ -18,7 +18,48 @@ import {
 } from "@/components/ui/alert-dialog"
 import { useBadgeMode } from "@/lib/use-badge-mode"
 import { useHydrated } from "@/lib/use-hydrated"
+import { cn } from "@/lib/utils"
 import { toast } from "sonner"
+
+/**
+ * A brand's icon chip. Prefers the cheap hosted mark (/b/{slug}/mark.svg — a
+ * single stored-blob read) and only falls back to a full Satori badge render
+ * for brands without an uploaded mark, then to a Palette glyph. This avoids
+ * rendering a full badge just to show a 32px logo for every row.
+ */
+function BrandChip({ slug, adaptUrl }: { slug: string; adaptUrl: (url: string) => string }) {
+  // 0 = hosted mark asset, 1 = branded badge render, 2 = palette fallback.
+  const [stage, setStage] = useState<0 | 1 | 2>(0)
+
+  if (stage === 2) {
+    return (
+      <span className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-border bg-muted/50 text-muted-foreground">
+        <Palette className="size-4" />
+      </span>
+    )
+  }
+
+  const isMark = stage === 0
+  const src = isMark ? `/b/${slug}/mark.svg` : adaptUrl(`/badge/-.svg?brand=${slug}&variant=branded`)
+
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      key={stage}
+      src={src}
+      alt=""
+      width={32}
+      height={32}
+      loading="lazy"
+      decoding="async"
+      onError={() => setStage((s) => (s + 1) as 0 | 1 | 2)}
+      className={cn(
+        "size-8 shrink-0 rounded-lg border border-border",
+        isMark ? "bg-muted/40 object-contain p-1" : "object-cover",
+      )}
+    />
+  )
+}
 
 interface BrandRow {
   id: number
@@ -136,19 +177,7 @@ export function BrandsList({ initialBrands }: { initialBrands: BrandRow[] }) {
             >
               <div className="flex min-w-0 items-center gap-3">
                 {mounted ? (
-                  // The brand's own logo on its brand color — a live icon chip.
-                  // Lazy + async-decoded so a long brand list doesn't fire every
-                  // badge render at once on page load (each is a live SVG render).
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img
-                    src={adaptUrl(`/badge/-.svg?brand=${b.slug}&variant=branded`)}
-                    alt=""
-                    width={32}
-                    height={32}
-                    loading="lazy"
-                    decoding="async"
-                    className="size-8 shrink-0 rounded-lg border border-border object-cover"
-                  />
+                  <BrandChip slug={b.slug} adaptUrl={adaptUrl} />
                 ) : (
                   <span className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-border bg-muted/50 text-muted-foreground">
                     <Palette className="size-4" />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,7 +117,7 @@ importers:
     dependencies:
       '@sentry/nextjs':
         specifier: ^10.63.0
-        version: 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.107.2(lightningcss@1.32.0))
+        version: 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.107.2(lightningcss@1.32.0))
       '@shieldcn/core':
         specifier: workspace:*
         version: link:../core
@@ -187,7 +187,7 @@ importers:
         version: 2.6.2
       '@sentry/nextjs':
         specifier: ^10.63.0
-        version: 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.107.2(lightningcss@1.32.0))
+        version: 10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.107.2(lightningcss@1.32.0))
       '@shieldcn/core':
         specifier: workspace:*
         version: link:../core
@@ -9666,7 +9666,7 @@ snapshots:
     dependencies:
       '@sentry/core': 10.63.0
 
-  '@sentry/nextjs@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.107.2(lightningcss@1.32.0))':
+  '@sentry/nextjs@10.63.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.107.2(lightningcss@1.32.0))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@rollup/plugin-commonjs': 28.0.1(rollup@4.62.2)
@@ -11697,8 +11697,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.10
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -11720,7 +11720,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11731,22 +11731,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11757,7 +11757,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3


### PR DESCRIPTION
Two follow-ups to the brands dashboard perf work.

Chip: prefer the hosted mark blob (/b/{slug}/mark.svg — one stored-blob read)
over a full Satori badge render for each row's 32px logo. Falls back to the
branded badge for brands without a mark, then a Palette glyph. Removes the
per-row full-badge render that saturated the backend on load.

SVGO: run every uploaded brand SVG through SVGO in putBrandAsset (the single
choke point for stored assets), so all upload paths (asset + logo routes)
get optimized. Adds removeScripts since v4 preset-default no longer strips
<script>, and these assets are served as image/svg+xml. viewBox is preserved.
