### PR TITLE
ci(release): skip husky hooks for tegami version commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ jobs:
         run: pnpm tegami ci
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          # tegami's generated version commit isn't conventional-commit shaped;
+          # skip local husky hooks in CI (commit-check runs on PRs anyway).
+          HUSKY: "0"
 
       # Action release: when the version PR merges, packages/action's version
       # changes. Rebuild the committed dist, tag vX.Y.Z, and move the floating


### PR DESCRIPTION
## What
Sets HUSKY=0 on the tegami ci step.

## Why
The generated Version Packages commit isn't conventional-commit shaped, so the local husky commit-msg hook failed the release job on main.

## Testing
Release job will re-run on merge; commit-check still validates PR commits.