### PR TITLE
fix(badges): stop misclassifying solid-fill marks as stroke icons

### DIFF
--- a/packages/core/src/badges/svg-parser.test.ts
+++ b/packages/core/src/badges/svg-parser.test.ts
@@ -119,6 +119,25 @@ describe("parseSvg — normal shapes still work", () => {
     expect(parsed?.icon.strokeWidth).toBe(2)
   })
 
+  it("a root fill=none wrapper around solid-fill paths is NOT stroke-based", () => {
+    // Common export pattern (e.g. Figma): <svg fill="none"> wrapping paths that
+    // carry their own solid fill + a decorative stroke. Classifying these as
+    // stroke-based rendered them as invisible hairline outlines at badge scale.
+    const parsed = parseSvg(
+      `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 288 320"><path fill="currentColor" stroke="currentColor" stroke-width="2.025" d="M143.8 1a45.6 45.6 0 1 1 0 91.2 45.6 45.6 0 0 1 0-91.2Z"/></svg>`,
+    )
+    expect(parsed?.isStroke).toBe(false)
+    expect(parsed?.icon.strokeWidth).toBeUndefined()
+    expect(parsed?.icon.path).toContain("M143.8")
+  })
+
+  it("a root fill=none wrapper with hex-filled paths is NOT stroke-based", () => {
+    const parsed = parseSvg(
+      `<svg fill="none" viewBox="0 0 24 24"><path fill="#e11d48" d="M2 2h20v20H2z"/></svg>`,
+    )
+    expect(parsed?.isStroke).toBe(false)
+  })
+
   it("returns null when no renderable shapes are present", () => {
     expect(parseSvg(`<svg viewBox="0 0 24 24"><text>hi</text></svg>`)).toBeNull()
   })

--- a/packages/core/src/badges/svg-parser.ts
+++ b/packages/core/src/badges/svg-parser.ts
@@ -29,8 +29,15 @@ export function parseSvg(svg: string): ParsedSvg | null {
   const vbMatch = svg.match(/viewBox="([^"]+)"/)
   const viewBox = vbMatch ? vbMatch[1] : inferViewBox(svg)
 
-  // Detect stroke-based SVGs
+  // Detect stroke-based SVGs (Lucide/Feather style: fill="none" everywhere,
+  // shapes drawn purely by stroke). A root `fill="none"` wrapper is a common
+  // pattern on FILLED icons too (e.g. <svg fill="none"><path fill="currentColor"
+  // stroke="currentColor" stroke-width="2">), so only classify as stroke-based
+  // when no element carries a solid fill — otherwise a solid mark renders as
+  // invisible hairline outlines at badge scale.
+  const hasSolidFill = /fill\s*=\s*["'](?!none["'])[^"']+["']/i.test(svg)
   const isStroke =
+    !hasSolidFill &&
     (svg.includes('fill="none"') || svg.includes("fill='none'")) &&
     (svg.includes('stroke="currentColor"') || svg.includes('stroke="'))
 


### PR DESCRIPTION
## What

Fixes brand marks (and any custom SVG logo) with a root `fill="none"` wrapper rendering as invisible hairline outlines instead of solid theme-ink shapes.

## Why

The useblume mark renders as near-invisible circle outlines on badges — reported as "the logo isn't changing color". Its SVG is a common Figma export pattern:

```svg
<svg fill="none" viewBox="0 0 288 320"><path fill="currentColor" stroke="currentColor" stroke-width="2.025" .../>
```

`parseSvg`'s stroke detection was `fill="none" present && any stroke attr present` — the root wrapper satisfied it, so solid-fill paths rendered stroke-only with a 2.025 stroke over a 288-unit viewBox (~0.1px at badge scale).

## Type

- [x] `fix` — Bug fix

## How

Only classify an SVG as stroke-based when **no element carries a solid fill**. Lucide/Feather-style icons (fill="none" everywhere, stroke-drawn) are unaffected — covered by the existing stroke-detection test.

## Checklist

- [x] Branch follows conventional naming (`fix/`)
- [x] Commits follow Conventional Commits
- [x] Tested locally with `pnpm dev`
- [x] Badge renders correctly in SVG and PNG (verified end-to-end with the production useblume mark: solid `fill="#18181b"` output, no hairline stroke)
- [ ] Docs updated (no provider or query param changes)

## Testing

- 2 new parser regression tests (root-wrapper + currentColor, root-wrapper + hex fill)
- core: 308 passed, web: 99 passed, tsc clean