### PR TITLE
feat(providers): add OpenSSF Scorecard and Best Practices badges

### DIFF
--- a/packages/core/src/providers/openssf.test.ts
+++ b/packages/core/src/providers/openssf.test.ts
@@ -1,0 +1,172 @@
+/**
+ * shieldcn
+ * src/providers/openssf.test
+ *
+ * Verifies the OpenSSF providers against both upstreams:
+ * Scorecard (`api.scorecard.dev`, 404s when unscanned) and Best Practices
+ * (`bestpractices.dev`, returns [] when unregistered).
+ *
+ * Each case uses a distinct owner/repo so the provider cache can't carry a
+ * value between tests.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { getOpenSSFBestPractices, getOpenSSFScorecard, scorecardColor } from "./openssf"
+import { clearBackoff } from "../cache"
+import { statusColors } from "../badges/themes"
+
+// repo → score. A repo absent from this map has never been scanned (404).
+const SCORES: Record<string, number> = {
+  "high/repo": 9,
+  "mid/repo": 6.4,
+  "low/repo": 1.7,
+  "zero/repo": 0,
+}
+
+// repo → badge_level. Absent means unregistered ([]).
+const LEVELS: Record<string, { id: number; level: string }> = {
+  "silver/repo": { id: 13303, level: "silver" },
+  "gold/repo": { id: 42, level: "gold" },
+  "starting/repo": { id: 7, level: "in_progress" },
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string) => {
+      const json = (body: unknown) =>
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+
+      // --- Scorecard ---
+      const scorecard = url.match(/api\.scorecard\.dev\/projects\/github\.com\/(.+)$/)
+      if (scorecard) {
+        const slug = decodeURIComponent(scorecard[1])
+        if (slug === "boom/repo") return new Response("oops", { status: 500 })
+        // Scanned but scoreless — must not render "NaN".
+        if (slug === "scoreless/repo") return json({ date: "2026-08-04" })
+        const score = SCORES[slug]
+        if (score === undefined) return new Response("not found", { status: 404 })
+        return json({ score, date: "2026-08-04" })
+      }
+
+      // --- Best Practices ---
+      if (url.startsWith("https://www.bestpractices.dev/projects.json?url=")) {
+        const repoUrl = decodeURIComponent(url.split("url=")[1])
+        const slug = repoUrl.replace("https://github.com/", "")
+        if (slug === "boom/repo") return new Response("oops", { status: 500 })
+        // Registered but level not yet reported.
+        if (slug === "levelless/repo") return json([{ id: 99 }])
+        const entry = LEVELS[slug]
+        return json(entry ? [{ id: entry.id, badge_level: entry.level }] : [])
+      }
+
+      return new Response("not found", { status: 404 })
+    }),
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  clearBackoff("openssf")
+})
+
+describe("scorecardColor", () => {
+  it("maps score bands to status keywords", () => {
+    expect(scorecardColor(10)).toBe("success")
+    expect(scorecardColor(8)).toBe("success")
+    expect(scorecardColor(7.9)).toBe("pending")
+    expect(scorecardColor(5)).toBe("pending")
+    expect(scorecardColor(4.9)).toBe("failure")
+    expect(scorecardColor(0)).toBe("failure")
+  })
+
+  // Provider badges resolve color through statusColors only; a palette name
+  // like "brightgreen" renders as the theme default instead of the intended
+  // color, so every color we emit must be a key in that map.
+  it("only emits keywords the renderer can resolve", () => {
+    for (const score of [10, 8, 7, 5, 4, 0]) {
+      expect(statusColors).toHaveProperty(scorecardColor(score))
+    }
+  })
+})
+
+describe("OpenSSF Scorecard provider", () => {
+  it("returns the score to one decimal with a viewer link", async () => {
+    const data = await getOpenSSFScorecard("high", "repo")
+    expect(data?.label).toBe("scorecard")
+    // Stable badge width: an integer score still renders "9.0".
+    expect(data?.value).toBe("9.0")
+    expect(data?.color).toBe("success")
+    expect(data?.link).toBe("https://scorecard.dev/viewer/?uri=github.com/high/repo")
+  })
+
+  it("keeps a fractional score and colors it by threshold", async () => {
+    const data = await getOpenSSFScorecard("mid", "repo")
+    expect(data?.value).toBe("6.4")
+    expect(data?.color).toBe("pending")
+  })
+
+  it("renders a low score rather than treating it as a failure", async () => {
+    const data = await getOpenSSFScorecard("low", "repo")
+    expect(data?.value).toBe("1.7")
+    expect(data?.color).toBe("failure")
+  })
+
+  it("renders a zero score (not null — 0 is a real result)", async () => {
+    const data = await getOpenSSFScorecard("zero", "repo")
+    expect(data?.value).toBe("0.0")
+    expect(data?.color).toBe("failure")
+  })
+
+  it("returns null for a repo that has never been scanned (404)", async () => {
+    expect(await getOpenSSFScorecard("unscanned", "repo")).toBeNull()
+  })
+
+  it("returns null when the record has no score instead of rendering NaN", async () => {
+    expect(await getOpenSSFScorecard("scoreless", "repo")).toBeNull()
+  })
+
+  it("returns null on a transient server failure", async () => {
+    expect(await getOpenSSFScorecard("boom", "repo")).toBeNull()
+  })
+})
+
+describe("OpenSSF Best Practices provider", () => {
+  it("returns the badge level and deep-links to the project id", async () => {
+    const data = await getOpenSSFBestPractices("silver", "repo")
+    expect(data?.label).toBe("openssf")
+    expect(data?.value).toBe("silver")
+    // No color: a status keyword would suppress the caller's ?color=, and
+    // silver/gold can't be expressed as one. Callers theme it themselves.
+    expect(data?.color).toBeUndefined()
+    expect(data?.link).toBe("https://www.bestpractices.dev/projects/13303")
+  })
+
+  it("leaves gold themeable too", async () => {
+    const data = await getOpenSSFBestPractices("gold", "repo")
+    expect(data?.value).toBe("gold")
+    expect(data?.color).toBeUndefined()
+  })
+
+  it("renders in_progress as words", async () => {
+    const data = await getOpenSSFBestPractices("starting", "repo")
+    expect(data?.value).toBe("in progress")
+    expect(data?.color).toBeUndefined()
+  })
+
+  it("returns null for an unregistered repo (empty array, not a 404)", async () => {
+    expect(await getOpenSSFBestPractices("unregistered", "repo")).toBeNull()
+  })
+
+  it("returns null when the project reports no level", async () => {
+    expect(await getOpenSSFBestPractices("levelless", "repo")).toBeNull()
+  })
+
+  it("returns null on a transient server failure", async () => {
+    expect(await getOpenSSFBestPractices("boom", "repo")).toBeNull()
+  })
+})

--- a/packages/core/src/providers/openssf.ts
+++ b/packages/core/src/providers/openssf.ts
@@ -1,0 +1,117 @@
+/**
+ * shieldcn
+ * src/providers/openssf
+ *
+ * OpenSSF API clients for supply-chain security badges.
+ * Supports: Scorecard score, Best Practices badge level.
+ *
+ * Both upstreams are public and unauthenticated, so neither consumes the
+ * GitHub token pool.
+ */
+
+import type { BadgeData } from "../badges/types"
+import { providerFetch } from "../provider-fetch"
+
+// Scorecard is recomputed weekly and Best Practices changes only when a
+// maintainer edits the questionnaire, so both tolerate a long TTL.
+const OPENSSF_TTL = 21600 // 6h
+
+// ---------------------------------------------------------------------------
+// Scorecard
+// ---------------------------------------------------------------------------
+
+interface ScorecardResponse {
+  score?: number
+  date?: string
+}
+
+/**
+ * Pick the badge color for a Scorecard score (0–10).
+ *
+ * Returns a `statusColors` keyword rather than a palette name: for provider
+ * badges the renderer only resolves status keywords, so a name like
+ * "brightgreen" would be silently dropped and fall back to the theme default.
+ */
+export function scorecardColor(score: number): string {
+  if (score >= 8) return "success"
+  if (score >= 5) return "pending"
+  return "failure"
+}
+
+/** OpenSSF Scorecard aggregate score for a GitHub repository. */
+export async function getOpenSSFScorecard(
+  owner: string,
+  repo: string
+): Promise<BadgeData | null> {
+  const slug = `${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`
+  const data = await providerFetch<ScorecardResponse>({
+    provider: "openssf",
+    cacheKey: `scorecard:${owner}:${repo}`,
+    url: `https://api.scorecard.dev/projects/github.com/${slug}`,
+    ttl: OPENSSF_TTL,
+  })
+  if (!data) return null
+
+  const score = data.score
+  // A repo that has never been scanned 404s (→ null above), but guard against
+  // a scanned-yet-scoreless record rather than rendering "NaN".
+  if (typeof score !== "number" || Number.isNaN(score)) return null
+
+  return {
+    label: "scorecard",
+    // One decimal keeps the badge width stable as the score drifts (9 → "9.0").
+    value: score.toFixed(1),
+    color: scorecardColor(score),
+    link: `https://scorecard.dev/viewer/?uri=github.com/${owner}/${repo}`,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Best Practices
+// ---------------------------------------------------------------------------
+
+interface BestPracticesProject {
+  id?: number
+  badge_level?: string
+}
+
+/**
+ * OpenSSF Best Practices badge level for a GitHub repository.
+ *
+ * Looked up by repository URL rather than project ID, so callers use the same
+ * /{owner}/{repo} shape as every other GitHub topic instead of having to know
+ * their numeric bestpractices.dev ID.
+ */
+export async function getOpenSSFBestPractices(
+  owner: string,
+  repo: string
+): Promise<BadgeData | null> {
+  const repoUrl = `https://github.com/${owner}/${repo}`
+  const projects = await providerFetch<BestPracticesProject[]>({
+    provider: "openssf",
+    cacheKey: `bestpractices:${owner}:${repo}`,
+    url: `https://www.bestpractices.dev/projects.json?url=${encodeURIComponent(repoUrl)}`,
+    ttl: OPENSSF_TTL,
+  })
+  // An unregistered repo returns [] rather than a 404.
+  if (!Array.isArray(projects) || projects.length === 0) return null
+
+  const project = projects[0]
+  const level = project.badge_level
+  if (!level) return null
+
+  return {
+    label: "openssf",
+    // The API spells the lowest tier "in_progress"; render it as words.
+    value: level.replace(/_/g, " "),
+    // Deliberately no color. A status keyword would suppress the caller's
+    // ?color= (statusColor outranks it), and the tiers people actually want —
+    // metallic silver and gold — aren't expressible as status keywords anyway.
+    // The tier name carries the meaning; let the caller theme it.
+    // Deep-link to the project page when the lookup gave us its ID.
+    link:
+      project.id === undefined
+        ? "https://www.bestpractices.dev"
+        : `https://www.bestpractices.dev/projects/${project.id}`,
+  }
+}

--- a/packages/core/src/route-handler.ts
+++ b/packages/core/src/route-handler.ts
@@ -124,6 +124,7 @@ import {
   type SponsorEntry,
   githubRepoExists,
 } from "./providers/github"
+import { getOpenSSFScorecard, getOpenSSFBestPractices } from "./providers/openssf"
 import { getDiscordOnline, getDiscordByInvite } from "./providers/discord"
 import { getNbaTeamBadge } from "./providers/nba"
 import { parseStaticBadgeContent, getDynamicJsonBadge, getFlagBadge } from "./providers/badge"
@@ -354,6 +355,7 @@ async function resolveGitHubBadge(
     "assets-dl", "dt",
     "downloads", "downloads-all", "downloads-asset",
     "dependabot",
+    "scorecard", "openssf",
   ])
 
   let topic: string
@@ -388,6 +390,10 @@ async function resolveGitHubBadge(
     case "tag":         return getGitHubLatestTag(owner, repo)
     case "contributors": return getGitHubContributors(owner, repo)
     case "dependabot":  return getGitHubDependabot(owner, repo)
+
+    // Supply-chain security (OpenSSF)
+    case "scorecard":   return getOpenSSFScorecard(owner, repo)
+    case "openssf":     return getOpenSSFBestPractices(owner, repo)
 
     // Release (optional channel: stable)
     case "release":     return getGitHubRelease(owner, repo, extra[0])
@@ -1634,7 +1640,7 @@ function getDefaultLogoSlug(segments: string[]): { simpleIcon?: string; reactIco
       "license","release","contributors","ci","checks","issues","open-issues","closed-issues",
       "label-issues","prs","open-prs","closed-prs","merged-prs","milestones","commits",
       "last-commit","assets-dl","dt","downloads","downloads-all","downloads-asset",
-      "dependabot","sponsors"])
+      "dependabot","sponsors","scorecard","openssf"])
     const topic = knownTopics.has(rest[0]) ? rest[0] : rest[2]
 
     if (topic === "sponsors") return { simpleIcon: "githubsponsors" }
@@ -1642,6 +1648,12 @@ function getDefaultLogoSlug(segments: string[]): { simpleIcon?: string; reactIco
     if (topic === "forks") return { reactIcon: "GoRepoForked" }
     if (topic === "release" || topic === "tag") return { reactIcon: "GoTag" }
     if (topic === "ci" || topic === "checks") return null // uses status dot
+    // The data is OpenSSF's, not GitHub's — an octocat would misattribute it,
+    // and simple-icons has no OpenSSF mark. A shield reads correctly for both.
+    // GoShieldLock (not GoShieldCheck/GoShield): those are two-path icons and
+    // the icon pipeline only lays out single-path glyphs, so they overlap the
+    // label. Every other reactIcon used here is single-path too.
+    if (topic === "scorecard" || topic === "openssf") return { reactIcon: "GoShieldLock" }
     if (topic === "license") return { reactIcon: "FaBalanceScale" }
     if (topic === "contributors") return { reactIcon: "GoPeople" }
     if (topic === "issues" || topic === "open-issues" || topic === "closed-issues" || topic === "label-issues") return { reactIcon: "GoIssueDraft" }


### PR DESCRIPTION
## What

Hey from [Thaw](https://github.com/thaw-app) 👋 — we love shieldcn and want to use it as the badge layer for our README / release surface. The one gap blocking that for us is first-class OpenSSF endpoints, so we added them:

- **OpenSSF Scorecard** — `/github/{owner}/{repo}/scorecard` (and `/{topic}/{owner}/{repo}`)
  - Pulls from `api.scorecard.dev`, colors by score band (`success` / `pending` / `failure`), links to the Scorecard viewer
- **OpenSSF Best Practices** — `/github/{owner}/{repo}/openssf`
  - Looks up by repo URL on `bestpractices.dev`, renders the badge level (`in progress` / `passing` / `silver` / `gold`), deep-links to the project page
  - Deliberately uncolored so callers can theme silver/gold themselves (`?color=` isn’t swallowed by a status keyword)

Both are public/unauthenticated (no token-pool cost), cached 6h, and covered by unit tests against mocked upstreams.

**Icon:** temporary `GoShieldLock` (single-path — the icon pipeline can’t lay out multi-path glyphs without overlapping the label). Simple Icons has no OpenSSF mark, and an octocat would misattribute the data. Happy to swap in a flattened OpenSSF mark if you want it — artwork is Apache-2.0 but needs single-path conversion and a trademark call.

## Why

We need these endpoints to use shieldcn on [thaw-app/Thaw](https://github.com/thaw-app/Thaw). Today the only path to Scorecard / Best Practices is dynamic JSON; native topics keep the same `/github/{owner}/{repo}/{topic}` shape as every other GitHub badge. This PR keeps the surface area to the provider + route wiring so it’s easy to review — happy to follow up with docs / showcase / gallery once the endpoints land.

Closes #

## Type

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `docs` — Documentation
- [ ] `refactor` — Code restructuring
- [ ] `perf` — Performance improvement
- [ ] `style` — Visual / CSS changes
- [ ] `chore` — Maintenance / deps
- [ ] `ci` — CI/CD changes
- [ ] `test` — Tests

## Checklist

- [x] Branch follows conventional naming (`feat/`, `fix/`, `docs/`, etc.)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tested locally with `pnpm dev`
- [ ] Badge renders correctly in SVG and PNG (if applicable)
- [ ] Docs updated (if adding/changing a provider or query param) — happy to follow up once the endpoints are accepted

## Screenshots

Example URLs (once deployed):

```
https://shieldcn.dev/github/scorecard/thaw-app/Thaw.svg?variant=branded
https://shieldcn.dev/github/openssf/thaw-app/Thaw.svg?variant=outline&color=C0C0C0
```

<!-- Paste live SVG/PNG renders after local `pnpm dev` smoke if you want visuals in the PR -->