### PR TITLE
docs(readme): link github action docs from star history section

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,18 @@ prompt examples and options.
 
 ## Star history
 
-Rendered by the [shieldcn starchart action](https://shieldcn.dev/docs/charts/star-history)
-— star charts that survived GitHub's stargazers API restriction, updated daily
-by `shieldcn[bot]`.
+Rendered by the **shieldcn starchart** GitHub Action — star charts that
+survived GitHub's stargazers API restriction, updated daily by
+`shieldcn[bot]`. Add it to your repo:
+
+```yaml
+- uses: jal-co/shieldcn@v1
+  with:
+    theme: violet
+```
+
+[**GitHub Action docs →**](https://shieldcn.dev/docs/charts/star-history) ·
+[action reference](packages/action/README.md)
 
 <p align="center">
   <a href="https://github.com/jal-co/shieldcn/stargazers"><picture><source media="(prefers-color-scheme: dark)" srcset=".github/shieldcn/star-chart-dark.svg" /><img alt="Star history of jal-co/shieldcn" src=".github/shieldcn/star-chart-light.svg" /></picture></a>


### PR DESCRIPTION
## What
Star history section now includes the quick-start YAML and prominent links to the hosted GitHub Action docs and the action reference README.

## Why
The Marketplace listing renders the root README — visitors need copy-paste usage and a path to full docs.

## Testing
Markdown-only change; links verified against /docs/charts/star-history and packages/action/README.md.