### PR TITLE
fix(brands): make brand editing fast and mark handling reliable

### DIFF
--- a/packages/core/src/brand-logo-mode.test.ts
+++ b/packages/core/src/brand-logo-mode.test.ts
@@ -1,0 +1,106 @@
+/**
+ * shieldcn
+ * brand-logo-mode.test
+ *
+ * Locks in the mode-safety contract for hosted brand marks (`logo=brand`):
+ * the renderer parses the mark SVG to paths and recolors them to the badge's
+ * theme ink, so the STORED fill color never leaks into badge output. A brand
+ * needs exactly one mark to read correctly on both light and dark badges —
+ * "the color didn't strip" is a regression against this file.
+ *
+ * getBrand/getBrandAsset are mocked so rendering is tested without a database.
+ */
+
+import { describe, it, expect, vi } from "vitest"
+
+const DARK_MARK = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="#000000" d="M2 2h20v20H2z"/></svg>`
+const LIGHT_MARK = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="#ffffff" d="M2 2h20v20H2z"/></svg>`
+const COLORED_MARK = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="#e11d48" d="M2 2h20v20H2z"/></svg>`
+
+/** Per-test asset fixtures, keyed by kind. Swapped via setAssets(). */
+let assets: Record<string, string> = {}
+function setAssets(next: Record<string, string>) {
+  assets = next
+}
+
+vi.mock("./brands", async (orig) => {
+  const actual = await orig<typeof import("./brands")>()
+  return {
+    ...actual,
+    getBrand: vi.fn(async (slug: string) =>
+      slug === "acme"
+        ? { id: 1, slug: "acme", ownerId: "test", name: "Acme", config: {}, profile: {}, brandMd: null }
+        : null,
+    ),
+    getBrandAsset: vi.fn(async (_slug: string, kind: string) =>
+      assets[kind]
+        ? { contentType: "image/svg+xml", data: Buffer.from(assets[kind]), fileName: null }
+        : null,
+    ),
+    getBrandFont: vi.fn(async () => null),
+  }
+})
+
+const { createBadgeHandlers } = await import("./route-handler")
+
+async function renderSvg(path: string, slug: string[]) {
+  const { GET } = createBadgeHandlers()
+  const res = await GET(new Request(`https://x.dev${path}`), {
+    params: Promise.resolve({ slug }),
+  })
+  return res.text()
+}
+
+const BADGE = ["badge", "build-passing.svg"]
+/** The mark's square path, as emitted by the svg parser (absolute coords). */
+const MARK_PATH = /d="M2 2H22V22H2z"/i
+
+describe("brand mark ink never leaks into badge output (logo=brand)", () => {
+  it("renders identical badges for dark-ink and light-ink stored marks", async () => {
+    setAssets({ "mark": DARK_MARK })
+    const fromDark = await renderSvg("/badge/build-passing.svg?brand=acme&logo=brand", BADGE)
+    setAssets({ "mark": LIGHT_MARK })
+    const fromLight = await renderSvg("/badge/build-passing.svg?brand=acme&logo=brand", BADGE)
+    expect(fromDark).toBe(fromLight)
+    expect(fromDark).toMatch(MARK_PATH)
+  })
+
+  it("strips a colored mark to theme ink too", async () => {
+    setAssets({ "mark": COLORED_MARK })
+    const svg = await renderSvg("/badge/build-passing.svg?brand=acme&logo=brand", BADGE)
+    expect(svg).toMatch(MARK_PATH)
+    // The stored rose fill must not survive into the output.
+    expect(svg).not.toMatch(/fill="#e11d48"/i)
+  })
+
+  it("recolors the mark for both modes (no stored-ink dependence)", async () => {
+    setAssets({ "mark": DARK_MARK })
+    const dark = await renderSvg("/badge/build-passing.svg?brand=acme&logo=brand", BADGE)
+    const light = await renderSvg("/badge/build-passing.svg?brand=acme&logo=brand&mode=light", BADGE)
+    expect(dark).toMatch(MARK_PATH)
+    expect(light).toMatch(MARK_PATH)
+    // Different modes restyle the badge — output must differ, from one mark.
+    expect(dark).not.toBe(light)
+  })
+
+  it("logo=brand-alt renders the alternate mark", async () => {
+    const ALT = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="#ffffff" d="M4 4h16v16H4z"/></svg>`
+    setAssets({ "mark": DARK_MARK, "mark-alt": ALT })
+    const svg = await renderSvg("/badge/build-passing.svg?brand=acme&logo=brand-alt", BADGE)
+    expect(svg).toMatch(/d="M4 4H20V20H4z"/i)
+  })
+
+  it("auto-adds the brand mark when no logo param is given", async () => {
+    setAssets({ "mark": DARK_MARK })
+    const svg = await renderSvg("/badge/build-passing.svg?brand=acme", BADGE)
+    expect(svg).toMatch(MARK_PATH)
+  })
+
+  it("headers recolor the mark identically for any stored ink", async () => {
+    setAssets({ "mark": DARK_MARK })
+    const fromDark = await renderSvg("/header/minimal.svg?title=Hi&brand=acme&logo=brand", ["header", "minimal.svg"])
+    setAssets({ "mark": LIGHT_MARK })
+    const fromLight = await renderSvg("/header/minimal.svg?title=Hi&brand=acme&logo=brand", ["header", "minimal.svg"])
+    expect(fromDark).toBe(fromLight)
+  })
+})

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -110,8 +110,27 @@ export type { PoolClient }
 /**
  * Initialize the database schema.
  * Called on first request or at startup.
+ *
+ * Guarded so the DDL runs once per process, not once per query. Every data
+ * helper awaits initDB() before touching the DB; without this guard each
+ * badge/brand request paid a full CREATE/ALTER/DROP round-trip to serverless
+ * Postgres first, which is what made the dashboard feel impossibly slow. On
+ * failure the guard resets so the next call retries instead of caching a
+ * rejected promise forever.
  */
-export async function initDB() {
+let initPromise: Promise<void> | null = null
+
+export function initDB(): Promise<void> {
+  if (!initPromise) {
+    initPromise = runSchema().catch((err) => {
+      initPromise = null
+      throw err
+    })
+  }
+  return initPromise
+}
+
+async function runSchema() {
   await query(`
     CREATE TABLE IF NOT EXISTS github_tokens (
       id SERIAL PRIMARY KEY,

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -3358,9 +3358,11 @@ async function handleBadgeGETInner(
           searchParams.delete("font")
         }
         // logo=brand renders the brand's own hosted logo instead of a provider
-        // icon. Resolve the mode-appropriate SVG (dark badge bg → light-ink
-        // logo) and rewrite `logo` to a data URI so it flows uniformly through
-        // the badge, header, and group logo paths downstream.
+        // icon. Rewrite `logo` to a data URI so it flows uniformly through the
+        // badge, header, and group logo paths downstream. The stored ink color
+        // is irrelevant here: the renderer parses the SVG to paths and recolors
+        // them to the badge's theme ink, so a single mark reads correctly on
+        // both modes (verified by brand-logo-mode.test.ts).
         const logoParam = searchParams.get("logo")
         if (logoParam === "brand" || logoParam === "brand-alt") {
           // Brands ship a square mark (+ optional alt). `logo=brand` uses the

--- a/packages/web/app/api/brands/[slug]/assets/route.ts
+++ b/packages/web/app/api/brands/[slug]/assets/route.ts
@@ -14,6 +14,7 @@ import {
   isValidAssetKind,
   assetTypeError,
   contentTypeFromExt,
+  recolorSvgForOppositeMode,
   MAX_ASSET_BYTES,
 } from "@/lib/brand-assets"
 
@@ -80,8 +81,37 @@ export async function POST(req: NextRequest, { params }: Params) {
   const typeErr = assetTypeError(kind, contentType)
   if (typeErr) return NextResponse.json({ error: typeErr }, { status: 415 })
 
-  const data = Buffer.from(await file.arrayBuffer())
-  await putBrandAsset(brand.id, kind, contentType, data, file.name)
+  try {
+    const data = Buffer.from(await file.arrayBuffer())
+    await putBrandAsset(brand.id, kind, contentType, data, file.name)
 
-  return NextResponse.json({ ok: true, kind, contentType, bytes: data.length })
+    // Direct mark uploads get the same alt-mark synthesis as the import flow:
+    // recolor the ink for the opposite badge mode so logo=brand-alt works
+    // without a second manual upload. Only fills the slot when the brand has
+    // no alt yet — an explicitly uploaded alt mark is never clobbered.
+    let altGenerated = false
+    if (kind === "mark" && contentType.includes("svg")) {
+      const kinds = await listBrandAssetKinds(brand.id)
+      const hasAlt = kinds.some((a) => a.kind === "mark-alt")
+      if (!hasAlt) {
+        const svg = data.toString("utf8")
+        const recolored =
+          recolorSvgForOppositeMode(svg, "to-light") ??
+          recolorSvgForOppositeMode(svg, "to-dark")
+        if (recolored) {
+          await putBrandAsset(brand.id, "mark-alt", "image/svg+xml", Buffer.from(recolored, "utf8"))
+          altGenerated = true
+        }
+      }
+    }
+
+    return NextResponse.json({ ok: true, kind, contentType, bytes: data.length, altGenerated })
+  } catch (err) {
+    // Surface the real failure instead of an opaque 500 — an asset store error
+    // was previously an unhandled throw, which made upload failures undebuggable
+    // from the client.
+    console.error(`[brands] asset upload failed slug=${slug} kind=${kind}:`, err)
+    const message = err instanceof Error ? err.message : "asset store failed"
+    return NextResponse.json({ error: `upload failed: ${message}` }, { status: 500 })
+  }
 }

--- a/packages/web/components/brand-editor.tsx
+++ b/packages/web/components/brand-editor.tsx
@@ -10,8 +10,9 @@
  * it and shown for reference/export.
  */
 
-import { useEffect, useState, type ReactNode } from "react"
+import { useEffect, useState, type CSSProperties, type ReactNode } from "react"
 import { useRouter } from "next/navigation"
+import { useDebouncedValue } from "@/lib/use-debounced-value"
 import { Check, Loader2, Save, Upload, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { ContextDevLogo } from "@/components/context-dev-logo"
@@ -45,10 +46,26 @@ const FONT_SLOTS: { kind: BrandFontKind; label: string }[] = [
   { kind: "font-heading", label: "Heading (font=brand-heading)" },
 ]
 
-const LOGO_SLOTS: { kind: BrandImageKind; label: string; bg: string; hint?: string }[] = [
-  { kind: "mark", label: "Mark / icon", bg: "#18181b", hint: "logo=brand" },
-  { kind: "mark-alt", label: "Alt mark", bg: "#18181b", hint: "logo=brand-alt" },
+const LOGO_SLOTS: { kind: BrandImageKind; label: string; hint?: string }[] = [
+  { kind: "mark", label: "Mark / icon", hint: "logo=brand" },
+  { kind: "mark-alt", label: "Alt mark", hint: "logo=brand-alt" },
 ]
+
+/**
+ * Checkerboard preview surface for logo slots. Marks can carry any ink — a
+ * black mark on a solid dark card (or a white one on light) reads as "nothing
+ * uploaded". The mid-gray checker keeps every ink visible in both site themes.
+ */
+const CHECKER_BG: CSSProperties = {
+  backgroundColor: "#9ca3af",
+  backgroundImage:
+    "linear-gradient(45deg, rgba(0,0,0,0.18) 25%, transparent 25%), " +
+    "linear-gradient(-45deg, rgba(0,0,0,0.18) 25%, transparent 25%), " +
+    "linear-gradient(45deg, transparent 75%, rgba(0,0,0,0.18) 75%), " +
+    "linear-gradient(-45deg, transparent 75%, rgba(0,0,0,0.18) 75%)",
+  backgroundSize: "12px 12px",
+  backgroundPosition: "0 0, 0 6px, 6px -6px, -6px 0",
+}
 
 /** An editable hex color field with a native picker + palette quick-picks. */
 function BrandColorField({
@@ -147,6 +164,11 @@ export function BrandEditor({
   const [persisted, setPersisted] = useState<boolean>(Boolean(brand))
 
   const palette = profile.palette ?? []
+  // The preview badges are real server-rendered SVGs (Satori) — one network
+  // render per demo badge. Drive them from a debounced config so typing a hex
+  // color or tweaking tokens doesn't fire dozens of renders per keystroke; the
+  // preview catches up ~350ms after you stop.
+  const previewConfig = useDebouncedValue(config, 350)
 
   // Arriving from the Studio's "Save as brand": prefill the style tokens
   // captured from the current README's dominant look (theme, variant, colors,
@@ -316,7 +338,13 @@ export function BrandEditor({
       })
       const json = await res.json().catch(() => ({}))
       if (!res.ok) throw new Error(json.error ?? "upload failed")
-      setStoredAssets((prev) => ({ ...prev, [kind]: file.name }))
+      setStoredAssets((prev) => ({
+        ...prev,
+        [kind]: file.name,
+        // Uploading a mark auto-generates a recolored alt server-side (when
+        // none exists) — reflect it immediately so the slot fills in.
+        ...(json.altGenerated ? { "mark-alt": "auto-generated" } : {}),
+      }))
       // Bust the <img> cache for logos so the preview reflects the new file.
       setLogoRev((r) => r + 1)
       // Uploading a mark means "use this as the logo": point config.logo at the
@@ -491,7 +519,7 @@ export function BrandEditor({
                 >
                   <div
                     className="relative flex h-16 w-full items-center justify-center overflow-hidden rounded-md border border-border"
-                    style={{ background: l.bg }}
+                    style={CHECKER_BG}
                   >
                     {busy ? (
                       <Loader2 className="size-4 animate-spin text-muted-foreground" />
@@ -596,7 +624,7 @@ export function BrandEditor({
           <code>?brand={slug || "acme"}</code>.
         </p>
         <BrandDemoBadges
-          config={config}
+          config={previewConfig}
           slug={slug || undefined}
           saved={persisted}
           hasLogo={storedAssets["mark"] != null || storedAssets["mark-alt"] != null}

--- a/packages/web/components/dashboard/brands-list.tsx
+++ b/packages/web/components/dashboard/brands-list.tsx
@@ -55,8 +55,20 @@ function BrandChip({ slug, adaptUrl }: { slug: string; adaptUrl: (url: string) =
       onError={() => setStage((s) => (s + 1) as 0 | 1 | 2)}
       className={cn(
         "size-8 shrink-0 rounded-lg border border-border",
-        isMark ? "bg-muted/40 object-contain p-1" : "object-cover",
+        isMark ? "object-contain p-1" : "object-cover",
       )}
+      // Marks carry any ink — a checker base keeps black and white marks
+      // visible regardless of the site theme (a solid muted bg hid dark marks).
+      style={isMark ? {
+        backgroundColor: "#9ca3af",
+        backgroundImage:
+          "linear-gradient(45deg, rgba(0,0,0,0.18) 25%, transparent 25%), " +
+          "linear-gradient(-45deg, rgba(0,0,0,0.18) 25%, transparent 25%), " +
+          "linear-gradient(45deg, transparent 75%, rgba(0,0,0,0.18) 75%), " +
+          "linear-gradient(-45deg, transparent 75%, rgba(0,0,0,0.18) 75%)",
+        backgroundSize: "12px 12px",
+        backgroundPosition: "0 0, 0 6px, 6px -6px, -6px 0",
+      } : undefined}
     />
   )
 }

--- a/packages/web/lib/brand-assets.test.ts
+++ b/packages/web/lib/brand-assets.test.ts
@@ -46,4 +46,34 @@ describe("recolorSvgForOppositeMode", () => {
     expect(out).toContain('fill="none"')
     expect(out).toContain("#ffffff") // stroke flipped
   })
+
+  it("injects a root fill on a fill-less SVG (default black ink) for to-light", () => {
+    // SVG's presentational default ink is black — no attribute to rewrite, but
+    // the mark is still invisible on a dark badge without an explicit flip.
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M1 1L2 2"/></svg>`
+    const out = recolorSvgForOppositeMode(svg, "to-light")
+    expect(out).toContain('<svg fill="#ffffff"')
+  })
+
+  it("returns null for a fill-less SVG for to-dark (already dark ink)", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><path d="M1 1L2 2"/></svg>`
+    expect(recolorSvgForOppositeMode(svg, "to-dark")).toBeNull()
+  })
+
+  it("flips rgb() dark inks", () => {
+    const svg = `<svg><path fill="rgb(10, 10, 10)" d="M0 0"/></svg>`
+    const out = recolorSvgForOppositeMode(svg, "to-light")
+    expect(out).toContain("#ffffff")
+  })
+
+  it("leaves colored rgb() fills untouched", () => {
+    const svg = `<svg><path fill="rgb(225, 29, 72)" d="M0 0"/></svg>`
+    expect(recolorSvgForOppositeMode(svg, "to-light")).toBeNull()
+  })
+
+  it("flips 3-digit hex inks", () => {
+    const svg = `<svg><path fill="#111" d="M0 0"/></svg>`
+    const out = recolorSvgForOppositeMode(svg, "to-light")
+    expect(out).toContain("#ffffff")
+  })
 })

--- a/packages/web/lib/brand-assets.ts
+++ b/packages/web/lib/brand-assets.ts
@@ -55,30 +55,41 @@ export function recolorSvgForOppositeMode(
   if (!svg.includes("<svg")) return null
   const toColor = target === "to-light" ? "#ffffff" : "#000000"
 
-  // Is a hex/keyword near-black or near-white?
-  const isDarkInk = (v: string): boolean => {
+  // Parse a color value to [r,g,b], or null when unparseable. Handles hex
+  // (3/6-digit), black/white keywords, and rgb(r, g, b).
+  const toRgb = (v: string): [number, number, number] | null => {
     const c = v.trim().toLowerCase()
-    if (c === "black" || c === "#000" || c === "#000000") return true
-    const m = c.match(/^#([0-9a-f]{6})$/)
-    if (!m) return false
-    const n = parseInt(m[1], 16)
-    const r = (n >> 16) & 255, g = (n >> 8) & 255, b = n & 255
-    return 0.299 * r + 0.587 * g + 0.114 * b < 40
+    if (c === "black") return [0, 0, 0]
+    if (c === "white") return [255, 255, 255]
+    let m = c.match(/^#([0-9a-f]{3})$/)
+    if (m) {
+      const [r, g, b] = m[1].split("")
+      return [parseInt(r + r, 16), parseInt(g + g, 16), parseInt(b + b, 16)]
+    }
+    m = c.match(/^#([0-9a-f]{6})$/)
+    if (m) {
+      const n = parseInt(m[1], 16)
+      return [(n >> 16) & 255, (n >> 8) & 255, n & 255]
+    }
+    m = c.match(/^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/)
+    if (m) return [Number(m[1]), Number(m[2]), Number(m[3])]
+    return null
+  }
+  const luma = (rgb: [number, number, number]) =>
+    0.299 * rgb[0] + 0.587 * rgb[1] + 0.114 * rgb[2]
+  const isDarkInk = (v: string): boolean => {
+    const rgb = toRgb(v)
+    return rgb !== null && luma(rgb) < 40
   }
   const isLightInk = (v: string): boolean => {
-    const c = v.trim().toLowerCase()
-    if (c === "white" || c === "#fff" || c === "#ffffff") return true
-    const m = c.match(/^#([0-9a-f]{6})$/)
-    if (!m) return false
-    const n = parseInt(m[1], 16)
-    const r = (n >> 16) & 255, g = (n >> 8) & 255, b = n & 255
-    return 0.299 * r + 0.587 * g + 0.114 * b > 215
+    const rgb = toRgb(v)
+    return rgb !== null && luma(rgb) > 215
   }
   const shouldFlip = target === "to-light" ? isDarkInk : isLightInk
 
   let changed = false
   const out = svg.replace(
-    /(fill|stroke|stop-color|color)\s*[:=]\s*(["']?)(#[0-9a-fA-F]{3,6}|black|white)\2/g,
+    /(fill|stroke|stop-color|color)\s*[:=]\s*(["']?)(#[0-9a-fA-F]{3,6}|black|white|rgb\([^)]*\))\2/g,
     (match, prop, quote, value) => {
       if (value.toLowerCase() === "none") return match
       if (shouldFlip(value)) {
@@ -89,7 +100,22 @@ export function recolorSvgForOppositeMode(
       return match
     },
   )
-  return changed ? out : null
+  if (changed) return out
+
+  // No color attributes matched. SVG's presentational default ink is BLACK, so
+  // a fill-less icon (very common for single-path marks) renders near-invisible
+  // on a dark badge and the regex above has nothing to rewrite — this was the
+  // "sometimes the color doesn't strip" case. Inject an explicit ink on the
+  // root <svg> so the alt mark actually flips. Only meaningful for to-light
+  // (a fill-less SVG is already dark ink).
+  if (target === "to-light") {
+    const hasAnyInk = /(fill|stroke|stop-color)\s*[:=]\s*["']?(?!none)[#a-z0-9(]/i.test(svg)
+    if (!hasAnyInk) {
+      const injected = svg.replace(/<svg\b/, `<svg fill="${toColor}"`)
+      if (injected !== svg) return injected
+    }
+  }
+  return null
 }
 
 /** Guess a content type from a URL/file extension when the server omits one. */

--- a/packages/web/lib/use-debounced-value.ts
+++ b/packages/web/lib/use-debounced-value.ts
@@ -1,0 +1,22 @@
+/**
+ * shieldcn
+ * lib/use-debounced-value.ts
+ *
+ * Returns a debounced copy of a fast-changing value. Use to decouple cheap,
+ * per-keystroke input state from expensive downstream work (network fetches,
+ * server-rendered previews) so the input stays responsive while the heavy work
+ * only runs once typing settles.
+ */
+
+import { useEffect, useState } from "react"
+
+export function useDebouncedValue<T>(value: T, delayMs = 350): T {
+  const [debounced, setDebounced] = useState(value)
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delayMs)
+    return () => clearTimeout(id)
+  }, [value, delayMs])
+
+  return debounced
+}


### PR DESCRIPTION
## What

Fixes the brand dashboard being unusably slow, mark uploads failing opaquely, missing alt marks, and inconsistent SVG color stripping.

## Why

Brand editing in /dashboard/brands was impossibly slow, mark uploads intermittently 500'd with no error detail, `logo=brand-alt` 404'd for directly-uploaded marks, and uploaded SVGs sometimes kept their original color.

## Type

- [x] `fix` — Bug fix

## How

- **Perf (server)**: `initDB()` re-ran the full schema DDL (10+ CREATE/ALTER, 8 DROP TABLE) on **every query**. Now guarded by a module-level promise — once per process. Brand API calls drop to ~28ms after init.
- **Perf (editor)**: the live preview re-rendered 6 server-side Satori badges per keystroke. Now driven by a debounced config (350ms).
- **Alt marks**: direct uploads via the assets route now synthesize the recolored `mark-alt` (import-flow parity); never clobbers a manually uploaded alt.
- **Recolor heuristic**: handles fill-less SVGs (SVG default ink is black — nothing to rewrite before), `rgb()` colors, and 3-digit hex.
- **500s**: asset upload failures now log server-side and return the real error message instead of an unhandled throw.
- **Visibility**: editor logo slots + brand-list chips render raw marks on a checkerboard base instead of solid dark, so dark-ink marks are visible.
- **Contract test**: new `brand-logo-mode.test.ts` proves stored mark ink never leaks into badge/header output (the renderer parses marks to paths and recolors to theme ink in both modes). A mode-aware asset picker was prototyped and reverted after proving output is byte-identical regardless of stored ink.

## Checklist

- [x] Branch follows conventional naming (`fix/`)
- [x] Commits follow Conventional Commits
- [x] Tested locally with `pnpm dev`
- [x] Badge renders correctly in SVG and PNG (render pipeline covered by contract tests; no render-path behavior change)
- [ ] Docs updated (no provider or query param changes)

## Testing

- core: 306 passed (6 new contract tests)
- web: 99 passed (5 new recolor cases)
- tsc + eslint clean in both packages
- Perf verified against dev server: first request ~1.4s (compile+init), subsequent ~28ms