### PR TITLE
feat!: retire star-history charts after github api restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,6 @@ npx skills add jal-co/shieldcn -a cursor # installs to Cursor
 See [`skills/shieldcn-badges/SKILL.md`](skills/shieldcn-badges/SKILL.md) for
 prompt examples and options.
 
-## Star History
-
-<p align="center">
-  <picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/chart/github/stars/jal-co/shieldcn.svg?theme=zinc&amp;bg=transparent&amp;border=false&amp;logo=false&amp;icon=Star" /><img alt="shieldcn star history" src="https://shieldcn.dev/chart/github/stars/jal-co/shieldcn.svg?mode=light&amp;theme=zinc&amp;bg=transparent&amp;border=false&amp;logo=false&amp;icon=Star" /></picture>
-</p>
-
 ## Sponsors
 
 <p align="center">

--- a/packages/core/src/badges/chart-route.test.ts
+++ b/packages/core/src/badges/chart-route.test.ts
@@ -55,30 +55,28 @@ describe("handleBadgeGET /chart", () => {
   beforeEach(() => { globalThis.fetch = ghStub() as unknown as typeof fetch })
   afterEach(() => { globalThis.fetch = realFetch })
 
-  it("renders a star-history SVG", async () => {
+  it("renders a 100x1 transparent SVG for retired star-history charts", async () => {
     const req = new Request("https://x.dev/chart/github/stars/vercel/next.js.svg?theme=blue")
     const res = await handleBadgeGET(req, ["chart", "github", "stars", "vercel", "next.js.svg"])
     expect(res.status).toBe(200)
     expect(res.headers.get("Content-Type")).toBe("image/svg+xml")
     const svg = await res.text()
-    expect(svg.startsWith("<svg")).toBe(true)
-    expect(svg).toContain("vercel/next.js")
-    expect(svg).not.toContain("NaN")
+    expect(svg).toContain('width="100"')
+    expect(svg).toContain('height="1"')
+    expect(svg).not.toContain("vercel/next.js")
   })
 
-  it("returns JSON time series for .json", async () => {
+  it("returns 410 JSON for retired star-history .json", async () => {
     const req = new Request("https://x.dev/chart/github/stars/vercel/next.js.json")
     const res = await handleBadgeGET(req, ["chart", "github", "stars", "vercel", "next.js.json"])
-    expect(res.status).toBe(200)
+    expect(res.status).toBe(410)
     const data = await res.json()
-    expect(data.total).toBe(40)
-    expect(Array.isArray(data.points)).toBe(true)
-    expect(data.points.length).toBeGreaterThan(1)
+    expect(data.error).toContain("no longer available")
   })
 
-  it("shows a usage error for a malformed path", async () => {
-    const req = new Request("https://x.dev/chart/github/stars.svg")
-    const res = await handleBadgeGET(req, ["chart", "github", "stars.svg"])
+  it("shows a usage error for a malformed issues path", async () => {
+    const req = new Request("https://x.dev/chart/github/issues.svg")
+    const res = await handleBadgeGET(req, ["chart", "github", "issues.svg"])
     const svg = await res.text()
     expect(svg).toContain("usage:")
   })

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -11,7 +11,7 @@ import { renderChart, resolveAccent, resolveFontFamily, type ChartSeries, type C
 import { renderHeader, type HeaderLogoInput } from "./badges/render-header"
 import { renderSponsors, type SponsorAvatar, type SponsorTier } from "./badges/render-sponsors"
 import { resolveHeaderBackground } from "./badges/header-backgrounds"
-import { getStarHistory, getIssueHistory } from "./providers/starhistory"
+import { getIssueHistory } from "./providers/starhistory"
 import { getCommitHistory, type CommitHistory } from "./providers/commit-history"
 import { getNpmDownloadSeries } from "./providers/npm"
 import { formatCount } from "./format"
@@ -241,6 +241,14 @@ const ERROR_CACHE_HEADERS = {
   "Cache-Control":
     "public, max-age=60, s-maxage=60, stale-while-revalidate=120",
 }
+
+/**
+ * 100x1 fully transparent SVG served for permanently retired image endpoints
+ * (star-history charts) so existing READMEs render nothing instead of a
+ * broken image or an error badge.
+ */
+const TRANSPARENT_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="1" viewBox="0 0 100 1"></svg>'
 
 /**
  * Cache headers for stateful view-counter badges.
@@ -1881,7 +1889,8 @@ function clampNum(
 /**
  * Handle a chart request.
  *
- * URL format: /chart/github/stars/{owner}/{repo}.svg
+ * URL format: /chart/github/issues/{owner}/{repo}.svg
+ * (star history is retired — star URLs return a 100x1 transparent image)
  * Query params: width, height, mode, theme, color, area, title.
  */
 async function handleChart(
@@ -1891,6 +1900,38 @@ async function handleChart(
   options?: BadgeRequestOptions,
 ): Promise<Response> {
   const rest = cleanSegments.slice(1) // after "chart"
+
+  // Star-history charts are permanently unavailable: GitHub restricted the
+  // stargazers list endpoint (`/repos/{owner}/{repo}/stargazers`) to repo
+  // admins/collaborators in mid-2026, so timestamped star data can no longer
+  // be fetched for arbitrary repos. To avoid breaking READMEs with error
+  // badges, star chart URLs now render a 100x1 transparent image.
+  // https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/
+  const isStarChart =
+    rest[0] === "stars" || (rest[0] === "github" && rest[1] === "stars")
+  if (isStarChart) {
+    if (format === "json") {
+      return Response.json(
+        {
+          error:
+            "star history charts are no longer available: GitHub restricted the stargazers API to repo admins/collaborators",
+          docs: "https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/",
+        },
+        { status: 410, headers: CACHE_HEADERS },
+      )
+    }
+    if (format === "png") {
+      const { Resvg } = await ensureResvg()
+      const png = new Resvg(TRANSPARENT_SVG).render().asPng()
+      return new Response(Buffer.from(png), {
+        headers: { "Content-Type": "image/png", ...CACHE_HEADERS },
+      })
+    }
+    return new Response(TRANSPARENT_SVG, {
+      headers: { "Content-Type": "image/svg+xml", ...CACHE_HEADERS },
+    })
+  }
+
   const mode = (searchParams.get("mode") === "light" ? "light" : "dark") as "light" | "dark"
   const width = clampNum(searchParams.get("width"), 200, 2000, 800)
   const height = clampNum(searchParams.get("height"), 120, 1200, 400)
@@ -2934,7 +2975,6 @@ function asNumber(v: unknown): number | null {
  * Resolve a `/chart/...` path + params into a renderable series.
  *
  * Supported kinds:
- *   /chart/github/stars/{owner}/{repo}
  *   /chart/github/issues/{owner}/{repo}
  *   /chart/npm/{package}            (weekly downloads, last `days`)
  *   /chart/json?values=1,2,3        (inline data)
@@ -3002,22 +3042,23 @@ async function resolveChartData(
     }
   }
 
-  // --- GitHub stars / issues over time ---
-  if (provider === "github" || provider === "stars" || provider === "issues") {
+  // --- GitHub issues over time ---
+  // (Star history retired: the stargazers API is admin/collaborator-only as
+  // of mid-2026; star chart URLs short-circuit to a transparent image in
+  // `handleChart` before ever reaching this resolver.)
+  if (provider === "github" || provider === "issues") {
     let kind: string | undefined
     let owner: string | undefined
     let repo: string | undefined
-    if (provider === "github" && (rest[1] === "stars" || rest[1] === "issues")) {
+    if (provider === "github" && rest[1] === "issues") {
       kind = rest[1]; owner = rest[2]; repo = rest[3]
-    } else if (provider === "stars" || provider === "issues") {
+    } else if (provider === "issues") {
       kind = provider; owner = rest[1]; repo = rest[2]
     }
     if (!kind || !owner || !repo) {
-      return { ok: false, status: 400, msg: "usage: /chart/github/{stars|issues}/{owner}/{repo}.svg" }
+      return { ok: false, status: 400, msg: "usage: /chart/github/issues/{owner}/{repo}.svg" }
     }
-    const history = kind === "issues"
-      ? await getIssueHistory(owner, repo)
-      : await getStarHistory(owner, repo)
+    const history = await getIssueHistory(owner, repo)
     if (!history) {
       return { ok: false, status: 404, msg: `could not load ${kind} for ${owner}/${repo}` }
     }

--- a/packages/web/app/showcase/showcase-client.tsx
+++ b/packages/web/app/showcase/showcase-client.tsx
@@ -406,12 +406,6 @@ function SponsorsShowcase() {
 
 const CHART_EXAMPLES: { title: string; description: string; src: string; href: string }[] = [
   {
-    title: "GitHub stars over time",
-    description: "Star history for any repo — like starcharts, shadcn-styled.",
-    src: "/chart/github/stars/shadcn-ui/ui.svg?theme=blue",
-    href: "/docs/charts",
-  },
-  {
     title: "GitHub issues over time",
     description: "Cumulative issues opened, sampled from the search API.",
     src: "/chart/github/issues/honojs/hono.svg?theme=rose",
@@ -445,7 +439,7 @@ function ChartShowcase() {
           Charts
         </h2>
         <p className="mt-2 text-sm text-muted-foreground">
-          Shadcn-styled graphs for GitHub stars, issues, npm downloads, and your own JSON data.
+          Shadcn-styled graphs for GitHub issues, commits, npm downloads, and your own JSON data.
         </p>
       </div>
       <div className="grid gap-4 sm:grid-cols-2">

--- a/packages/web/components/chart-sandbox.tsx
+++ b/packages/web/components/chart-sandbox.tsx
@@ -24,7 +24,11 @@ import { LogoPicker } from "@/components/logo-picker"
 // Types
 // ---------------------------------------------------------------------------
 
+// "stars" is retired: GitHub restricted the stargazers API to repo
+// admins/collaborators (June 2026), so star-history data can no longer be
+// fetched. Star chart URLs now render a 100x1 transparent image.
 type ChartKind = "stars" | "issues" | "commits" | "npm" | "json"
+type ActiveChartKind = Exclude<ChartKind, "stars">
 
 interface ChartSandboxProps {
   /** Initial chart kind. */
@@ -40,10 +44,13 @@ const FONTS = ["inter", "geist", "geist-mono", "jetbrains-mono", "fira-code", "r
 // Component
 // ---------------------------------------------------------------------------
 
-export function ChartSandbox({ kind: initialKind = "stars", defaults = {} }: ChartSandboxProps) {
+export function ChartSandbox({ kind: initialKind = "npm", defaults = {} }: ChartSandboxProps) {
   const id = useId()
 
-  const [kind, setKind] = useState<ChartKind>(initialKind)
+  // Coerce the retired "stars" kind (still referenced from older docs) to npm.
+  const [kind, setKind] = useState<ActiveChartKind>(
+    initialKind === "stars" ? "npm" : initialKind,
+  )
 
   // Data inputs (interpretation depends on kind).
   const [owner, setOwner] = useState(defaults.owner ?? "vercel")
@@ -95,7 +102,6 @@ export function ChartSandbox({ kind: initialKind = "stars", defaults = {} }: Cha
 
   const endpoint = useMemo(() => {
     switch (kind) {
-      case "stars": return "/chart/github/stars/:owner/:repo.svg"
       case "issues": return "/chart/github/issues/:owner/:repo.svg"
       case "commits": return "/chart/github/commits/:user.svg"
       case "npm": return "/chart/npm/:package.svg"
@@ -106,7 +112,7 @@ export function ChartSandbox({ kind: initialKind = "stars", defaults = {} }: Cha
   const builtUrl = useMemo(() => {
     const ext = imageFormat === "svg" ? ".svg" : ".png"
     let path: string
-    if (kind === "stars" || kind === "issues") {
+    if (kind === "issues") {
       if (!owner || !repo) return null
       path = `/chart/github/${kind}/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}${ext}`
     } else if (kind === "commits") {
@@ -189,10 +195,10 @@ export function ChartSandbox({ kind: initialKind = "stars", defaults = {} }: Cha
         {/* Kind + data inputs */}
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <SField label="chart">
-            <Select value={kind} onValueChange={v => setKind(v as ChartKind)}>
+            <Select value={kind} onValueChange={v => setKind(v as ActiveChartKind)}>
               <SelectTrigger aria-label="Chart kind" className="w-full"><SelectValue /></SelectTrigger>
               <SelectContent>
-                <SelectItem value="stars">GitHub stars</SelectItem>
+                <SelectItem value="stars" disabled>GitHub stars (retired by GitHub)</SelectItem>
                 <SelectItem value="issues">GitHub issues</SelectItem>
                 <SelectItem value="commits">GitHub commits</SelectItem>
                 <SelectItem value="npm">npm downloads</SelectItem>
@@ -201,7 +207,7 @@ export function ChartSandbox({ kind: initialKind = "stars", defaults = {} }: Cha
             </Select>
           </SField>
 
-          {(kind === "stars" || kind === "issues") && (
+          {kind === "issues" && (
             <>
               <SField label="owner">
                 <Input id={`${id}-owner`} value={owner} onChange={e => setOwner(e.target.value)} placeholder="vercel" />

--- a/packages/web/components/hero-showcase.tsx
+++ b/packages/web/components/hero-showcase.tsx
@@ -51,9 +51,9 @@ const CARDS = {
       z: 30,
     },
     {
-      key: "stars",
-      src: "/chart/github/stars/vercel/next.js.svg?theme=blue",
-      alt: "GitHub star history — vercel/next.js",
+      key: "npm-chart",
+      src: "/chart/npm/zod.svg?theme=blue",
+      alt: "npm weekly downloads — zod",
       top: "40%",
       left: "3%",
       width: 244,

--- a/packages/web/components/home-charts.tsx
+++ b/packages/web/components/home-charts.tsx
@@ -11,7 +11,7 @@ function useHydrated() {
 }
 
 const CHARTS: { src: string; alt: string }[] = [
-  { src: "/chart/github/stars/vercel/next.js.svg?theme=blue", alt: "GitHub star history" },
+  { src: "/chart/npm/zod.svg?theme=blue", alt: "npm weekly downloads" },
   { src: "/chart/github/commits/torvalds.svg?theme=green", alt: "GitHub lifetime commit history" },
 ]
 

--- a/packages/web/components/studio/inspectors.tsx
+++ b/packages/web/components/studio/inspectors.tsx
@@ -1056,7 +1056,7 @@ export function ChartInspector({ block, onChange }: { block: ChartBlock; onChang
         <Select value={s.kind} onValueChange={v => set({ kind: v as ChartState["kind"] })}>
           <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
           <SelectContent>
-            <SelectItem value="stars">GitHub stars</SelectItem>
+            <SelectItem value="stars" disabled>GitHub stars (retired by GitHub)</SelectItem>
             <SelectItem value="issues">GitHub issues</SelectItem>
             <SelectItem value="commits">GitHub commits</SelectItem>
             <SelectItem value="npm">npm downloads</SelectItem>
@@ -1064,6 +1064,14 @@ export function ChartInspector({ block, onChange }: { block: ChartBlock; onChang
           </SelectContent>
         </Select>
       </Field>
+
+      {s.kind === "stars" ? (
+        <p className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-600 dark:text-amber-400">
+          GitHub restricted the stargazers API to repo admins/collaborators, so
+          star history charts no longer work. This chart now renders as an
+          invisible 100×1 image — switch it to another chart kind.
+        </p>
+      ) : null}
 
       {(s.kind === "stars" || s.kind === "issues") ? (
         <Row>

--- a/packages/web/content/docs/api-reference.mdx
+++ b/packages/web/content/docs/api-reference.mdx
@@ -140,7 +140,7 @@ Join any badge paths with `+`. Query params apply to all segments. See [Badge Gr
 
 | Endpoint | Description |
 |----------|-------------|
-| `/chart/github/stars/{owner}/{repo}.svg` | GitHub star history |
+| `/chart/github/stars/{owner}/{repo}.svg` | ~~GitHub star history~~ — retired ([GitHub restricted the stargazers API](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/)); returns a 100×1 transparent image |
 | `/chart/github/issues/{owner}/{repo}.svg` | GitHub issues over time |
 | `/chart/npm/{package}.svg` | npm weekly downloads |
 | `/chart/json.svg?values=1,2,3` | Inline JSON data |

--- a/packages/web/content/docs/charts/index.mdx
+++ b/packages/web/content/docs/charts/index.mdx
@@ -1,30 +1,36 @@
 ---
 title: Charts
-description: Shadcn-styled graphs for GitHub stars, GitHub issues, lifetime commit history, npm downloads, and your own JSON data — rendered as portable SVGs.
+description: Shadcn-styled graphs for GitHub issues, lifetime commit history, npm downloads, and your own JSON data — rendered as portable SVGs.
 ---
 
 Shadcn-styled line/area charts you can drop in a README, docs site, or anywhere
-an image works — plain SVG, no JavaScript, no iframe. Five kinds: GitHub star
-history (like [starcharts](https://github.com/caarlos0/starcharts)), GitHub
+an image works — plain SVG, no JavaScript, no iframe. Four kinds: GitHub
 issues over time, lifetime commit history (a homage to
 [commit-history](https://github.com/peetzweg/commit-history)), npm downloads,
 and arbitrary JSON.
 
+> **Star history charts are retired.** GitHub
+> [restricted the stargazers API](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/)
+> to repo admins and collaborators in June 2026, so timestamped star data can
+> no longer be fetched for arbitrary repos. Existing
+> `/chart/github/stars/...` URLs now render a 100×1 transparent image so they
+> don't break READMEs — swap them for an npm downloads or commit history
+> chart.
+
 <ChartPreview
-  src="/chart/github/stars/vercel/next.js.svg"
-  alt="vercel/next.js star history"
+  src="/chart/npm/zod.svg?theme=blue"
+  alt="zod npm downloads"
 />
 
 ## Builder
 
 Pick a chart kind, tweak the styling, and copy the URL or markdown.
 
-<ChartSandbox kind="stars" />
+<ChartSandbox kind="npm" />
 
 ## URL format
 
 ```
-/chart/github/stars/{owner}/{repo}.svg     → GitHub star history
 /chart/github/issues/{owner}/{repo}.svg    → GitHub issues over time
 /chart/github/commits/{user}.svg            → lifetime commit history
 /chart/github/commits/{user1},{user2}.svg   → compare users
@@ -38,28 +44,14 @@ Every endpoint also serves `.png` and `.json` (the raw time series).
 Use it in markdown:
 
 ```md
-![Star History](https://shieldcn.dev/chart/github/stars/vercel/next.js.svg)
+![npm downloads](https://shieldcn.dev/chart/npm/zod.svg)
 ```
 
-Or as a clickable image linking back to the repo:
+Or as a clickable image linking back to the package:
 
 ```md
-[![Star History](https://shieldcn.dev/chart/github/stars/vercel/next.js.svg)](https://github.com/vercel/next.js)
+[![npm downloads](https://shieldcn.dev/chart/npm/zod.svg)](https://www.npmjs.com/package/zod)
 ```
-
-## GitHub stars
-
-<ChartPreview
-  src="/chart/github/stars/shadcn-ui/ui.svg?theme=blue"
-  alt="shadcn-ui/ui star history"
-  description="Blue accent via theme"
-/>
-
-<ChartPreview
-  src="/chart/github/stars/withastro/astro.svg?bg=transparent&border=false&theme=orange"
-  alt="withastro/astro star history"
-  description="Transparent background, no border — drops onto any page"
-/>
 
 ## GitHub issues over time
 
@@ -194,21 +186,21 @@ selects the value array; optional `dateQuery` selects a parallel date array.
 > for the line paths), and a sandboxed `<img>` SVG can't load embedded fonts —
 > so the rendered typeface depends on what's available to the viewer.
 
-## How star history works
+## What happened to star history?
 
-GitHub has no "stars over time" API. shieldcn reconstructs the curve from the
-stargazers endpoint, which (with the `star+json` media type) returns a
-`starred_at` timestamp per stargazer:
+Star history charts reconstructed the curve from GitHub's stargazers endpoint
+(`/repos/{owner}/{repo}/stargazers` with the `star+json` media type), which
+returned a `starred_at` timestamp per stargazer. In June 2026 GitHub
+[restricted that endpoint](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/)
+to repo admins and collaborators, so the data is no longer accessible for
+arbitrary repos.
 
-- **Small / medium repos** — every page is fetched and the full list is sampled
-  down to ~30 points for an exact curve.
-- **Large repos** — pages are sampled evenly and the first stargazer of each is
-  read, then the curve is anchored to the live star count, exactly like
-  starcharts.
-
-Requests are distributed across the donated [token pool](/token-pool) and
-cached with a 6-hour fresh window plus a 30-day last-known-good fallback, so a
-transient rate limit never collapses the chart.
+To keep existing READMEs from breaking, `/chart/github/stars/...` URLs now
+return a **100×1 transparent image** (and `.json` returns `410 Gone`). Replace
+them with an [issues](#github-issues-over-time),
+[commits](#github-commits-over-time), or [npm downloads](#npm-downloads)
+chart. The plain [stars count badge](/docs/badges/github) still works — it
+uses the repo metadata endpoint, which is unaffected.
 
 ## How commit history works
 
@@ -218,14 +210,13 @@ and works the same way it does. GitHub's GraphQL
 commit count for a window of at most a year, so a lifetime is sliced into
 **monthly windows** — batched a year at a time into aliased queries — then the
 counts are accumulated into the rising curve. Only public commits are counted.
-Like the star data, requests go through the donated [token pool](/token-pool)
+Requests go through the donated [token pool](/token-pool)
 with a 6-hour fresh window and a 30-day last-known-good fallback.
 
 ## Data sources
 
 | Chart | Source | Cache |
 |-------|--------|-------|
-| Stars | [GitHub Stargazers API](https://docs.github.com/en/rest/activity/starring) | 6h fresh · 30d last-known-good |
 | Issues | [GitHub Search API](https://docs.github.com/en/rest/search) (`type:issue`) | 6h fresh · 30d last-known-good |
 | Commits | [GitHub GraphQL API](https://docs.github.com/en/graphql) (`contributionsCollection`) | 6h fresh · 30d last-known-good |
 | npm | [npm downloads API](https://github.com/npm/registry/blob/main/docs/download-counts.md) | 1h |

--- a/packages/web/content/docs/skill.mdx
+++ b/packages/web/content/docs/skill.mdx
@@ -32,8 +32,8 @@ Once installed, ask your coding agent to add badges. The skill triggers automati
 Use size xs, the ghost variant, and make them work in both light and dark mode.`} />
   <CodeBlock compact wrap language="text" code={`Migrate the existing Shields.io badges in this README to shieldcn.
 Undo any split-style/two-tone badges: use single-surface badges and remove split=true, labelColor, and split-label styling unless explicitly needed.`} />
-  <CodeBlock compact wrap language="text" code={`Add a shieldcn star-history chart for this repo below the intro.
-Make it transparent, link it to the stargazers page, and keep it readable in both light and dark mode.`} />
+  <CodeBlock compact wrap language="text" code={`Add a shieldcn npm downloads chart for this package below the intro.
+Make it transparent, link it to the npm page, and keep it readable in both light and dark mode.`} />
   <CodeBlock compact wrap language="text" code="Add a CI status badge for this repo" />
   <CodeBlock compact wrap language="text" code="Add shieldcn badges to the docs" />
   <CodeBlock compact wrap language="text" code="Set up a badge row with stars, license, and version" />

--- a/packages/web/content/docs/studio.mdx
+++ b/packages/web/content/docs/studio.mdx
@@ -27,7 +27,7 @@ A README in the Studio is an ordered list of blocks. Add any of:
 | **Header** | A repository [header banner](/docs/headers): logo, title, tagline, a shadcn-styled or **photo (Unsplash) background**, served from a single image URL. |
 | **Badges** | A row of [badges](/docs/badges/github) with a searchable type picker, variants, themes, logos, split styling, per-row alignment, and links. |
 | **Group** | A [badge group](/docs/badges/group) — multiple badges fused into one joined image with shared rounded edges (shadcn ButtonGroup style). One variant, size, theme, and font apply to every segment. |
-| **Chart** | A [star-history, issues, npm-downloads, or inline-JSON chart](/docs/charts). |
+| **Chart** | An [issues, commits, npm-downloads, or inline-JSON chart](/docs/charts). |
 | **Table** | A spreadsheet-style grid editor with per-column alignment, exported as a GitHub-flavored Markdown table. |
 | **Image** | Any image by URL or repo-relative path, with alignment, width, and an optional link. |
 
@@ -52,5 +52,5 @@ Badges, headers, and charts become image URLs; text blocks pass through as Markd
 
 - [Repository headers](/docs/headers) — the header banners you can drop into the Studio, including photo backgrounds.
 - [Badges](/docs/badges/github) — every badge provider the Studio can add.
-- [Charts](/docs/charts) — star-history, issues, and npm-download charts.
+- [Charts](/docs/charts) — issues, commits, and npm-download charts (star history is retired — GitHub restricted the stargazers API).
 - [Agent Skill](/docs/skill) — let AI coding agents add shieldcn badges and build READMEs for you.

--- a/packages/web/lib/studio-shared.ts
+++ b/packages/web/lib/studio-shared.ts
@@ -36,6 +36,10 @@ import {
 // serializable object, so we model it here and mirror the sandbox URL builder).
 // ---------------------------------------------------------------------------
 
+// "stars" is retired: GitHub restricted the stargazers API to repo
+// admins/collaborators (June 2026). Star chart URLs render a 100x1
+// transparent image; the kind remains in the union so imported/saved
+// documents still parse.
 export type ChartKind = "stars" | "issues" | "commits" | "npm" | "json"
 
 export interface ChartState {
@@ -67,7 +71,7 @@ export interface ChartState {
 }
 
 export const CHART_DEFAULTS: ChartState = {
-  kind: "stars",
+  kind: "npm",
   owner: "vercel",
   repo: "next.js",
   user: "torvalds",

--- a/skills/shieldcn-badges/SKILL.md
+++ b/skills/shieldcn-badges/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shieldcn-badges
-description: Create polished shieldcn README badges, badge groups, charts, headers, sponsors grids, and full README hero sections. Use when a user wants shadcn/ui-styled badges, Shields.io replacement, npm/GitHub/CI/status badges, star-history or download charts, README header banners, contributor/sponsor images, or README Studio guidance. Triggers include "add badges", "add shields", "README badges", "npm badge", "GitHub stars badge", "CI badge", "star history chart", "download chart", "README header", "README banner", "contributors grid", "sponsors grid", "build a README", "README Studio", "shieldcn", and requests to make a project README look better.
+description: Create polished shieldcn README badges, badge groups, charts, headers, sponsors grids, and full README hero sections. Use when a user wants shadcn/ui-styled badges, Shields.io replacement, npm/GitHub/CI/status badges, download charts, README header banners, contributor/sponsor images, or README Studio guidance. Triggers include "add badges", "add shields", "README badges", "npm badge", "GitHub stars badge", "CI badge", "download chart", "README header", "README banner", "contributors grid", "sponsors grid", "build a README", "README Studio", "shieldcn", and requests to make a project README look better.
 metadata:
   author: jal-co
   version: "1.0.0"
@@ -95,11 +95,6 @@ technical open-source project.
 ```
 
 ### Charts and visual proof
-
-```text
-Add a shieldcn star-history chart for [owner/repo] below the intro. Make it
-transparent so it blends into GitHub, and link it to the repository stargazers.
-```
 
 ```text
 Add a shieldcn npm download chart for [package] to the README. Use a concise
@@ -294,8 +289,12 @@ Style recommendations:
 
 Charts render as portable SVG/PNG images styled like shadcn cards.
 
+Star history charts are retired — GitHub restricted the stargazers API to repo
+admins/collaborators (June 2026). `/chart/github/stars/...` URLs render a
+100×1 transparent image; use an issues, commits, or npm downloads chart
+instead. Plain stars *count* badges still work.
+
 ```text
-/chart/github/stars/{owner}/{repo}.svg       star history
 /chart/github/issues/{owner}/{repo}.svg      issues over time
 /chart/github/commits/{user}.svg             lifetime contribution commits
 /chart/npm/{package}.svg                     npm download history
@@ -306,7 +305,7 @@ Charts render as portable SVG/PNG images styled like shadcn cards.
 Markdown example:
 
 ```md
-[![Star history](https://shieldcn.dev/chart/github/stars/vercel/next.js.svg?bg=transparent&border=false)](https://github.com/vercel/next.js/stargazers)
+[![npm downloads](https://shieldcn.dev/chart/npm/zod.svg?bg=transparent&border=false)](https://www.npmjs.com/package/zod)
 ```
 
 Chart params: `theme`, `font`, `color`, `fill`, `area`, `width`, `height`,


### PR DESCRIPTION
## What

Retires star-history charts. `/chart/github/stars/...` now returns a 100×1 transparent image (`.svg`/`.png`) or `410 Gone` (`.json`). Star chart kind is marked retired in the docs builder and Studio; site examples swapped for npm download charts.

## Why

GitHub [restricted the stargazers list endpoint](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/) to repo admins/collaborators (June 2026), so timestamped star data can no longer be fetched for arbitrary repos. Serving a transparent pixel keeps existing READMEs from showing broken images or error badges.

## How

- `route-handler.ts` short-circuits star chart URLs before any GitHub call; stars branch removed from `resolveChartData` (issues charts use the search API and are unaffected)
- Builder (`chart-sandbox.tsx`) and Studio (`inspectors.tsx`, `studio-shared.ts`) disable the stars option and default to npm; Studio shows an amber warning on legacy stars blocks
- Docs: retirement callout + "What happened to star history?" section in `charts/index.mdx`; api-reference, studio, skill docs updated
- Homepage/hero/showcase star charts replaced with npm download charts; README star-history section removed

## Testing

- `packages/core`: 300 tests pass (chart route tests updated for transparent SVG / 410 JSON)
- `tsc --noEmit` clean in core and web
- Verified live on dev server: svg → 89-byte transparent 100×1, png → 100×1 RGBA, json → 410

## Screenshots

Verified in browser: docs callout renders, builder dropdown shows "GitHub stars (retired by GitHub)" disabled, npm chart hero renders.