### PR TITLE
ci(release): guard v0.0.0 tagging and skip husky on tag pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,10 @@ jobs:
       - name: Check for existing tag
         id: tag
         run: |
-          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+          # 0.0.0 means the Version Packages PR hasn't merged yet — nothing to tag.
+          if [ "${{ steps.version.outputs.version }}" = "0.0.0" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          elif git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
@@ -62,6 +65,8 @@ jobs:
 
       - name: Commit dist if changed
         if: steps.tag.outputs.exists == 'false'
+        env:
+          HUSKY: "0"
         run: |
           git add packages/action/dist
           if ! git diff --cached --quiet; then
@@ -75,6 +80,7 @@ jobs:
         if: steps.tag.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
+          HUSKY: "0"
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           MAJOR="v$(echo "$VERSION" | cut -d. -f1)"

--- a/README.md
+++ b/README.md
@@ -49,9 +49,18 @@ prompt examples and options.
 
 ## Star history
 
-Rendered by the [shieldcn starchart action](https://shieldcn.dev/docs/charts/star-history)
-— star charts that survived GitHub's stargazers API restriction, updated daily
-by `shieldcn[bot]`.
+Rendered by the **shieldcn starchart** GitHub Action — star charts that
+survived GitHub's stargazers API restriction, updated daily by
+`shieldcn[bot]`. Add it to your repo:
+
+```yaml
+- uses: jal-co/shieldcn@v1
+  with:
+    theme: violet
+```
+
+[**GitHub Action docs →**](https://shieldcn.dev/docs/charts/star-history) ·
+[action reference](packages/action/README.md)
 
 <p align="center">
   <a href="https://github.com/jal-co/shieldcn/stargazers"><picture><source media="(prefers-color-scheme: dark)" srcset=".github/shieldcn/star-chart-dark.svg" /><img alt="Star history of jal-co/shieldcn" src=".github/shieldcn/star-chart-light.svg" /></picture></a>


### PR DESCRIPTION
## What
Skips the tag-and-release steps while the action version is still 0.0.0, and sets HUSKY=0 on the dist commit and tag push steps.

## Why
The release job tried to tag v0.0.0 before the Version Packages PR merged, and husky's pre-push branch check rejects CI tag pushes.

## Testing
Release job re-runs on merge; with #223 unmerged it now no-ops after versioning.